### PR TITLE
Fix issue #169: Restrict index input range to 1-100

### DIFF
--- a/src/client/components/presentation/Cues.jsx
+++ b/src/client/components/presentation/Cues.jsx
@@ -68,14 +68,14 @@ const CuesForm = ({ addCue, onClose, position }) => {
     <form onSubmit={onAddCue}>
       <FormControl as="fieldset">
         <Heading size="md">Add element</Heading>
-        <FormHelperText mb={2}>Index 1-350</FormHelperText>
+        <FormHelperText mb={2}>Index 1-100</FormHelperText>
         <NumberInput
           value={index}
           mb={4}
           min={1}
-          max={350}
+          max={100}
           onChange={handleNumericInputChange(setIndex)}
-          onBlur={validateAndSetNumber(setIndex, 1, 350)}
+          onBlur={validateAndSetNumber(setIndex, 1, 100)}
           required
         >
           <NumberInputField data-testid="index-number" />

--- a/src/client/components/presentation/EditToolBox.jsx
+++ b/src/client/components/presentation/EditToolBox.jsx
@@ -79,7 +79,7 @@ const EditToolBox = ({ isOpen, onClose, cueData, updateCue }) => {
               mb={2}
               onChange={(e) => setCueName(e.target.value)}
             />
-            <FormHelperText mb={2}>Index 1-350</FormHelperText>
+            <FormHelperText mb={2}>Index 1-100</FormHelperText>
             <NumberInput
               value={index}
               mb={4}

--- a/src/client/tests/unit/cues.test.js
+++ b/src/client/tests/unit/cues.test.js
@@ -12,7 +12,7 @@ describe('cues', () => {
       </MemoryRouter>
     )
     expect(screen.getByText('Screen 1-4*')).toBeDefined()
-    expect(screen.getByText('Index 1-350')).toBeDefined()
+    expect(screen.getByText('Index 1-100')).toBeDefined()
     expect(screen.getByText('Name*')).toBeDefined()
   })
 

--- a/src/server/routes/presentation.js
+++ b/src/server/routes/presentation.js
@@ -104,6 +104,11 @@ router.put("/:id", userExtractor, upload.single("image"), async (req, res) => {
       return res.status(400).json({ error: "Missing required fields" })
     }
 
+        // Validate index range
+    if (req.body.index < 1 || req.body.index > 100) {
+      return res.status(400).json({ error: "Index must be between 0 and 100" })
+    }
+
     const presentation = await Presentation.findById(id)
     const cuenumber = presentation.cues.length
 /*  Limiter for the maximum amount of files, disabled
@@ -159,6 +164,11 @@ router.put("/:id/:cueId", userExtractor, upload.single("image"), async (req, res
 
     if (!id || !index || !screen || !cueId || !cueName) {
       return res.status(400).json({ error: "Missing required fields" })
+    }
+
+    // Validate index range
+    if (index < 1 || index > 100) {
+      return res.status(400).json({ error: "Index must be between 0 and 100" })
     }
 
     const presentation = await Presentation.findById(id)

--- a/src/server/tests/presentation_api.test.js
+++ b/src/server/tests/presentation_api.test.js
@@ -112,18 +112,20 @@ describe("test presentation", () => {
           screen: "1",
         })
       expect(response.status).toBe(400)
+      expect(response.body.error).toBe("Index must be between 0 and 100")
     })
 
-    it("PUT /api/presentation/:id/ with index less than 100 should return 400", async () => {
+    it("PUT /api/presentation/:id/ with index less than 1 should return 400", async () => {
       const response = await api
         .put(`/api/presentation/${testPresentationId}`)
         .set("Authorization", authHeader)
         .send({
-          index: 0,
+          index: -1,
           cueName: "Test Cue",
           screen: "1",
         })
       expect(response.status).toBe(400)
+      expect(response.body.error).toBe("Index must be between 0 and 100")
     })
 
     it("PUT /api/presentation/:id/:cueId with index less than 1 should return 400", async () => {
@@ -131,12 +133,13 @@ describe("test presentation", () => {
         .put(`/api/presentation/${testPresentationId}/${testCueId}`)
         .set("Authorization", authHeader)
         .send({
-          index: 0,
+          index: -1,
           cueName: "Test Cue",
           screen: "1",
         })
       
       expect(response.status).toBe(400)
+      expect(response.body.error).toBe("Index must be between 0 and 100")
     })
 
     it("PUT /api/presentation/:id/:cueId with index greater than 100 should return 400", async () => {
@@ -149,6 +152,7 @@ describe("test presentation", () => {
           screen: "1",
         })
       expect(response.status).toBe(400)
+      expect(response.body.error).toBe("Index must be between 0 and 100")
     })
   })
 })

--- a/src/server/tests/presentation_api.test.js
+++ b/src/server/tests/presentation_api.test.js
@@ -11,6 +11,7 @@ const api = supertest(app)
 
 let authHeader
 let testPresentationId
+let testCueId
 
 describe("test presentation", () => {
   beforeEach(async () => {
@@ -34,6 +35,17 @@ describe("test presentation", () => {
       name: "Test presentation",
     })
     testPresentationId = presentation._id
+
+    const cueResponse = await api
+      .post(`/api/presentation/${testPresentationId}/cues`)
+      .set("Authorization", authHeader)
+      .send({
+        index: 1,
+        cueName: "Test Cue",
+        screen: "1",
+      })
+
+    testCueId = cueResponse.body._id
   })
 
   describe("GET /api/presentation/:id", () => {
@@ -86,6 +98,34 @@ describe("test presentation", () => {
       const response = await api.put("/api/presentation/:id")
 
       expect(response.status).toBe(400)
+    })
+  })
+
+  describe("Test index range validation", () => {
+    it("PUT /api/presentation/:id with invalid index should return 400", async () => {
+      const response = await api
+        .put(`/api/presentation/${testPresentationId}`)
+        .set("Authorization", authHeader)
+        .send({
+          index: 101,
+          cueName: "Test Cue",
+          screen: "1",
+        })
+      expect(response.status).toBe(400)
+      expect(response.body.error).toBe("Index must be between 0 and 100")
+    })
+
+    it("PUT /api/presentation/:id/:cueId with invalid index should return 400", async () => {
+      const response = await api
+        .put(`/api/presentation/${testPresentationId}/${testCueId}`)
+        .set("Authorization", authHeader)
+        .send({
+          index: 101,
+          cueName: "Test Cue",
+          screen: "1",
+        })
+      expect(response.status).toBe(400)
+      expect(response.body.error).toBe("Index must be between 0 and 100")
     })
   })
 })

--- a/src/server/tests/presentation_api.test.js
+++ b/src/server/tests/presentation_api.test.js
@@ -102,7 +102,7 @@ describe("test presentation", () => {
   })
 
   describe("Test index range validation", () => {
-    it("PUT /api/presentation/:id with invalid index should return 400", async () => {
+    it("PUT /api/presentation/:id/ with index greater than 100 should return 400", async () => {
       const response = await api
         .put(`/api/presentation/${testPresentationId}`)
         .set("Authorization", authHeader)
@@ -112,10 +112,34 @@ describe("test presentation", () => {
           screen: "1",
         })
       expect(response.status).toBe(400)
-      expect(response.body.error).toBe("Index must be between 0 and 100")
     })
 
-    it("PUT /api/presentation/:id/:cueId with invalid index should return 400", async () => {
+    it("PUT /api/presentation/:id/ with index less than 100 should return 400", async () => {
+      const response = await api
+        .put(`/api/presentation/${testPresentationId}`)
+        .set("Authorization", authHeader)
+        .send({
+          index: 0,
+          cueName: "Test Cue",
+          screen: "1",
+        })
+      expect(response.status).toBe(400)
+    })
+
+    it("PUT /api/presentation/:id/:cueId with index less than 1 should return 400", async () => {
+      const response = await api
+        .put(`/api/presentation/${testPresentationId}/${testCueId}`)
+        .set("Authorization", authHeader)
+        .send({
+          index: 0,
+          cueName: "Test Cue",
+          screen: "1",
+        })
+      
+      expect(response.status).toBe(400)
+    })
+
+    it("PUT /api/presentation/:id/:cueId with index greater than 100 should return 400", async () => {
       const response = await api
         .put(`/api/presentation/${testPresentationId}/${testCueId}`)
         .set("Authorization", authHeader)
@@ -125,7 +149,6 @@ describe("test presentation", () => {
           screen: "1",
         })
       expect(response.status).toBe(400)
-      expect(response.body.error).toBe("Index must be between 0 and 100")
     })
   })
 })


### PR DESCRIPTION
Fixes issue #169 by restricting the index input range to be 1-100, from the previous 0-350.

Updated Cues.jsx and EditToolBox.jsx to show the right index range to the user and added validation to the presentation.js router to ensure the index is within the valid range.