### PR TITLE
Use npm ci instead of npm i

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           node-version: "20"
       - name: Install dependencies
-        run: npm i
+        run: npm ci
 
       - name: Build image
         id: build-image


### PR DESCRIPTION
From https://docs.npmjs.com/cli/v11/commands/npm-ci: "This command is similar to npm install, except it's meant to be used in automated environments such as test platforms, continuous integration, and deployment -- "