### PR TITLE
Bugfix/issue 220 fix coverage discrepancy

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -6,9 +6,9 @@ TEST_MONGODB_URI=<Set your uri here>
 VITE_DEV_PORT=<frontend port>
 
 BUCKET_NAME=<your bucket name>
-BUCKET_REGION=<your bucket region>
-ACCESS_KEY=<your s3 bucket access key>
-SECRET_ACCESS_KEY=<your s3 bucket secret access key>
+AWS_REGION=<your bucket region>
+AWS_ACCESS_KEY_ID=<your s3 bucket access key>
+AWS_SECRET_ACCESS_KEY=<your s3 bucket secret access key>
 
 
 VITE_FIREBASE_API_KEY=<your firebase apikey>

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -31,7 +31,6 @@ jobs:
           VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
           VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
-          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
           SECRET: ${{ secrets.SECRET }}
 
       - name: Upload frontend & backend coverage to Codecov

--- a/src/server/utils/config.js
+++ b/src/server/utils/config.js
@@ -1,15 +1,15 @@
 require("dotenv").config()
 
 const { PORT } = process.env
-const MONGODB_URI = process.env.NODE_ENV === "test"
-  ? process.env.TEST_MONGODB_URI
-  : process.env.MONGODB_URI
+const MONGODB_URI =
+  process.env.NODE_ENV === "test"
+    ? process.env.TEST_MONGODB_URI
+    : process.env.MONGODB_URI
 const { SECRET } = process.env
 const { BUCKET_NAME } = process.env
 const { BUCKET_REGION } = process.env
 const { ACCESS_KEY } = process.env
 const { SECRET_ACCESS_KEY } = process.env
-
 
 module.exports = {
   MONGODB_URI,

--- a/src/server/utils/config.js
+++ b/src/server/utils/config.js
@@ -7,16 +7,16 @@ const MONGODB_URI =
     : process.env.MONGODB_URI
 const { SECRET } = process.env
 const { BUCKET_NAME } = process.env
-const { BUCKET_REGION } = process.env
-const { ACCESS_KEY } = process.env
-const { SECRET_ACCESS_KEY } = process.env
+const { AWS_REGION } = process.env
+const { AWS_ACCESS_KEY_ID } = process.env
+const { AWS_SECRET_ACCESS_KEY } = process.env
 
 module.exports = {
   MONGODB_URI,
   PORT,
   SECRET,
   BUCKET_NAME,
-  BUCKET_REGION,
-  ACCESS_KEY,
-  SECRET_ACCESS_KEY,
+  AWS_REGION,
+  AWS_ACCESS_KEY_ID,
+  AWS_SECRET_ACCESS_KEY,
 }

--- a/src/server/utils/s3.js
+++ b/src/server/utils/s3.js
@@ -8,17 +8,17 @@ const {
 const { getSignedUrl } = require("@aws-sdk/s3-request-presigner")
 
 const {
-  BUCKET_REGION,
   BUCKET_NAME,
-  ACCESS_KEY,
-  SECRET_ACCESS_KEY,
+  AWS_REGION,
+  AWS_ACCESS_KEY_ID,
+  AWS_SECRET_ACCESS_KEY,
 } = require("./config")
 
 const s3 = new S3Client({
-  region: BUCKET_REGION,
+  region: AWS_REGION,
   credentials: {
-    accessKeyId: ACCESS_KEY,
-    secretAccessKey: SECRET_ACCESS_KEY,
+    accessKeyId: AWS_ACCESS_KEY_ID,
+    secretAccessKey: AWS_SECRET_ACCESS_KEY,
   },
 })
 

--- a/src/server/utils/s3.js
+++ b/src/server/utils/s3.js
@@ -3,7 +3,7 @@ const {
   PutObjectCommand,
   DeleteObjectCommand,
   GetObjectCommand,
-  HeadObjectCommand
+  HeadObjectCommand,
 } = require("@aws-sdk/client-s3")
 const { getSignedUrl } = require("@aws-sdk/s3-request-presigner")
 
@@ -27,7 +27,7 @@ const uploadFile = (fileBuffer, fileName, mimetype) => {
     Bucket: BUCKET_NAME,
     Body: fileBuffer,
     Key: fileName,
-    ContentType: mimetype
+    ContentType: mimetype,
   }
 
   return s3.send(new PutObjectCommand(uploadParams))
@@ -59,7 +59,7 @@ const getFileSize = async (cue, presentationId) => {
   const key = `${presentationId}/${cue.file.id.toString()}`
   const params = {
     Bucket: BUCKET_NAME,
-    Key: key
+    Key: key,
   }
   const command = new HeadObjectCommand(params)
   const seconds = 3 * 60 * 60
@@ -103,4 +103,10 @@ const getFileType = async (cue, presentationId) => {
   }
 }
 
-module.exports = { uploadFile, deleteFile, getObjectSignedUrl, getFileSize, getFileType }
+module.exports = {
+  uploadFile,
+  deleteFile,
+  getObjectSignedUrl,
+  getFileSize,
+  getFileType,
+}

--- a/src/server/utils/verifyToken.js
+++ b/src/server/utils/verifyToken.js
@@ -4,16 +4,20 @@ const {
   GetSecretValueCommand,
 } = require("@aws-sdk/client-secrets-manager")
 
-const { BUCKET_REGION, ACCESS_KEY, SECRET_ACCESS_KEY } = require("./config")
+const {
+  AWS_REGION,
+  AWS_ACCESS_KEY_ID,
+  AWS_SECRET_ACCESS_KEY,
+} = require("./config")
 
 const initializeFirebase = async () => {
   const secret_name = "ServiceAccountKey"
 
   const client = new SecretsManagerClient({
-    region: BUCKET_REGION,
+    region: AWS_REGION,
     credentials: {
-      accessKeyId: ACCESS_KEY,
-      secretAccessKey: SECRET_ACCESS_KEY,
+      accessKeyId: AWS_ACCESS_KEY_ID,
+      secretAccessKey: AWS_SECRET_ACCESS_KEY,
     },
   })
 

--- a/src/server/utils/verifyToken.js
+++ b/src/server/utils/verifyToken.js
@@ -1,12 +1,10 @@
 const admin = require("firebase-admin")
-const { SecretsManagerClient, GetSecretValueCommand } = require("@aws-sdk/client-secrets-manager")
-
 const {
-  BUCKET_REGION,
-  ACCESS_KEY,
-  SECRET_ACCESS_KEY,
-} = require("./config")
+  SecretsManagerClient,
+  GetSecretValueCommand,
+} = require("@aws-sdk/client-secrets-manager")
 
+const { BUCKET_REGION, ACCESS_KEY, SECRET_ACCESS_KEY } = require("./config")
 
 const initializeFirebase = async () => {
   const secret_name = "ServiceAccountKey"
@@ -19,31 +17,25 @@ const initializeFirebase = async () => {
     },
   })
 
-    const response = await client.send(
-      new GetSecretValueCommand({
-        SecretId: secret_name,
-        VersionStage: "AWSCURRENT", 
-      })
-    )
+  const response = await client.send(
+    new GetSecretValueCommand({
+      SecretId: secret_name,
+      VersionStage: "AWSCURRENT",
+    })
+  )
 
+  const secret = JSON.parse(response.SecretString)
 
-    const secret = JSON.parse(response.SecretString)
-
-    if (!admin.apps.length) {
-      admin.initializeApp({
-        credential: admin.credential.cert(secret),
-      })
-      console.log("Firebase initialized successfully.")
-    }
-
+  if (!admin.apps.length) {
+    admin.initializeApp({
+      credential: admin.credential.cert(secret),
+    })
+    console.log("Firebase initialized successfully.")
+  }
 }
-
-
-
 
 const verifyToken = async (req, res, next) => {
   const token = req.headers.authorization?.split(" ")[1]
-
 
   if (!token) {
     return res.status(401).json({ error: "no token" })


### PR DESCRIPTION
#220 
Fix discrepancies between Codecov and local tests regarding server/utils coverage. 

This was caused by environment variables being named in different ways locally compared to GitHub secrets variables, which caused locally passing tests to fail in Actions.

Examples:

Local: BUCKET_REGION
GitHub: AWS_REGION

Local: ACCESS_KEY
GitHub: AWS_ACCESS_KEY_ID

Local: SECRET_ACCESS_KEY
GitHub: AWS_SECRET_ACCESS_KEY 

Because the variable names in GitHub follow proper naming conventions, all code was adjusted to match them. The .env-template file was updated accordingly. **Local .env files also need to be updated accordingly!**

Improvements in coverage:
- src/server/utils/s3.js: Coverage change +47.83%
- src/server/utils/verifyToken.js: Coverage change +13.04%