### PR TITLE
Bugfix/issue 246 update presentation file size

### DIFF
--- a/src/client/components/presentation/index.jsx
+++ b/src/client/components/presentation/index.jsx
@@ -51,7 +51,8 @@ const PresentationPage = () => {
   useEffect(() => {
     if (presentationInfo) {
       const totalSize = presentationInfo.reduce((sum, cue) => {
-        return cue.file ? sum + parseInt(cue.file.size) : sum
+        const fileSize = cue.file?.size || 0
+        return !isNaN(fileSize) ? sum + Number(fileSize) : sum
       }, 0)
       const newSize = (totalSize / (1024 * 1024)).toFixed(2)
       if (presentationSize !== newSize) {


### PR DESCRIPTION
Added optional chaining to access the size property. If cue.file is undefined, fileSize will be undefined. If fileSize is undefined, it defaults to 0. 

Adds only valid numbers to the total size, so NaN should not be present anymore.