### PR TITLE
Fix discrepancy between local and actions test results by renaming st…

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -23,15 +23,19 @@ jobs:
           npm run test-all
         env:
           TEST_MONGODB_URI: ${{ secrets.TEST_MONGODB_URI }}
+          
           BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          BUCKET_REGION: ${{ secrets.AWS_REGION }}
+          ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          
           VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
           VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
           VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+          
           FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          
           SECRET: ${{ secrets.SECRET }}
 
       - name: Upload frontend & backend coverage to Codecov


### PR DESCRIPTION
Fix discrepancy between local and actions test results by renaming staging.yml environment variables to match local .env variable naming. This was causing Firebase and S3 errors that lead to locally passing tests suddenly failing in actions test runs. 

Example error messages:

>     Failed to initialize Firebase: Error: Resolved credential object is not valid

>     Resolved credential object is not valid
