### PR TITLE
Fix actions runs credential errors: Rename environment variables to match those in local .env

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -24,9 +24,9 @@ jobs:
         env:
           TEST_MONGODB_URI: ${{ secrets.TEST_MONGODB_URI }}
           BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          BUCKET_REGION: ${{ secrets.AWS_REGION }}
+          ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
           VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
           VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}


### PR DESCRIPTION
#### A little context
A little wiser after the changes of pull #248 broke the whole app and had to be reverted, the opposite approach was taken by simply renaming the environment variables in staging.yml to match those in local .env. 

#### Description
Addressed discrepancies between local and actions test results by renaming staging.yml environment variables to match local .env variable naming. This was causing Firebase and S3 errors that lead to locally passing tests suddenly failing in actions test runs -> test coverage in Codecov was incorrect, and wasn't being updated.

#### Example error messages in actions backend test runs
>     Failed to initialize Firebase: Error: Resolved credential object is not valid

>     ● S3 operations › should get signed URL
>       Resolved credential object is not valid

#### Results
Actions backend test results before the change:

> Test Suites: 2 failed, 5 passed, 7 total
> Tests:       4 failed, 24 passed, 28 total

Actions backend test results after the change:

>  Test Suites: 7 passed, 7 total
> Tests:       28 passed, 28 total

Codecov coverage:
- src/server/utils/s3.js: Coverage change **+47.83%**
- src/server/routes/presentation.js: Coverage change **+0.80%**
- src/server/utils/helper.js: Coverage change **+45.00%**
- src/server/utils/verifyToken.js: Coverage change **+13.04%**

Total coverage change: **+3.65%**

Source for coverage figures: [https://app.codecov.io/github/MuViCo/MuViCo/commit/ecde39d40ddb4109a72baed6923ca4e4289c3d31/indirect-changes](https://app.codecov.io/github/MuViCo/MuViCo/commit/ecde39d40ddb4109a72baed6923ca4e4289c3d31/indirect-changes)