### PR TITLE
Bugfix/issue 259 fifth screen appearing

### DIFF
--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -228,6 +228,17 @@ const EditMode = ({ id, cues, isToolboxOpen, setIsToolboxOpen }) => {
       rowHeight,
       gap
     )
+
+    // Stop if cue screen is not within valid range
+    if (yIndex < 1 || yIndex > 4) {
+      return
+    }
+
+    // Stop if cue index is not within valid range
+    if (xIndex < 1 || xIndex > 100) {
+      return
+    }
+
     const cue = cues.find(
       (cue) => cue.index === xIndex && cue.screen === yIndex
     )

--- a/src/client/components/utils/addInitialElements.js
+++ b/src/client/components/utils/addInitialElements.js
@@ -11,6 +11,10 @@ const addInitialElements = async (presentationId, showToast) => {
         screen,
         "/blank.png"
       )
+
+      // Allow index 0 for initial elements (bypasses validation)
+      formData.append("isInitialElement", "true")
+
       await presentation.addCue(presentationId, formData)
     }
 

--- a/src/client/components/utils/addInitialElements.js
+++ b/src/client/components/utils/addInitialElements.js
@@ -12,10 +12,7 @@ const addInitialElements = async (presentationId, showToast) => {
         "/blank.png"
       )
 
-      // Allow index 0 for initial elements (bypasses validation)
-      formData.append("isInitialElement", "true")
-
-      await presentation.addCue(presentationId, formData)
+      await presentation.addInitialElementCue(presentationId, formData)
     }
 
     showToast({

--- a/src/client/services/presentation.js
+++ b/src/client/services/presentation.js
@@ -39,6 +39,25 @@ const addCue = async (id, formData) => {
   return response.data
 }
 
+/**
+ * Adds an initial element cue (index 0) to the server.
+ * Uses `isInitialElement=true` in the query to bypass the normal index limit (1-100).
+ */
+const addInitialElementCue = async (id, formData) => {
+  const config = {
+    headers: {
+      "Content-Type": "multipart/form-data",
+      Authorization: `bearer ${getToken()}`,
+    },
+  }
+  const response = await axios.put(
+    `${baseUrl}/${id}?isInitialElement=true`,
+    formData,
+    config
+  )
+  return response.data
+}
+
 const removeCue = async (id, cueId) => {
   const response = await axios.delete(`${baseUrl}/${id}/${cueId}`)
   return response.data
@@ -63,6 +82,7 @@ export default {
   get,
   remove,
   addCue,
+  addInitialElementCue,
   removeCue,
   updateCue,
 }

--- a/src/client/tests/unit/numberInputUtils.test.js
+++ b/src/client/tests/unit/numberInputUtils.test.js
@@ -5,7 +5,7 @@ import {
 } from "../../components/utils/numberInputUtils.js"
 
 describe("handleNumericInputChange", () => {
-  test("should only only numeric values", () => {
+  test("should only accept numeric values", () => {
     let state = ""
     const setState = (newState) => {
       state = newState

--- a/src/client/tests/unit/numberInputUtils.test.js
+++ b/src/client/tests/unit/numberInputUtils.test.js
@@ -1,0 +1,79 @@
+import {
+  handleNumericInputChange,
+  validateAndSetNumber,
+  getNextAvailableIndex,
+} from "../../components/utils/numberInputUtils.js"
+
+describe("handleNumericInputChange", () => {
+  test("should only only numeric values", () => {
+    let state = ""
+    const setState = (newState) => {
+      state = newState
+    }
+
+    handleNumericInputChange(setState)("42")
+    expect(state).toBe(42) // Accepts numbers
+
+    handleNumericInputChange(setState)("abc")
+    expect(state).toBe("") // Rejects non-numeric input
+
+    handleNumericInputChange(setState)("10a")
+    expect(state).toBe(10) // Accepts valid numeric input, rejects non-numeric part
+
+    handleNumericInputChange(setState)("")
+    expect(state).toBe("") // Allows empty input
+  })
+})
+
+describe("validateAndSetNumber", () => {
+  test("should ensure input is within bounds", () => {
+    let state = 5
+    const setState = (newState) => {
+      state = newState
+    }
+
+    const validate = validateAndSetNumber(setState, 1, 100)
+
+    validate({ target: { value: "50" } })
+    expect(state).toBe(50) // Input is within range, stays the same
+
+    validate({ target: { value: "101" } })
+    expect(state).toBe(100) // Input is over maximum limit, is set to valid max value (100)
+
+    validate({ target: { value: "0" } })
+    expect(state).toBe(1) // Input is under maximum limit, is set to valid min value (1)
+
+    validate({ target: { value: "abc" } })
+    expect(state).toBe(1) // Input is invalid, is set to default value (1)
+  })
+})
+
+describe("getNextAvailableIndex", () => {
+  test("should return 1 if screen is invalid", () => {
+    expect(getNextAvailableIndex(0, [])).toBe(1) // Screen < 1, returns default index
+    expect(getNextAvailableIndex(5, [])).toBe(1) // Screen > 4, returns default index
+    expect(getNextAvailableIndex(NaN, [])).toBe(1) // NaN, returns default index
+  })
+
+  test("should find the first available index", () => {
+    const cues = [
+      { screen: 1, index: 0 },
+      { screen: 1, index: 1 },
+      { screen: 1, index: 2 },
+      { screen: 2, index: 0 },
+    ]
+
+    expect(getNextAvailableIndex(1, cues)).toBe(3) // Correctly returns next available index 3 for screen 1
+    expect(getNextAvailableIndex(2, cues)).toBe(1) // Correctly returns next available index 1 for screen 2
+  })
+
+  test("should handle gaps in index numbers", () => {
+    const cues = [
+      { screen: 1, index: 0 },
+      { screen: 1, index: 2 },
+      { screen: 1, index: 3 },
+    ]
+
+    expect(getNextAvailableIndex(1, cues)).toBe(1) // Correctly returns next available index 1
+  })
+})

--- a/src/client/tests/unit/numberInputUtils.test.js
+++ b/src/client/tests/unit/numberInputUtils.test.js
@@ -12,16 +12,16 @@ describe("handleNumericInputChange", () => {
     }
 
     handleNumericInputChange(setState)("42")
-    expect(state).toBe(42) // Accepts numbers
+    expect(state).toBe(42)
 
     handleNumericInputChange(setState)("abc")
-    expect(state).toBe("") // Rejects non-numeric input
+    expect(state).toBe("")
 
     handleNumericInputChange(setState)("10a")
-    expect(state).toBe(10) // Accepts valid numeric input, rejects non-numeric part
+    expect(state).toBe(10)
 
     handleNumericInputChange(setState)("")
-    expect(state).toBe("") // Allows empty input
+    expect(state).toBe("")
   })
 })
 
@@ -35,24 +35,24 @@ describe("validateAndSetNumber", () => {
     const validate = validateAndSetNumber(setState, 1, 100)
 
     validate({ target: { value: "50" } })
-    expect(state).toBe(50) // Input is within range, stays the same
+    expect(state).toBe(50)
 
     validate({ target: { value: "101" } })
-    expect(state).toBe(100) // Input is over maximum limit, is set to valid max value (100)
+    expect(state).toBe(100)
 
     validate({ target: { value: "0" } })
-    expect(state).toBe(1) // Input is under maximum limit, is set to valid min value (1)
+    expect(state).toBe(1)
 
     validate({ target: { value: "abc" } })
-    expect(state).toBe(1) // Input is invalid, is set to default value (1)
+    expect(state).toBe(1)
   })
 })
 
 describe("getNextAvailableIndex", () => {
   test("should return 1 if screen is invalid", () => {
-    expect(getNextAvailableIndex(0, [])).toBe(1) // Screen < 1, returns default index
-    expect(getNextAvailableIndex(5, [])).toBe(1) // Screen > 4, returns default index
-    expect(getNextAvailableIndex(NaN, [])).toBe(1) // NaN, returns default index
+    expect(getNextAvailableIndex(0, [])).toBe(1)
+    expect(getNextAvailableIndex(5, [])).toBe(1)
+    expect(getNextAvailableIndex(NaN, [])).toBe(1)
   })
 
   test("should find the first available index", () => {
@@ -63,8 +63,8 @@ describe("getNextAvailableIndex", () => {
       { screen: 2, index: 0 },
     ]
 
-    expect(getNextAvailableIndex(1, cues)).toBe(3) // Correctly returns next available index 3 for screen 1
-    expect(getNextAvailableIndex(2, cues)).toBe(1) // Correctly returns next available index 1 for screen 2
+    expect(getNextAvailableIndex(1, cues)).toBe(3)
+    expect(getNextAvailableIndex(2, cues)).toBe(1)
   })
 
   test("should handle gaps in index numbers", () => {
@@ -74,6 +74,6 @@ describe("getNextAvailableIndex", () => {
       { screen: 1, index: 3 },
     ]
 
-    expect(getNextAvailableIndex(1, cues)).toBe(1) // Correctly returns next available index 1
+    expect(getNextAvailableIndex(1, cues)).toBe(1)
   })
 })

--- a/src/server/routes/presentation.js
+++ b/src/server/routes/presentation.js
@@ -107,7 +107,13 @@ router.put("/:id", userExtractor, upload.single("image"), async (req, res) => {
     if (req.body.screen < 1 || req.body.screen > 4) {
       return res
         .status(400)
-        .json({ error: "Screen number must be between 1 and 4." })
+        .json({ error: "Cue screen must be between 1 and 4." })
+    }
+
+    if (req.body.index < 1 || req.body.index > 100) {
+      return res
+        .status(400)
+        .json({ error: "Cue index must be between 1 and 100." })
     }
 
     if (file && file.size > 50 * 1024 * 1024 && !user.isAdmin) {
@@ -214,7 +220,13 @@ router.put(
       if (screen < 1 || screen > 4) {
         return res
           .status(400)
-          .json({ error: "Screen number must be between 1 and 4." })
+          .json({ error: "Cue screen must be between 1 and 4." })
+      }
+
+      if (index < 1 || index > 100) {
+        return res
+          .status(400)
+          .json({ error: "Cue index must be between 1 and 100." })
       }
 
       const presentation = await Presentation.findById(id)

--- a/src/server/routes/presentation.js
+++ b/src/server/routes/presentation.js
@@ -100,25 +100,34 @@ router.put("/:id", userExtractor, upload.single("image"), async (req, res) => {
     const { id } = req.params
     const fileId = generateFileId()
     const { file, user } = req
+    const { cueName, image } = req.body
+    const index = Number(req.body.index)
+    const screen = Number(req.body.screen)
+    const isInitialElement = req.query.isInitialElement === "true"
 
-    if (!id || !req.body.index || !req.body.cueName || !req.body.screen) {
+    if (!id || isNaN(index) || !cueName || isNaN(screen)) {
       return res.status(400).json({ error: "Missing required fields" })
     }
 
-    if (req.body.screen < 1 || req.body.screen > 4) {
-      return res
-        .status(400)
-        .json({ error: "Cue screen must be between 1 and 4." })
+    if (screen < 1 || screen > 4) {
+      return res.status(400).json({
+        error: `Invalid cue screen: ${screen}. Screen must be between 1 and 4.`,
+      })
     }
 
-    // Validate cue index (must be 1-100, unless an initial element)
-    if (
-      (req.body.index < 1 || req.body.index > 100) &&
-      req.body.isInitialElement != "true"
-    ) {
-      return res
-        .status(400)
-        .json({ error: "Cue index must be between 1 and 100." })
+    // Index validation:
+    // - Initial elements (index 0) are system-generated and bypass the usual 1-100 limit.
+    // - Normal cues must have an index between 1-100, while initial elements must be exactly 0.
+    // - Initial element validation applies only during creation, not updates.
+    if (!isInitialElement && (index < 1 || index > 100)) {
+      return res.status(400).json({
+        error: `Invalid cue index: ${index}. Index must be between 1 and 100.`,
+      })
+    }
+    if (isInitialElement && index !== 0) {
+      return res.status(400).json({
+        error: `Invalid initial element index: ${index}. Index must be exactly 0.`,
+      })
     }
 
     if (file && file.size > 50 * 1024 * 1024 && !user.isAdmin) {
@@ -176,13 +185,13 @@ router.put("/:id", userExtractor, upload.single("image"), async (req, res) => {
       {
         $push: {
           cues: {
-            index: req.body.index,
-            name: req.body.cueName,
-            screen: req.body.screen,
+            index: index,
+            name: cueName,
+            screen: screen,
             file: {
               id: fileId,
               name: req.body.fileName,
-              url: req.body.image === "/blank.png" ? null : "",
+              url: image === "/blank.png" ? null : "",
             },
           },
         },
@@ -216,22 +225,24 @@ router.put(
     try {
       const { id, cueId } = req.params
       const { file } = req
-      const { index, screen, cueName, image } = req.body
+      const { cueName, image } = req.body
+      const index = Number(req.body.index)
+      const screen = Number(req.body.screen)
 
-      if (!id || !index || !screen || !cueId || !cueName) {
+      if (!id || isNaN(index) || !cueName || isNaN(screen)) {
         return res.status(400).json({ error: "Missing required fields" })
       }
 
       if (screen < 1 || screen > 4) {
-        return res
-          .status(400)
-          .json({ error: "Cue screen must be between 1 and 4." })
+        return res.status(400).json({
+          error: `Invalid cue screen: ${screen}. Screen must be between 1 and 4.`,
+        })
       }
 
       if (index < 1 || index > 100) {
-        return res
-          .status(400)
-          .json({ error: "Cue index must be between 1 and 100." })
+        return res.status(400).json({
+          error: `Invalid cue index: ${index}. Index must be between 1 and 100.`,
+        })
       }
 
       const presentation = await Presentation.findById(id)

--- a/src/server/routes/presentation.js
+++ b/src/server/routes/presentation.js
@@ -100,6 +100,7 @@ router.put("/:id", userExtractor, upload.single("image"), async (req, res) => {
     const { id } = req.params
     const fileId = generateFileId()
     const { file, user } = req
+
     if (!id || !req.body.index || !req.body.cueName || !req.body.screen) {
       return res.status(400).json({ error: "Missing required fields" })
     }
@@ -110,7 +111,11 @@ router.put("/:id", userExtractor, upload.single("image"), async (req, res) => {
         .json({ error: "Cue screen must be between 1 and 4." })
     }
 
-    if (req.body.index < 1 || req.body.index > 100) {
+    // Validate cue index (must be 1-100, unless an initial element)
+    if (
+      (req.body.index < 1 || req.body.index > 100) &&
+      req.body.isInitialElement != "true"
+    ) {
       return res
         .status(400)
         .json({ error: "Cue index must be between 1 and 100." })

--- a/src/server/routes/presentation.js
+++ b/src/server/routes/presentation.js
@@ -104,6 +104,12 @@ router.put("/:id", userExtractor, upload.single("image"), async (req, res) => {
       return res.status(400).json({ error: "Missing required fields" })
     }
 
+    if (req.body.screen < 1 || req.body.screen > 4) {
+      return res
+        .status(400)
+        .json({ error: "Screen number must be between 1 and 4." })
+    }
+
     if (file && file.size > 50 * 1024 * 1024 && !user.isAdmin) {
       return res.status(400).json({ error: "File size exceeds 50 MB limit" })
     }
@@ -203,6 +209,12 @@ router.put(
 
       if (!id || !index || !screen || !cueId || !cueName) {
         return res.status(400).json({ error: "Missing required fields" })
+      }
+
+      if (screen < 1 || screen > 4) {
+        return res
+          .status(400)
+          .json({ error: "Screen number must be between 1 and 4." })
       }
 
       const presentation = await Presentation.findById(id)

--- a/src/server/tests/presentation_api.test.js
+++ b/src/server/tests/presentation_api.test.js
@@ -122,7 +122,7 @@ describe("test presentation", () => {
       const imageFilePath = path.join(__dirname, "mock_image.png")
       const image = fs.readFileSync(imageFilePath)
 
-      await api
+      const response = await api
         .put(`/api/presentation/${testPresentationId}`)
         .attach("image", image, "mock_image.png")
         .field("index", "1")
@@ -130,13 +130,15 @@ describe("test presentation", () => {
         .field("screen", "5") // Invalid screen
         .field("fileName", "")
         .expect(400)
+
+      expect(response.body.error).toBe("Cue screen must be between 1 and 4.")
     })
 
     test("PUT /api/presentation/:id with invalid index should return 400", async () => {
       const imageFilePath = path.join(__dirname, "mock_image.png")
       const image = fs.readFileSync(imageFilePath)
 
-      await api
+      const response = await api
         .put(`/api/presentation/${testPresentationId}`)
         .attach("image", image, "mock_image.png")
         .field("index", "101") // Invalid index
@@ -144,13 +146,15 @@ describe("test presentation", () => {
         .field("screen", "4")
         .field("fileName", "")
         .expect(400)
+
+      expect(response.body.error).toBe("Cue index must be between 1 and 100.")
     })
 
     test("PUT /api/presentation/:id with missing screen should return 400", async () => {
       const imageFilePath = path.join(__dirname, "mock_image.png")
       const image = fs.readFileSync(imageFilePath)
 
-      await api
+      const response = await api
         .put(`/api/presentation/${testPresentationId}`)
         .attach("image", image, "mock_image.png")
         .field("index", "1")
@@ -158,6 +162,8 @@ describe("test presentation", () => {
         .field("cueName", "Test Cue")
         .field("fileName", "")
         .expect(400)
+
+      expect(response.body.error).toBe("Missing required fields")
     })
   })
 
@@ -177,37 +183,43 @@ describe("test presentation", () => {
     test("PUT /api/presentation/:id/:cueId with invalid screen should return 400", async () => {
       testCueId = await createCue(2)
 
-      await api
+      const response = await api
         .put(`/api/presentation/${testPresentationId}/${testCueId}`)
         .field("index", "1")
         .field("cueName", "Test Cue")
         .field("screen", "5") // Invalid screen
         .field("fileName", "")
         .expect(400)
+
+      expect(response.body.error).toBe("Cue screen must be between 1 and 4.")
     })
 
     test("PUT /api/presentation/:id/:cueId with invalid index should return 400", async () => {
       testCueId = await createCue(2)
 
-      await api
+      const response = await api
         .put(`/api/presentation/${testPresentationId}/${testCueId}`)
         .field("index", "0") // Invalid index
         .field("cueName", "Test Cue")
         .field("screen", "4")
         .field("fileName", "")
         .expect(400)
+
+      expect(response.body.error).toBe("Cue index must be between 1 and 100.")
     })
 
     test("PUT /api/presentation/:id/:cueId with missing screen should return 400", async () => {
       testCueId = await createCue(2)
 
-      await api
+      const response = await api
         .put(`/api/presentation/${testPresentationId}/${testCueId}`)
         .field("index", "1")
         .field("cueName", "Test Cue")
         // Missing screen field
         .field("fileName", "")
         .expect(400)
+
+      expect(response.body.error).toBe("Missing required fields")
     })
   })
 })

--- a/src/server/tests/presentation_api.test.js
+++ b/src/server/tests/presentation_api.test.js
@@ -47,17 +47,14 @@ describe("test presentation", () => {
   })
   describe("DELETE", () => {
     test(" /api/presentation/:id", async () => {
-      await api
-        .delete(`/api/presentation/${testPresentationId}`)
-        .expect(204)
+      await api.delete(`/api/presentation/${testPresentationId}`).expect(204)
     })
   })
 
   describe("PUT /api/presentation/:id", () => {
     test("update presentation", async () => {
-      const imageFilePath = path.join(__dirname, 'mock_image.png')
+      const imageFilePath = path.join(__dirname, "mock_image.png")
       const image = fs.readFileSync(imageFilePath)
-
 
       await api
         .put(`/api/presentation/${testPresentationId}`)

--- a/src/server/tests/presentation_api.test.js
+++ b/src/server/tests/presentation_api.test.js
@@ -36,6 +36,22 @@ describe("test presentation", () => {
     testPresentationId = presentation._id
   })
 
+  // Helper function for creating cues
+  const createCue = async (screen) => {
+    const imageFilePath = path.join(__dirname, "mock_image.png")
+    const image = fs.readFileSync(imageFilePath)
+
+    const cueResponse = await api
+      .put(`/api/presentation/${testPresentationId}`)
+      .attach("image", image, "mock_image.png")
+      .field("index", "1")
+      .field("cueName", "Test Cue")
+      .field("screen", screen)
+      .field("fileName", "")
+
+    return cueResponse.body.cues[0]._id // Return ID of created cue
+  }
+
   describe("GET /api/presentation/:id", () => {
     test("presentation is returned as json", async () => {
       await api

--- a/src/server/tests/presentation_api.test.js
+++ b/src/server/tests/presentation_api.test.js
@@ -222,4 +222,61 @@ describe("test presentation", () => {
       expect(response.body.error).toBe("Missing required fields")
     })
   })
+
+  describe("Initial element tests", () => {
+    test("PUT /api/presentation/:id with 4 cues having index = 0 and isInitialElement = true should return 200", async () => {
+      const screens = [1, 2, 3, 4]
+
+      for (const screen of screens) {
+        const imageFilePath = path.join(__dirname, "mock_image.png")
+        const image = fs.readFileSync(imageFilePath)
+
+        await api
+          .put(`/api/presentation/${testPresentationId}`)
+          .attach("image", image, "mock_image.png")
+          .field("index", "0")
+          .field("cueName", `initial element for screen ${screen}`)
+          .field("screen", screen)
+          .field("fileName", "")
+          .field("isInitialElement", "true")
+          .expect(200)
+      }
+
+      // Fetch presentation to check stored cues
+      const response = await api
+        .get(`/api/presentation/${testPresentationId}`)
+        .set("Authorization", authHeader)
+        .expect(200)
+
+      const { cues } = response.body
+
+      // Ensure exactly 4 cues exist
+      expect(cues.length).toBe(4)
+
+      // Validate properties of each cue
+      cues.forEach((cue, index) => {
+        expect(cue.index).toBe(0)
+        expect(cue.name).toBe(`initial element for screen ${screens[index]}`)
+        expect(cue.screen).toBe(screens[index])
+      })
+    })
+
+    test("PUT /api/presentation/:id with 4 cues having index = 0 but missing isInitialElement should return 400", async () => {
+      const screens = [1, 2, 3, 4]
+
+      for (const screen of screens) {
+        const imageFilePath = path.join(__dirname, "mock_image.png")
+        const image = fs.readFileSync(imageFilePath)
+
+        await api
+          .put(`/api/presentation/${testPresentationId}`)
+          .attach("image", image, "mock_image.png")
+          .field("index", "0")
+          .field("cueName", `initial element for screen ${screen}`)
+          .field("screen", screen)
+          .field("fileName", "")
+          .expect(400)
+      }
+    })
+  })
 })

--- a/src/server/tests/presentation_api.test.js
+++ b/src/server/tests/presentation_api.test.js
@@ -253,5 +253,5 @@ describe("test presentation", () => {
         )
       }
     })
-  })
+  }, 10000)
 })

--- a/src/server/tests/presentation_api.test.js
+++ b/src/server/tests/presentation_api.test.js
@@ -11,6 +11,7 @@ const api = supertest(app)
 
 let authHeader
 let testPresentationId
+let testCueId
 
 describe("test presentation", () => {
   beforeEach(async () => {
@@ -99,6 +100,88 @@ describe("test presentation", () => {
       const response = await api.put("/api/presentation/:id")
 
       expect(response.status).toBe(400)
+    })
+  })
+
+  describe("Cue creation tests", () => {
+    test("PUT /api/presentation/:id with valid screen should return 200", async () => {
+      const imageFilePath = path.join(__dirname, "mock_image.png")
+      const image = fs.readFileSync(imageFilePath)
+
+      await api
+        .put(`/api/presentation/${testPresentationId}`)
+        .attach("image", image, "mock_image.png")
+        .field("index", "1")
+        .field("cueName", "Test Cue")
+        .field("screen", "1") // Valid screen
+        .field("fileName", "")
+        .expect(200)
+    })
+
+    test("PUT /api/presentation/:id with invalid screen should return 400", async () => {
+      const imageFilePath = path.join(__dirname, "mock_image.png")
+      const image = fs.readFileSync(imageFilePath)
+
+      await api
+        .put(`/api/presentation/${testPresentationId}`)
+        .attach("image", image, "mock_image.png")
+        .field("index", "1")
+        .field("cueName", "Test Cue")
+        .field("screen", "5") // Invalid screen
+        .field("fileName", "")
+        .expect(400)
+    })
+
+    test("PUT /api/presentation/:id with missing screen should return 400", async () => {
+      const imageFilePath = path.join(__dirname, "mock_image.png")
+      const image = fs.readFileSync(imageFilePath)
+
+      await api
+        .put(`/api/presentation/${testPresentationId}`)
+        .attach("image", image, "mock_image.png")
+        .field("index", "1")
+        // Missing screen field
+        .field("cueName", "Test Cue")
+        .field("fileName", "")
+        .expect(400)
+    })
+  })
+
+  describe("Cue update tests", () => {
+    test("PUT /api/presentation/:id/:cueId with valid screen should return 200", async () => {
+      testCueId = await createCue(2) // Create cue in screen 2
+
+      await api
+        .put(`/api/presentation/${testPresentationId}/${testCueId}`)
+        .field("index", "1")
+        .field("cueName", "Test Cue")
+        .field("screen", "1") // Valid screen
+        .field("fileName", "")
+        .expect(200)
+    })
+
+    test("PUT /api/presentation/:id/:cueId with invalid screen should return 400", async () => {
+      testCueId = await createCue(2) // Create cue in screen 2
+
+      await api
+        .put(`/api/presentation/${testPresentationId}/${testCueId}`)
+        .field("index", "1")
+        .field("cueName", "Test Cue")
+        .field("screen", "5") // Invalid screen
+        .field("fileName", "")
+        .expect(400)
+    })
+
+    test("PUT /api/presentation/:id/:cueId with missing screen should return 400", async () => {
+      testCueId = await createCue(2) // Create cue in screen 2
+
+      await api
+        .put(`/api/presentation/${testPresentationId}/${testCueId}`)
+        .field("index", "1")
+        .field("cueName", "Test Cue")
+        // Missing screen field
+        .field("fileName", "")
+        .expect(400)
     })
   })
 })

--- a/src/server/tests/presentation_api.test.js
+++ b/src/server/tests/presentation_api.test.js
@@ -104,7 +104,7 @@ describe("test presentation", () => {
   })
 
   describe("Cue creation tests", () => {
-    test("PUT /api/presentation/:id with valid screen should return 200", async () => {
+    test("PUT /api/presentation/:id with valid inputs should return 200", async () => {
       const imageFilePath = path.join(__dirname, "mock_image.png")
       const image = fs.readFileSync(imageFilePath)
 
@@ -113,7 +113,7 @@ describe("test presentation", () => {
         .attach("image", image, "mock_image.png")
         .field("index", "1")
         .field("cueName", "Test Cue")
-        .field("screen", "1") // Valid screen
+        .field("screen", "1")
         .field("fileName", "")
         .expect(200)
     })
@@ -128,6 +128,20 @@ describe("test presentation", () => {
         .field("index", "1")
         .field("cueName", "Test Cue")
         .field("screen", "5") // Invalid screen
+        .field("fileName", "")
+        .expect(400)
+    })
+
+    test("PUT /api/presentation/:id with invalid index should return 400", async () => {
+      const imageFilePath = path.join(__dirname, "mock_image.png")
+      const image = fs.readFileSync(imageFilePath)
+
+      await api
+        .put(`/api/presentation/${testPresentationId}`)
+        .attach("image", image, "mock_image.png")
+        .field("index", "101") // Invalid index
+        .field("cueName", "Test Cue")
+        .field("screen", "4")
         .field("fileName", "")
         .expect(400)
     })
@@ -147,21 +161,21 @@ describe("test presentation", () => {
     })
   })
 
-  describe("Cue update tests", () => {
-    test("PUT /api/presentation/:id/:cueId with valid screen should return 200", async () => {
-      testCueId = await createCue(2) // Create cue in screen 2
+  describe("Cue updation tests", () => {
+    test("PUT /api/presentation/:id/:cueId with valid inputs should return 200", async () => {
+      testCueId = await createCue(2)
 
       await api
         .put(`/api/presentation/${testPresentationId}/${testCueId}`)
-        .field("index", "1")
+        .field("index", "100")
         .field("cueName", "Test Cue")
-        .field("screen", "1") // Valid screen
+        .field("screen", "4")
         .field("fileName", "")
         .expect(200)
     })
 
     test("PUT /api/presentation/:id/:cueId with invalid screen should return 400", async () => {
-      testCueId = await createCue(2) // Create cue in screen 2
+      testCueId = await createCue(2)
 
       await api
         .put(`/api/presentation/${testPresentationId}/${testCueId}`)
@@ -172,8 +186,20 @@ describe("test presentation", () => {
         .expect(400)
     })
 
+    test("PUT /api/presentation/:id/:cueId with invalid index should return 400", async () => {
+      testCueId = await createCue(2)
+
+      await api
+        .put(`/api/presentation/${testPresentationId}/${testCueId}`)
+        .field("index", "0") // Invalid index
+        .field("cueName", "Test Cue")
+        .field("screen", "4")
+        .field("fileName", "")
+        .expect(400)
+    })
+
     test("PUT /api/presentation/:id/:cueId with missing screen should return 400", async () => {
-      testCueId = await createCue(2) // Create cue in screen 2
+      testCueId = await createCue(2)
 
       await api
         .put(`/api/presentation/${testPresentationId}/${testCueId}`)

--- a/src/server/tests/presentation_api.test.js
+++ b/src/server/tests/presentation_api.test.js
@@ -189,6 +189,18 @@ describe("test presentation", () => {
         "Invalid cue index: 0. Index must be between 1 and 100."
       )
     })
+
+    test("PUT /api/presentation/:id/:cueId with missing fields should return 400", async () => {
+      testCueId = (await createCue(1, "Test Cue", 2)).body.cues[0]._id
+
+      const response = await api
+        .put(`/api/presentation/${testPresentationId}/${testCueId}`)
+        .field("index", "1")
+        .field("fileName", "")
+        .expect(400)
+
+      expect(response.body.error).toBe("Missing required fields")
+    })
   })
 
   describe("Initial element tests", () => {

--- a/src/server/tests/presentation_api.test.js
+++ b/src/server/tests/presentation_api.test.js
@@ -37,7 +37,6 @@ describe("test presentation", () => {
     testPresentationId = presentation._id
   })
 
-  // Helper function for creating cues
   const createCue = async (
     index,
     cueName,
@@ -206,7 +205,6 @@ describe("test presentation", () => {
         expect(response.status).toBe(200)
       }
 
-      // Fetch presentation to check stored cues
       const response = await api
         .get(`/api/presentation/${testPresentationId}`)
         .set("Authorization", authHeader)
@@ -214,7 +212,6 @@ describe("test presentation", () => {
 
       const { cues } = response.body
 
-      // Ensure exactly 4 cues exist
       expect(cues.length).toBe(4)
 
       cues.forEach((cue, index) => {

--- a/src/server/tests/presentation_api.test.js
+++ b/src/server/tests/presentation_api.test.js
@@ -219,7 +219,7 @@ describe("test presentation", () => {
         expect(cue.name).toBe(`initial element for screen ${screens[index]}`)
         expect(cue.screen).toBe(screens[index])
       })
-    })
+    }, 10000)
 
     test("PUT /api/presentation/:id with 4 cues having index = 0 without isInitialElement flag should return 400", async () => {
       const screens = [1, 2, 3, 4]
@@ -253,5 +253,5 @@ describe("test presentation", () => {
         )
       }
     })
-  }, 10000)
+  })
 })

--- a/src/server/tests/presentation_api.test.js
+++ b/src/server/tests/presentation_api.test.js
@@ -239,5 +239,22 @@ describe("test presentation", () => {
         )
       }
     })
+
+    test("PUT /api/presentation/:id with 4 cues having isInitialElement = true but index != 0 should return 400", async () => {
+      const screens = [1, 2, 3, 4]
+
+      for (const screen of screens) {
+        const response = await createCue(
+          1,
+          `initial element for screen ${screen}`,
+          screen,
+          true
+        )
+        expect(response.status).toBe(400)
+        expect(response.body.error).toBe(
+          "Invalid initial element index: 1. Index must be exactly 0."
+        )
+      }
+    })
   })
 })


### PR DESCRIPTION
## #259 Cue index and screen input validation

This pull expands validation and error handling to enforce valid cue screen and index input ranges:
- Cue screen must be between 1-4.
- Cue index must be between 1-100. An exception is made for automatically generated initial element cues (index 0).

### Frontend changes

#### src/client/components/presentation/EditMode.jsx
- Update `handleDoubleClick` to prevent invalid cue placements: Do nothing if the user doubleclicks a location outside the valid cue area.

#### src/client/services/presentation.js
- Create `addInitialElementCue()` to handle initial elements separately.

#### src/client/components/utils/addInitialElements.js
- Use `addInitialElementCue()` instead of `addCue()` for initial element creation.

### Backend changes

#### src/server/routes/presentation.js
- Add validation for cue index and screen inputs in cue creation and update methods
- Destructure `cueName`, `image`, `index`, and `screen` in cue creation.
- Convert `index` and `screen` to numbers explicitly.
- Allow initial elements to bypass normal index validation by using the `isInitialElement` query parameter. 
  - This has only been implemented in the cue creation method, since initial elements are created once and have no need to be updated.
- Add error handling and messages for invalid screen and index values.

#### src/server/tests/presentation_api.test.js
- Add tests for valid/invalid cases in cue creation, updates, and initial element creation.
- Ensure initial elements (index = 0) require `isInitialElement=true` in the query.
- Add `createCue()` helper function.

#### src/client/tests/unit/numberInputUtils.test.js
- Add frontend test suite for numeric input validation.
- Test `handleNumericInputChange()` to ensure only valid numeric inputs are accepted.
- Test `validateAndSetNumber()` to enforce min/max constraints.
- Test `getNextAvailableIndex()` to find the next valid cue index.

### Next steps
Initial element cues can currently be dragged away from index 0, but can't be dragged back due to the enforcement of valid index range 1-100. This might confuse users, and could be addressed by making initial elements uneditable, since their role is to serve as a fixed initial element anyway.