### PR TITLE
Bugfix/issue 259 fifth screen appearing

### DIFF
--- a/src/client/components/utils/addInitialElements.js
+++ b/src/client/components/utils/addInitialElements.js
@@ -11,7 +11,6 @@ const addInitialElements = async (presentationId, showToast) => {
         screen,
         "/blank.png"
       )
-
       await presentation.addCue(presentationId, formData)
     }
 

--- a/src/client/components/utils/addInitialElements.js
+++ b/src/client/components/utils/addInitialElements.js
@@ -12,7 +12,7 @@ const addInitialElements = async (presentationId, showToast) => {
         "/blank.png"
       )
 
-      await presentation.addInitialElementCue(presentationId, formData)
+      await presentation.addCue(presentationId, formData)
     }
 
     showToast({

--- a/src/client/services/presentation.js
+++ b/src/client/services/presentation.js
@@ -39,25 +39,6 @@ const addCue = async (id, formData) => {
   return response.data
 }
 
-/**
- * Adds an initial element cue (index 0) to the server.
- * Uses `isInitialElement=true` in the query to bypass the normal index limit (1-100).
- */
-const addInitialElementCue = async (id, formData) => {
-  const config = {
-    headers: {
-      "Content-Type": "multipart/form-data",
-      Authorization: `bearer ${getToken()}`,
-    },
-  }
-  const response = await axios.put(
-    `${baseUrl}/${id}?isInitialElement=true`,
-    formData,
-    config
-  )
-  return response.data
-}
-
 const removeCue = async (id, cueId) => {
   const response = await axios.delete(`${baseUrl}/${id}/${cueId}`)
   return response.data
@@ -82,7 +63,6 @@ export default {
   get,
   remove,
   addCue,
-  addInitialElementCue,
   removeCue,
   updateCue,
 }

--- a/src/server/routes/presentation.js
+++ b/src/server/routes/presentation.js
@@ -103,7 +103,6 @@ router.put("/:id", userExtractor, upload.single("image"), async (req, res) => {
     const { cueName, image } = req.body
     const index = Number(req.body.index)
     const screen = Number(req.body.screen)
-    const isInitialElement = req.query.isInitialElement === "true"
 
     if (!id || isNaN(index) || !cueName || isNaN(screen)) {
       return res.status(400).json({ error: "Missing required fields" })
@@ -115,18 +114,9 @@ router.put("/:id", userExtractor, upload.single("image"), async (req, res) => {
       })
     }
 
-    // Index validation:
-    // - Initial elements (index 0) are system-generated and bypass the usual 1-100 limit.
-    // - Normal cues must have an index between 1-100, while initial elements must be exactly 0.
-    // - Initial element validation applies only during creation, not updates.
-    if (!isInitialElement && (index < 1 || index > 100)) {
+    if (index < 0 || index > 100) {
       return res.status(400).json({
-        error: `Invalid cue index: ${index}. Index must be between 1 and 100.`,
-      })
-    }
-    if (isInitialElement && index !== 0) {
-      return res.status(400).json({
-        error: `Invalid initial element index: ${index}. Index must be exactly 0.`,
+        error: `Invalid cue index: ${index}. Index must be between 0 and 100.`,
       })
     }
 
@@ -239,9 +229,9 @@ router.put(
         })
       }
 
-      if (index < 1 || index > 100) {
+      if (index < 0 || index > 100) {
         return res.status(400).json({
-          error: `Invalid cue index: ${index}. Index must be between 1 and 100.`,
+          error: `Invalid cue index: ${index}. Index must be between 0 and 100.`,
         })
       }
 

--- a/src/server/tests/presentation_api.test.js
+++ b/src/server/tests/presentation_api.test.js
@@ -37,18 +37,11 @@ describe("test presentation", () => {
     testPresentationId = presentation._id
   })
 
-  const createCue = async (
-    index,
-    cueName,
-    screen,
-    isInitialElement = false
-  ) => {
+  const createCue = async (index, cueName, screen) => {
     const imageFilePath = path.join(__dirname, "mock_image.png")
     const image = fs.readFileSync(imageFilePath)
 
-    const url = isInitialElement
-      ? `/api/presentation/${testPresentationId}?isInitialElement=true`
-      : `/api/presentation/${testPresentationId}`
+    const url = `/api/presentation/${testPresentationId}`
 
     const response = await api
       .put(url)
@@ -179,7 +172,7 @@ describe("test presentation", () => {
 
       const response = await api
         .put(`/api/presentation/${testPresentationId}/${testCueId}`)
-        .field("index", "0")
+        .field("index", "-1")
         .field("cueName", "Test Cue")
         .field("screen", "4")
         .field("fileName", "")
@@ -200,70 +193,6 @@ describe("test presentation", () => {
         .expect(400)
 
       expect(response.body.error).toBe("Missing required fields")
-    })
-  })
-
-  describe("Initial element tests", () => {
-    test("PUT /api/presentation/:id with 4 cues having index = 0 and isInitialElement = true should return 200", async () => {
-      const screens = [1, 2, 3, 4]
-
-      for (const screen of screens) {
-        const response = await createCue(
-          0,
-          `initial element for screen ${screen}`,
-          screen,
-          true
-        )
-        expect(response.status).toBe(200)
-      }
-
-      const response = await api
-        .get(`/api/presentation/${testPresentationId}`)
-        .set("Authorization", authHeader)
-        .expect(200)
-
-      const { cues } = response.body
-
-      expect(cues.length).toBe(4)
-
-      cues.forEach((cue, index) => {
-        expect(cue.index).toBe(0)
-        expect(cue.name).toBe(`initial element for screen ${screens[index]}`)
-        expect(cue.screen).toBe(screens[index])
-      })
-    }, 10000)
-
-    test("PUT /api/presentation/:id with 4 cues having index = 0 without isInitialElement flag should return 400", async () => {
-      const screens = [1, 2, 3, 4]
-
-      for (const screen of screens) {
-        const response = await createCue(
-          0,
-          `initial element for screen ${screen}`,
-          screen
-        )
-        expect(response.status).toBe(400)
-        expect(response.body.error).toBe(
-          "Invalid cue index: 0. Index must be between 1 and 100."
-        )
-      }
-    })
-
-    test("PUT /api/presentation/:id with 4 cues having isInitialElement = true but index != 0 should return 400", async () => {
-      const screens = [1, 2, 3, 4]
-
-      for (const screen of screens) {
-        const response = await createCue(
-          1,
-          `initial element for screen ${screen}`,
-          screen,
-          true
-        )
-        expect(response.status).toBe(400)
-        expect(response.body.error).toBe(
-          "Invalid initial element index: 1. Index must be exactly 0."
-        )
-      }
     })
   })
 })

--- a/src/server/tests/presentation_api.test.js
+++ b/src/server/tests/presentation_api.test.js
@@ -122,7 +122,7 @@ describe("test presentation", () => {
       const response = await createCue(101, "Test Cue", 4)
       expect(response.status).toBe(400)
       expect(response.body.error).toBe(
-        "Invalid cue index: 101. Index must be between 1 and 100."
+        "Invalid cue index: 101. Index must be between 0 and 100."
       )
     })
 
@@ -179,7 +179,7 @@ describe("test presentation", () => {
         .expect(400)
 
       expect(response.body.error).toBe(
-        "Invalid cue index: 0. Index must be between 1 and 100."
+        "Invalid cue index: -1. Index must be between 0 and 100."
       )
     })
 


### PR DESCRIPTION
## #259 Cue index and screen input validation

This update adds backend validation and error handling to enforce valid cue screen and index input ranges:  
- Cue screen must be 1-4.  
- Cue index must be 0-100.

Some changes from an earlier pull request (#293) were merged to `feature-merge-dev` but reverted due to a bug where initial elements could be moved out of index 0 but not back in. This was addressed by lowering the backend minimum index limit to 0 and removing redundant logic.  

Due to the revert and merge conflict resolution, the commit history of the pull request may look a little confusing, showing only the most recent commits after the reversion. This is expected as a result of pulling `feature-merge-dev` into this branch and resolving conflicts.

### Frontend changes  
#### src/client/components/presentation/EditMode.jsx  
- Update `handleDoubleClick` to prevent invalid cue placements: Do nothing if the user double-clicks outside the valid cue area.

### Backend changes  
#### src/server/routes/presentation.js  
- Enforce cue index (0-100) and screen (1-4) validation in cue creation and update methods.  
- Destructure `cueName`, `image`, `index`, and `screen` in cue creation.  
- Convert `index` and `screen` explicitly to numbers.  
- Error handling and messaging for invalid screen and index values.  

### Test changes  
#### src/server/tests/presentation_api.test.js  
- Add tests for valid/invalid cases in cue creation and updates.  
- Add `createCue()` helper function.  

#### src/client/tests/unit/numberInputUtils.test.js  
- Add frontend test suite for numeric input validation.  

### Next steps  
Currently, there are inconsistencies with validation as the frontend enforces an index range of 1-100 (except cue dragging allows moving cues to index 0), while the backend allows 0-100 to ensure initial elements function correctly. 

A decision should be made on whether to allow frontend users to create index 0 cues or to align backend validation with the frontend (1-100). If the latter is chosen, adjustments will be needed in the initial element creation and update logic to prevent issues like the one mentioned above.