### PR TITLE
Enable proper screen data updation when mirroring

### DIFF
--- a/src/client/components/presentation/ShowMode.jsx
+++ b/src/client/components/presentation/ShowMode.jsx
@@ -120,10 +120,23 @@ const ShowMode = ({ cues }) => {
         const mirroredScreen = mirroring[screenNumber]
         const sourceScreen = mirroredScreen ? mirroredScreen : screenNumber
 
+        // Get the last available cue if the current cueIndex is missing
+        const getLastValidCue = (screen, index) => {
+          while (index >= 0) {
+            if (preloadedCues[screen]?.[index]) {
+              return preloadedCues[screen][index]
+            }
+            index -= 1
+          }
+          return {}
+        }
+
+        const screenData = getLastValidCue(sourceScreen, cueIndex)
+
         return (
           <Screen
             key={screenNumber}
-            screenData={preloadedCues[sourceScreen]?.[cueIndex]}
+            screenData={screenData}
             screenNumber={screenNumber}
             isVisible={screenVisibility[screenNumber]}
             onClose={handleScreenClose}


### PR DESCRIPTION
Previously, when a screen was mirroring another screen’s content and the mirrored screen did not have an element at the current index, the previously displayed content would remain on the screen instead of updating correctly.

This update enables proper screen data updation when mirroring a screen. If the mirrored screen does not have data at the current index, the system retrieves the last available cue from the mirrored screen.

