### PR TITLE
Bugfix/issue 291 and 290 fix presentation grid layout

### DIFF
--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -371,7 +371,6 @@ const EditMode = ({ id, cues, isToolboxOpen, setIsToolboxOpen }) => {
             display="grid"
             gridTemplateRows={`repeat(${yLabels.length + 1}, ${rowHeight}px)`}
             gap={`${gap}px`}
-            position="sticky"
             left={0}
             zIndex={2}
             bg={"transparent"}

--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -396,10 +396,9 @@ const EditMode = ({ id, cues, isToolboxOpen, setIsToolboxOpen }) => {
             ))}
           </Box>
 
-          <Box position="relative">
+          <Box position="relative" overflow="auto">
             <Box
               height="600px"
-              overflow="auto"
               width="100%"
               position="relative"
               ref={containerRef}


### PR DESCRIPTION
## #290 : Bug: "Screen" tiles will stick when scrolling right
## #291 : Bug: presentation grid scroll bar is at the bottom of document

This pull fixes two layout bugs. First, screen tiles (Screen 1, Screen 2, Screen 3, Screen 4) stuck to the view when presentation grid was scrolled horisontally.

Second, presentation grid scrollbar was at the bottom of the document, instead of at the bottom of presentation grid, which made it hard to notice for users.

### Changes

**`src/client/components/presentation/EditMode.jsx`**
- "Screen" tile sticking was fixed by removing "position: sticky" property from ChakraUI's Box-element.
- Scrollbar was fixed by adding property "overflow: auto" to the right Box-element.

