### PR TITLE
Enable proper screen data updation when mirroring

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ Once the user enters 'Show mode' the cues can be activated. Each cue is linked t
 
 The cues are differentiated by their 'screen' and 'index' values. Cues with the same 'screen' are shown in the same pop up window, while cues with the same 'index' are activated simultaneously. This allows the user to control media on several screens independently. A user can delete a presentation or cue, which also deletes the media of said presentation / cue.
 
-Currently the application is running on a staging server, which, for security reasons is not made public. The deployment server will be publicly available soon.
-
 ### Documentation
 
 For detailed instructions on how to use the application check out the [User Guide](https://github.com/MuViCo/MuViCo/blob/3fa0f45fdeec4fe03a244c961004a385991dd78b/documentation/userguide.md)

--- a/src/client/components/presentation/ShowMode.jsx
+++ b/src/client/components/presentation/ShowMode.jsx
@@ -102,6 +102,17 @@ const ShowMode = ({ cues }) => {
     }
   }
 
+  // Get the last available cue if the current cueIndex is missing
+  const getLastValidCue = (screen, index) => {
+    while (index >= 0) {
+      if (preloadedCues[screen]?.[index]) {
+        return preloadedCues[screen][index]
+      }
+      index -= 1
+    }
+    return {}
+  }
+
   return (
     <div className="show-mode">
       {/* Pass screen visibility and cue navigation to ShowModeButtons */}
@@ -120,10 +131,12 @@ const ShowMode = ({ cues }) => {
         const mirroredScreen = mirroring[screenNumber]
         const sourceScreen = mirroredScreen ? mirroredScreen : screenNumber
 
+        const screenData = getLastValidCue(sourceScreen, cueIndex)
+
         return (
           <Screen
             key={screenNumber}
-            screenData={preloadedCues[sourceScreen]?.[cueIndex]}
+            screenData={screenData}
             screenNumber={screenNumber}
             isVisible={screenVisibility[screenNumber]}
             onClose={handleScreenClose}

--- a/src/client/components/presentation/ShowModeButtons.jsx
+++ b/src/client/components/presentation/ShowModeButtons.jsx
@@ -4,7 +4,7 @@ import { ChevronLeftIcon, ChevronRightIcon, ChevronDownIcon } from "@chakra-ui/i
 
 const DropdownButton = ({ screenNumber, screens, toggleScreenMirroring }) => (
   <Menu>
-    <MenuButton as={Button} colorScheme="gray" p={1}>
+    <MenuButton as={Button} colorScheme="gray" p={1} aria-label={`Dropdown for screen ${screenNumber}`}>
       <ChevronDownIcon />
     </MenuButton>
     <MenuList>


### PR DESCRIPTION
### Problem
Previously, when a screen was mirroring another screen’s content and the mirrored screen did not have an element at the current index, the previously displayed content would remain on the screen instead of updating correctly.

### Solution
This update enables proper screen data updation when mirroring a screen. If the mirrored screen does not have data at the current index, the system retrieves the last available cue from the mirrored screen.

### Changes
**src/components/ShowMode.jsx**

- Updated screen mirroring logic to ensure that if the mirrored screen doesn't have content at the current index, it retrieves the last available cue.

**src/components/ShowModeButtons.jsx**

- Added an aria-label to MenuButton for identifying the dropdown button in tests

**src/tests/showmode.test.js**

- Added tests to verify the behavior of screen mirroring.