### PR TITLE
Feature/issue 192 swap elements with each other

### DIFF
--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -86,6 +86,11 @@ const EditMode = ({ id, cues, isToolboxOpen, setIsToolboxOpen }) => {
       rowHeight,
       gap
     )
+
+    const cueExists = cues.some(
+      (cue) => cue.index === xIndex && cue.screen === yIndex
+    )
+
     if (
       !cueExists &&
       xIndex >= 0 &&

--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -7,6 +7,7 @@ import {
   updatePresentation,
   createCue,
   removeCue,
+  updatePresentationSwappedCues,
 } from "../../redux/presentationReducer"
 import { createFormData } from "../utils/formDataUtils"
 import ToolBox from "./ToolBox"
@@ -51,6 +52,20 @@ const EditMode = ({ id, cues, isToolboxOpen, setIsToolboxOpen }) => {
   }, [isToolboxOpen])
 
   const handleMouseDown = (event) => {
+    const { xIndex, yIndex } = getPosition(
+      event,
+      containerRef,
+      columnWidth,
+      rowHeight,
+      gap
+    )
+
+    if (cueExists(xIndex, yIndex)) {
+      const movingCue = cues.find(
+        (cue) => cue.index === xIndex && cue.screen === yIndex
+      )
+      setSelectedCue(movingCue)
+    }
     if (event.target.closest(".react-grid-item")) {
       setIsDragging(true)
       setHoverPosition(null)
@@ -71,9 +86,6 @@ const EditMode = ({ id, cues, isToolboxOpen, setIsToolboxOpen }) => {
       rowHeight,
       gap
     )
-    const cueExists = cues.some(
-      (cue) => cue.index === xIndex && cue.screen === yIndex
-    )
     if (
       !cueExists &&
       xIndex >= 0 &&
@@ -89,6 +101,23 @@ const EditMode = ({ id, cues, isToolboxOpen, setIsToolboxOpen }) => {
 
   const handleMouseUp = (event) => {
     setIsDragging(false)
+    const { xIndex, yIndex } = getPosition(
+      event,
+      containerRef,
+      columnWidth,
+      rowHeight,
+      gap
+    )
+
+    if (cueExists(xIndex, yIndex)) {
+      const targetCue = cues.find(
+        (cue) => cue.index === xIndex && cue.screen === yIndex
+      )
+      if (selectedCue && targetCue && selectedCue !== targetCue) {
+        handleElementPositionChange(selectedCue, targetCue)
+      }
+    }
+
     if (!isDragging) {
       if (clickTimeout.current) {
         clearTimeout(clickTimeout.current)
@@ -273,6 +302,23 @@ const EditMode = ({ id, cues, isToolboxOpen, setIsToolboxOpen }) => {
     }
   }
 
+  const dispatchUpdateSwappedCues = async (newTargetCue, newSelectedCue) => {
+    setStatus("loading")
+    try {
+      await dispatch(
+        updatePresentationSwappedCues(id, newTargetCue, newSelectedCue)
+      )
+      setStatus("saved")
+    } catch (error) {
+      console.error(error)
+      showToast({
+        title: "Error",
+        description: error.message || "An error occurred",
+        status: "error",
+      })
+    }
+  }
+
   const getPosition = (event, containerRef, columnWidth, rowHeight, gap) => {
     const dropX = event.clientX
     const containerRect = containerRef.current.getBoundingClientRect()
@@ -289,6 +335,24 @@ const EditMode = ({ id, cues, isToolboxOpen, setIsToolboxOpen }) => {
     const xIndex = Math.floor(absoluteDropX / cellWidthWithGap)
 
     return { xIndex, yIndex }
+  }
+
+  const handleElementPositionChange = async (selectedCue, targetCue) => {
+    const newTargetCue = {
+      ...targetCue,
+      index: selectedCue.index,
+      screen: selectedCue.screen,
+    }
+
+    const newSelectedCue = {
+      ...selectedCue,
+      index: targetCue.index,
+      screen: targetCue.screen,
+    }
+
+    await dispatchUpdateSwappedCues(newTargetCue, newSelectedCue)
+
+    setSelectedCue(null)
   }
 
   const handleDrop = useCallback(

--- a/src/client/redux/presentationReducer.js
+++ b/src/client/redux/presentationReducer.js
@@ -22,8 +22,8 @@ const presentationSlice = createSlice({
     editCue(state, action) {
       const cueToChange = action.payload
       const updatedCues = state.cues.map((cue) =>
-          cue._id !== cueToChange._id ? cue : cueToChange,
-        )
+        cue._id !== cueToChange._id ? cue : cueToChange
+      )
       state.cues = updatedCues
     },
     removePresentation(state) {
@@ -41,7 +41,6 @@ export const {
 } = presentationSlice.actions
 
 export default presentationSlice.reducer
-
 
 export const fetchPresentationInfo = (id) => async (dispatch) => {
   try {
@@ -69,7 +68,9 @@ export const createCue = (id, formData) => async (dispatch) => {
   try {
     const updatedPresentation = await presentationService.addCue(id, formData)
     const newCue = updatedPresentation.cues.find(
-      (cue) => cue.index === Number(formData.get("index")) && cue.screen === Number(formData.get("screen"))
+      (cue) =>
+        cue.index === Number(formData.get("index")) &&
+        cue.screen === Number(formData.get("screen"))
     )
     dispatch(addCue(newCue))
   } catch (error) {
@@ -90,23 +91,67 @@ export const deletePresentation = (id) => async (dispatch) => {
   }
 }
 
-export const updatePresentation = (presentationId, updatedCueData, cueId) => async (dispatch) => {
-  try {
-    const formData = createFormData(
-      updatedCueData.index,
-      updatedCueData.cueName,
-      updatedCueData.screen,
-      updatedCueData.file,
-      updatedCueData.cueId || cueId
-    )
-    
-    const updatedCue = await presentationService.updateCue(presentationId, updatedCueData.cueId || cueId, formData)
-    dispatch(editCue(updatedCue))
-  } catch (error) {
-    const errorMessage = error.response?.data?.error || "An error occurred"
-    console.error(errorMessage)
-    throw new Error(errorMessage)
+export const updatePresentation =
+  (presentationId, updatedCueData, cueId) => async (dispatch) => {
+    try {
+      const formData = createFormData(
+        updatedCueData.index,
+        updatedCueData.cueName,
+        updatedCueData.screen,
+        updatedCueData.file,
+        updatedCueData.cueId || cueId
+      )
+
+      const updatedCue = await presentationService.updateCue(
+        presentationId,
+        updatedCueData.cueId || cueId,
+        formData
+      )
+      dispatch(editCue(updatedCue))
+    } catch (error) {
+      const errorMessage = error.response?.data?.error || "An error occurred"
+      console.error(errorMessage)
+      throw new Error(errorMessage)
+    }
   }
-}
 
+export const updatePresentationSwappedCues =
+  (presentationId, firstUpdatedCue, secondUpdatedCue) => async (dispatch) => {
+    try {
+      const firstFormData = createFormData(
+        firstUpdatedCue.index,
+        firstUpdatedCue.name,
+        firstUpdatedCue.screen,
+        firstUpdatedCue.file,
+        firstUpdatedCue._id
+      )
 
+      const secondFormData = createFormData(
+        secondUpdatedCue.index,
+        secondUpdatedCue.name,
+        secondUpdatedCue.screen,
+        secondUpdatedCue.file,
+        secondUpdatedCue._id
+      )
+
+      const [updatedFirstCue, updatedSecondCue] = await Promise.all([
+        presentationService.updateCue(
+          presentationId,
+          firstUpdatedCue._id,
+          firstFormData
+        ),
+        presentationService.updateCue(
+          presentationId,
+          secondUpdatedCue._id,
+          secondFormData
+        ),
+      ])
+
+      dispatch(editCue(updatedFirstCue))
+      dispatch(editCue(updatedSecondCue))
+    } catch (error) {
+      const errorMessage = error.response?.data?.error || "An error occurred"
+      console.error(errorMessage)
+      throw new Error(errorMessage)
+    }
+  }

--- a/src/client/tests/unit/presentationReducer.test.js
+++ b/src/client/tests/unit/presentationReducer.test.js
@@ -1,10 +1,36 @@
+import { describe } from "node:test"
 import reducer, {
   setPresentationInfo,
   deleteCue,
   addCue,
   removePresentation,
   editCue,
+  fetchPresentationInfo,
+  removeCue,
+  createCue,
+  deletePresentation,
+  updatePresentation,
+  updatePresentationSwappedCues,
 } from "../../redux/presentationReducer.js"
+import presentationService from "../../services/presentation.js"
+import { configureStore } from "@reduxjs/toolkit"
+
+jest.mock("../../services/presentation.js", () => ({
+  get: jest.fn(),
+  removeCue: jest.fn(),
+  addCue: jest.fn(),
+  remove: jest.fn(),
+  updateCue: jest.fn(),
+}))
+
+const makeStore = () => {
+  return configureStore({
+    reducer: {
+      presentation: reducer,
+    },
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware(),
+  })
+}
 
 // Test Synchronous Actions
 describe("presentationReducer actions", () => {
@@ -138,5 +164,235 @@ describe("presentationReducer reducer", () => {
     }
 
     expect(reducer(initialStateWithCues, action)).toEqual(expectedState)
+  })
+})
+
+// Test Asynchronous Actions
+describe("presentationReducer asynchronous actions", () => {
+  it("should fetch presentation info", async () => {
+    const store = makeStore()
+    const mockCues = [{ _id: 1, name: "Cue 1" }]
+    presentationService.get.mockResolvedValue({ cues: mockCues })
+
+    await store.dispatch(fetchPresentationInfo("123"))
+
+    expect(presentationService.get).toHaveBeenCalledWith("123")
+    expect(store.getState().presentation.cues).toEqual(mockCues)
+  })
+
+  it("should handle error in fetch presentation info", async () => {
+    const store = makeStore()
+    presentationService.get.mockRejectedValue({
+      response: { data: { error: "Not found" } },
+    })
+
+    await expect(store.dispatch(fetchPresentationInfo("123"))).rejects.toThrow(
+      "Not found"
+    )
+  })
+
+  it("should remove cue", async () => {
+    const store = makeStore()
+    const initialState = [
+      { _id: 1, name: "Cue 1" },
+      { _id: 2, name: "Cue 2" },
+    ]
+    store.dispatch(setPresentationInfo(initialState))
+
+    const updatedCues = [{ _id: 2, name: "Cue 2" }]
+
+    presentationService.removeCue.mockResolvedValue({ cues: updatedCues })
+
+    await store.dispatch(removeCue("123", 1))
+
+    expect(presentationService.removeCue).toHaveBeenCalledWith("123", 1)
+    expect(store.getState().presentation.cues).toEqual(updatedCues)
+  })
+
+  it("should handle error in remove cue", async () => {
+    const store = makeStore()
+    presentationService.removeCue.mockRejectedValue({
+      response: { data: { error: "Not found" } },
+    })
+
+    await expect(store.dispatch(removeCue("123", 1))).rejects.toThrow(
+      "Not found"
+    )
+  })
+
+  it("should create cue", async () => {
+    const store = makeStore()
+    const formData = new FormData()
+    formData.append("index", "1")
+    formData.append("screen", "2")
+    formData.append("cueName", "New Cue")
+    formData.append("file", new File([""], "file.txt"))
+
+    const mockCue = { _id: 1, name: "New Cue", index: 1, screen: 2 }
+
+    presentationService.addCue.mockResolvedValue({ cues: [mockCue] })
+
+    await store.dispatch(createCue("123", formData))
+
+    expect(presentationService.addCue).toHaveBeenCalledWith("123", formData)
+
+    expect(store.getState().presentation.cues).toContainEqual(mockCue)
+  })
+
+  it("should handle error in create cue", async () => {
+    const store = makeStore()
+    const formData = new FormData()
+    formData.append("index", "1")
+    formData.append("screen", "2")
+    formData.append("cueName", "New Cue")
+    formData.append("file", new File([""], "file.txt"))
+    presentationService.addCue.mockRejectedValue({
+      response: { data: { error: "Not found" } },
+    })
+
+    await expect(store.dispatch(createCue("123", formData))).rejects.toThrow(
+      "Not found"
+    )
+  })
+
+  it("should delete presentation", async () => {
+    const store = makeStore()
+    const mockCues = [{ _id: 1, name: "Cue 1" }]
+    presentationService.remove.mockResolvedValue(mockCues)
+
+    await store.dispatch(deletePresentation("123"))
+
+    expect(presentationService.remove).toHaveBeenCalled()
+    expect(store.getState().presentation.cues).toBeNull()
+  })
+
+  it("should handle error in delete presentation", async () => {
+    const store = makeStore()
+    presentationService.remove.mockRejectedValue({
+      response: { data: { error: "Not found" } },
+    })
+
+    await expect(store.dispatch(deletePresentation("123"))).rejects.toThrow(
+      "Not found"
+    )
+  })
+
+  it("should update presentation cue", async () => {
+    const store = makeStore()
+
+    const initialState = [
+      { _id: 1, name: "Cue 1", index: 1, screen: 1 },
+      { _id: 2, name: "Cue 2", index: 2, screen: 2 },
+    ]
+
+    store.dispatch(setPresentationInfo(initialState))
+
+    const updatedCueData = { cueName: "Updated Cue", index: 1, screen: 1 }
+
+    presentationService.updateCue.mockResolvedValue({
+      ...initialState[0],
+      ...updatedCueData,
+    })
+
+    await store.dispatch(updatePresentation("123", updatedCueData, 1))
+
+    expect(presentationService.updateCue).toHaveBeenCalledWith(
+      "123",
+      1,
+      expect.any(FormData)
+    )
+
+    expect(store.getState().presentation.cues).toContainEqual({
+      ...initialState[0],
+      ...updatedCueData,
+    })
+  })
+
+  it("should handle error in update presentation cue", async () => {
+    const store = makeStore()
+
+    const updatedCueData = { cueName: "Updated Cue", index: 1, screen: 1 }
+
+    presentationService.updateCue.mockRejectedValue({
+      response: { data: { error: "Not found" } },
+    })
+
+    await expect(
+      store.dispatch(updatePresentation("123", updatedCueData, 1))
+    ).rejects.toThrow("Not found")
+  })
+
+  it("should update presentation cues swapped", async () => {
+    const store = makeStore()
+
+    const initialState = [
+      { _id: 1, name: "Cue 1", index: 1, screen: 1 },
+      { _id: 2, name: "Cue 2", index: 2, screen: 2 },
+    ]
+
+    store.dispatch(setPresentationInfo(initialState))
+
+    const firstUpdatedCue = {
+      _id: 1,
+      cueName: "Updated Cue 1",
+      index: 2,
+      screen: 2,
+    }
+    const secondUpdatedCue = {
+      _id: 2,
+      cueName: "Updated Cue 2",
+      index: 1,
+      screen: 1,
+    }
+
+    presentationService.updateCue
+      .mockResolvedValueOnce(firstUpdatedCue)
+      .mockResolvedValueOnce(secondUpdatedCue)
+
+    await store.dispatch(
+      updatePresentationSwappedCues("123", firstUpdatedCue, secondUpdatedCue)
+    )
+
+    expect(presentationService.updateCue).toHaveBeenCalledWith(
+      "123",
+      firstUpdatedCue._id,
+      expect.any(FormData)
+    )
+
+    expect(presentationService.updateCue).toHaveBeenCalledWith(
+      "123",
+      secondUpdatedCue._id,
+      expect.any(FormData)
+    )
+
+    expect(store.getState().presentation.cues).toContainEqual(firstUpdatedCue)
+    expect(store.getState().presentation.cues).toContainEqual(secondUpdatedCue)
+  })
+
+  it("should handle error in update presentation cues swapped", async () => {
+    const store = makeStore()
+
+    const firstUpdatedCue = {
+      _id: 1,
+      cueName: "Updated Cue 1",
+      index: 2,
+      screen: 2,
+    }
+    const secondUpdatedCue = {
+      _id: 2,
+      cueName: "Updated Cue 2",
+      index: 1,
+      screen: 1,
+    }
+
+    presentationService.updateCue.mockRejectedValue({
+      response: { data: { error: "Not found" } },
+    })
+
+    await expect(
+      store.dispatch(
+        updatePresentationSwappedCues("123", firstUpdatedCue, secondUpdatedCue)
+      )
+    ).rejects.toThrow("Not found")
   })
 })


### PR DESCRIPTION
## #192 Feature: As a user, I want to be able to swap elements with each other

Implemented element swapping by dragging one element over another. Also added some tests.

### Changes

`src/client/components/presentation/EditMode.jsx`
- Updated `handleMouseDown` to detect if a draggable element is selected.
- Modified `handleMouseUp` to check if another element is at the drop position and trigger swap.
- Added `handleElementPositionChange` to swap the selected and target elements’ indexes and screens.
- Added `dispatchUpdateSwappedCues` to update Redux state for both swapped elements

`src/client/redux/presentationReducer.js`
- Added asynchronous Redux action `updatePresentationSwappedCues` to ensure both elements’ positions are correctly updated in the store.

`src/client/tests/unit/presentationReducer.test.js`
- Added tests for asynchronous actions in `presentationReducer.js`.
