### PR TITLE
Refactor/issue 325 rename presentation form components

### DIFF
--- a/src/client/components/homepage/PresentationForm.jsx
+++ b/src/client/components/homepage/PresentationForm.jsx
@@ -8,7 +8,7 @@ import {
   Flex,
 } from "@chakra-ui/react"
 
-const CreatePresentation = ({ createPresentation, onCancel }) => {
+const PresentationForm = ({ createPresentation, onCancel }) => {
   const [name, setName] = useState("")
 
   const addPresentation = (event) => {
@@ -47,4 +47,4 @@ const CreatePresentation = ({ createPresentation, onCancel }) => {
   )
 }
 
-export default CreatePresentation
+export default PresentationForm

--- a/src/client/components/homepage/PresentationFormWrapper.jsx
+++ b/src/client/components/homepage/PresentationFormWrapper.jsx
@@ -1,8 +1,8 @@
 import { SimpleGrid, GridItem } from "@chakra-ui/react"
 import Togglable from "../utils/Togglable"
-import CreatePresentation from "./CreatePresentation"
+import PresentationForm from "./PresentationForm"
 
-const CreatePresentationContainer = ({
+const PresentationFormWrapper = ({
   createPresentation,
   togglableRef,
   handleCancel,
@@ -14,7 +14,7 @@ const CreatePresentationContainer = ({
         exitLabel="cancel"
         ref={togglableRef}
       >
-        <CreatePresentation
+        <PresentationForm
           createPresentation={createPresentation}
           onCancel={handleCancel}
         />
@@ -22,4 +22,4 @@ const CreatePresentationContainer = ({
     </GridItem>
   </SimpleGrid>
 )
-export default CreatePresentationContainer
+export default PresentationFormWrapper

--- a/src/client/components/homepage/index.jsx
+++ b/src/client/components/homepage/index.jsx
@@ -5,7 +5,7 @@ import { useState, useEffect, useRef } from "react"
 import presentationService from "../../services/presentations"
 import AdminControls from "./AdminControls"
 import PresentationsGrid from "./PresentationsGrid"
-import CreatePresentationContainer from "./CreatePresentationContainer"
+import PresentationFormWrapper from "./PresentationFormWrapper"
 import addInitialElements from "../utils/addInitialElements"
 import { useCustomToast } from "../utils/toastUtils"
 
@@ -56,7 +56,7 @@ const HomePage = ({ user }) => {
   return (
     <Container maxW="container.lg">
       <AdminControls isAdmin={user.isAdmin} navigate={navigate} />
-      <CreatePresentationContainer
+      <PresentationFormWrapper
         createPresentation={createPresentation}
         togglableRef={togglableRef}
         handleCancel={handleCancel}

--- a/src/client/tests/unit/homepage.test.js
+++ b/src/client/tests/unit/homepage.test.js
@@ -7,9 +7,9 @@ import HomePage from "../../components/homepage/index"
 import {
   AdminControls,
   PresentationsGrid,
-  CreatePresentation,
 } from "../../components/homepage/index"
-import PresentationForm from "../../components/homepage/CreatePresentation"
+import PresentationFormWrapper from "../../components/homepage/PresentationFormWrapper"
+import PresentationForm from "../../components/homepage/PresentationForm"
 import presentationService from "../../services/presentations"
 import addInitialElements from "../../components/utils/addInitialElements"
 
@@ -85,13 +85,23 @@ describe("HomePage", () => {
 })
 
 describe("PresentationForm", () => {
+  test("Renders the 'New presentation'-button", () => {
+    render(
+      <PresentationFormWrapper
+        createPresentation={() => {}}
+        togglableRef={() => {}}
+        handleCancel={() => {}}
+      />
+    )
+    expect(screen.getByText("New presentation")).toBeInTheDocument()
+  })
   test("renders the form with name input field and buttons", () => {
     render(<PresentationForm />)
 
     expect(screen.getByRole("button", { name: /create/i })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument()
     expect(screen.getByTestId("presentation-name")).toBeInTheDocument()
-    expect(screen.getByLabelText("Name")).toBeInTheDocument()
+    expect(screen.getByLabelText("Name*")).toBeInTheDocument()
   })
 
   test("calls createPresentation function when create button is clicked", () => {
@@ -103,7 +113,7 @@ describe("PresentationForm", () => {
       />
     )
 
-    const nameInput = screen.getByLabelText("Name")
+    const nameInput = screen.getByLabelText("Name*")
     fireEvent.change(nameInput, { target: { value: "Test Presentation" } })
     fireEvent.click(screen.getByText("create"))
 
@@ -184,45 +194,5 @@ describe("PresentationsGrid", () => {
     )
     fireEvent.click(screen.getByText("Test Presentation"))
     expect(handlePresentationClickMock).toHaveBeenCalledWith("123")
-  })
-})
-
-describe("Create presentation form", () => {
-  test("renders the component", () => {
-    render(
-      <CreatePresentation
-        createPresentation={() => {}}
-        handleCancel={() => {}}
-        handleConnectionsClick={() => {}}
-      />
-    )
-    expect(screen.getByText("New presentation")).toBeInTheDocument()
-  })
-  test("renders the component with buttons", () => {
-    render(
-      <CreatePresentation
-        createPresentation={() => {}}
-        handleCancel={() => {}}
-        handleConnectionsClick={() => {}}
-      />
-    )
-    expect(screen.getByText("New presentation")).toBeInTheDocument()
-  })
-  test("calls createPresentation function when create button is clicked", () => {
-    const createPresentationMock = jest.fn()
-    render(
-      <CreatePresentation
-        createPresentation={createPresentationMock}
-        handleCancel={() => {}}
-        handleConnectionsClick={() => {}}
-      />
-    )
-    fireEvent.click(screen.getByText("New presentation"))
-    const nameInput = screen.getByLabelText("Name")
-    fireEvent.change(nameInput, { target: { value: "Test Presentation" } })
-    fireEvent.click(screen.getByText("create"))
-    expect(createPresentationMock).toHaveBeenCalledWith({
-      name: "Test Presentation",
-    })
   })
 })

--- a/src/client/tests/unit/homepage.test.js
+++ b/src/client/tests/unit/homepage.test.js
@@ -4,10 +4,8 @@ import { useNavigate } from "react-router-dom"
 import "@testing-library/jest-dom"
 
 import HomePage from "../../components/homepage/index"
-import {
-  AdminControls,
-  PresentationsGrid,
-} from "../../components/homepage/index"
+import PresentationsGrid from "../../components/homepage/PresentationsGrid"
+import AdminControls from "../../components/homepage/AdminControls"
 import PresentationFormWrapper from "../../components/homepage/PresentationFormWrapper"
 import PresentationForm from "../../components/homepage/PresentationForm"
 import presentationService from "../../services/presentations"
@@ -135,7 +133,7 @@ describe("PresentationForm", () => {
 })
 
 describe("AdminControls", () => {
-  test("renders the component", () => {
+  test("Renders the AdminControls component", () => {
     render(<AdminControls isAdmin={true} />)
     expect(screen.getByText("Admin controls")).toBeInTheDocument()
   })
@@ -165,7 +163,7 @@ const mock_data = [
 ]
 
 describe("PresentationsGrid", () => {
-  test("renders the component", () => {
+  test("Renders the PresentationsGrid component", () => {
     render(
       <PresentationsGrid
         presentations={[]}


### PR DESCRIPTION
## #325 : Rename presentation form components

This pull renames CreatePresentation and CreatePresentationContainer components into PresentationForm and PresentationFormWrapper, because their names were not intuitive.

In addition, this pull fixes and cleans up HomePage tests.

### Changes

**`src/client/components/homepage/PresentationForm.jsx`**
- Renaming component from CreatePresentation to PresentationForm

**`src/client/components/homepage/PresentationFormWrapper.jsx`**
- Renaming component from CreatePresentationContainer to PresentationFormWrapper to reflect it's wrapping nature, instead of more general word "container"
- Updating imports

**`src/client/components/homepage/index.jsx`**
- Updating imports and component names

**`src/client/tests/unit/homepage.test.js`**
- Fix tests, e.g. by getting elements with right text like `Name*` instead of `Name`
- Remove duplicate tests. There was two set of tests for PresentationForm. Now there is only one