### PR TITLE
Testing/issue 328 fix frontend tests

### DIFF
--- a/src/client/tests/unit/cues.test.js
+++ b/src/client/tests/unit/cues.test.js
@@ -238,6 +238,7 @@ describe("CuesForm update element", () => {
       index: 1,
       screen: 2,
       file: "/blank.png",
+      fileName: "blank.png",
     })
     await waitFor(
       () => {

--- a/src/client/tests/unit/showmode.test.js
+++ b/src/client/tests/unit/showmode.test.js
@@ -1,144 +1,184 @@
-import React from 'react'
-import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
-import ShowMode from '../../components/presentation/ShowMode'
+import React from "react"
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react"
+import ShowMode from "../../components/presentation/ShowMode"
 import "@testing-library/jest-dom"
 
 const mockCues = [
-    { file: { url: 'http://example.com/image1.jpg' }, index: 0, name: 'testtt', screen: 1, _id: '123456789' },
-    { file: { url: 'http://example.com/image2.jpg' }, index: 1, name: 'testtt2', screen: 2, _id: '987654321' }
+  {
+    file: { url: "http://example.com/image1.jpg" },
+    index: 0,
+    name: "testtt",
+    screen: 1,
+    _id: "123456789",
+  },
+  {
+    file: { url: "http://example.com/image2.jpg" },
+    index: 1,
+    name: "testtt2",
+    screen: 2,
+    _id: "987654321",
+  },
 ]
 
 const mockemptyCues = []
 
-describe('ShowMode', () => {
-    // simulate image loading behavior
-    beforeAll(() => {
-        global.Image = class {
-          constructor() {
-            setTimeout(() => {
-              if (this.onload) {
-                this.onload()
-              }
-            }, 0)
+describe("ShowMode", () => {
+  // simulate image loading behavior
+  beforeAll(() => {
+    global.Image = class {
+      constructor() {
+        setTimeout(() => {
+          if (this.onload) {
+            this.onload()
           }
-        }
+        }, 0)
+      }
+    }
+  })
+
+  afterAll(() => {
+    // clean up the global image mock
+    delete global.Image
+  })
+
+  test("renders without crashing", async () => {
+    await act(async () => {
+      render(<ShowMode cues={mockCues} />)
     })
 
-    afterAll(() => {
-      // clean up the global image mock
-      delete global.Image
-    })
-      
-    test('renders without crashing', async () => {
-      await act(async () => {
-        render(<ShowMode cues={mockCues} />)
-      })
-      
-      expect(screen.getByRole('button', { name: 'Open screen: 1' })).toBeInTheDocument()
-      expect(screen.getByRole('button', { name: 'Open screen: 2' })).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Open screen: 1" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Open screen: 2" })
+    ).toBeInTheDocument()
+  })
+
+  test("initializes state correctly", async () => {
+    await act(async () => {
+      render(<ShowMode cues={mockCues} />)
     })
 
-    test('initializes state correctly', async () => {
-        await act(async () => {
-          render(<ShowMode cues={mockCues} />)
-        })
-        
-        expect(screen.getByRole('heading', { name: 'Cue 0' })).toBeInTheDocument()
-        
-        expect(screen.getByRole('button', { name: 'Open screen: 1' })).toBeInTheDocument()
-        expect(screen.getByRole('button', { name: 'Open screen: 2' })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Cue 0" })).toBeInTheDocument()
+
+    expect(
+      screen.getByRole("button", { name: "Open screen: 1" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Open screen: 2" })
+    ).toBeInTheDocument()
+  })
+
+  test("navigates to next and previous cues", async () => {
+    await act(async () => {
+      render(<ShowMode cues={mockCues} />)
     })
 
-    test('navigates to next and previous cues', async () => {
-        await act(async () => {
-          render(<ShowMode cues={mockCues} />)
-        })
-        
-        act(() => {
-            fireEvent.click(screen.getByRole('button', { name: 'Next Cue' }))
-        })
-        expect(screen.getByRole('heading', { name: 'Cue 1' })).toBeInTheDocument()
-        
-        act(() => {
-            fireEvent.click(screen.getByRole('button', { name: 'Previous Cue' }))
-        })
-        expect(screen.getByRole('heading', { name: 'Cue 0' })).toBeInTheDocument()
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Next Cue" }))
+    })
+    expect(screen.getByRole("heading", { name: "Cue 1" })).toBeInTheDocument()
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Previous Cue" }))
+    })
+    expect(screen.getByRole("heading", { name: "Cue 0" })).toBeInTheDocument()
+  })
+
+  test("toggles screen visibility", async () => {
+    await act(async () => {
+      render(<ShowMode cues={mockCues} />)
     })
 
-    test('toggles screen visibility', async () => {
-        await act(async () => {
-          render(<ShowMode cues={mockCues} />)
-        })
-        
-        act(() => {
-            fireEvent.click(screen.getByRole('button', { name: 'Open screen: 1' }))
-        })
-        expect(screen.getByRole('button', { name: 'Close screen: 1' })).toBeInTheDocument()
-        
-        act(() => {
-            fireEvent.click(screen.getByRole('button', { name: 'Close screen: 1' }))
-        })
-        expect(screen.getByRole('button', { name: 'Open screen: 1' })).toBeInTheDocument()
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Open screen: 1" }))
+    })
+    expect(
+      screen.getByRole("button", { name: "Close screen: 1" })
+    ).toBeInTheDocument()
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Close screen: 1" }))
+    })
+    expect(
+      screen.getByRole("button", { name: "Open screen: 1" })
+    ).toBeInTheDocument()
+  })
+
+  test("toggles visibility for multiple screens", async () => {
+    await act(async () => {
+      render(<ShowMode cues={mockCues} />)
     })
 
-    test('toggles visibility for multiple screens', async () => {
-        await act(async () => {
-          render(<ShowMode cues={mockCues} />);
-        })
-        
-        act(() => {
-            fireEvent.click(screen.getByRole('button', { name: 'Open screen: 1' }));
-        })
-        expect(screen.getByRole('button', { name: 'Close screen: 1' })).toBeInTheDocument()
-        
-        act(() => {
-            fireEvent.click(screen.getByRole('button', { name: 'Open screen: 2' }));
-        })
-        expect(screen.getByRole('button', { name: 'Close screen: 2' })).toBeInTheDocument()
-        
-        act(() => {
-            fireEvent.click(screen.getByRole('button', { name: 'Close screen: 1' }));
-        })
-        expect(screen.getByRole('button', { name: 'Open screen: 1' })).toBeInTheDocument()
-        
-        act(() => {
-            fireEvent.click(screen.getByRole('button', { name: 'Close screen: 2' }));
-        })
-        expect(screen.getByRole('button', { name: 'Open screen: 2' })).toBeInTheDocument()
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Open screen: 1" }))
     })
-    
-    test('handles empty cues', async () => {
-        await act(async () => {
-          render(<ShowMode cues={mockemptyCues} />)
-        })
-        expect(screen.queryByRole('button', { name: 'Open screen: 1' })).not.toBeInTheDocument()
-        expect(screen.queryByRole('button', { name: 'Open screen: 2' })).not.toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Close screen: 1" })
+    ).toBeInTheDocument()
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Open screen: 2" }))
+    })
+    expect(
+      screen.getByRole("button", { name: "Close screen: 2" })
+    ).toBeInTheDocument()
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Close screen: 1" }))
+    })
+    expect(
+      screen.getByRole("button", { name: "Open screen: 1" })
+    ).toBeInTheDocument()
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Close screen: 2" }))
+    })
+    expect(
+      screen.getByRole("button", { name: "Open screen: 2" })
+    ).toBeInTheDocument()
+  })
+
+  test("handles empty cues", async () => {
+    await act(async () => {
+      render(<ShowMode cues={mockemptyCues} />)
+    })
+    expect(
+      screen.queryByRole("button", { name: "Open screen: 1" })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Open screen: 2" })
+    ).not.toBeInTheDocument()
+  })
+
+  test("mirrors one screen to another", async () => {
+    if (!window.HTMLElement.prototype.scrollTo) {
+      window.HTMLElement.prototype.scrollTo = () => {}
+    }
+
+    render(<ShowMode cues={mockCues} />)
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Open screen: 1" })
+      ).toBeInTheDocument()
     })
 
-    test('mirrors one screen to another', async () => {
-        if (!window.HTMLElement.prototype.scrollTo) {
-            window.HTMLElement.prototype.scrollTo = () => {}
-          }
-      
-        render(<ShowMode cues={mockCues} />)
-      
-        await waitFor(() => {
-          expect(screen.getByRole('button', { name: 'Open screen: 1' })).toBeInTheDocument()
-        })
-      
-        const dropdownButton = screen.getByRole('button', { name: 'Dropdown for screen 1' })
-      
-        act(() => {
-          fireEvent.click(dropdownButton)
-        })
-      
-        const menuItem = screen.getByText('Mirror screen: 2')
-        
-        act(() => {
-          fireEvent.click(menuItem)
-        })
-      
-        const button = screen.getByRole('button', { name: /Open screen: 1/i })
-        expect(button).toHaveTextContent(/Mirroring screen: 2/)
+    const dropdownButton = screen.getByRole("button", {
+      name: "Dropdown for screen 1",
     })
+
+    act(() => {
+      fireEvent.click(dropdownButton)
+    })
+
+    const menuItem = screen.getByText("Mirror screen: 2")
+
+    act(() => {
+      fireEvent.click(menuItem)
+    })
+
+    const button = screen.getByRole("button", { name: /Open screen: 1/i })
+    expect(button).toHaveTextContent(/Mirroring screen: 2/)
+  })
 })

--- a/src/client/tests/unit/showmode.test.js
+++ b/src/client/tests/unit/showmode.test.js
@@ -5,14 +5,14 @@ import "@testing-library/jest-dom"
 
 const mockCues = [
   {
-    file: { url: "http://example.com/image1.jpg" },
+    file: { url: "http://example.com/image1.jpg", type: "image/jpg" },
     index: 0,
     name: "testtt",
     screen: 1,
     _id: "123456789",
   },
   {
-    file: { url: "http://example.com/image2.jpg" },
+    file: { url: "http://example.com/image2.jpg", type: "image/jpg" },
     index: 1,
     name: "testtt2",
     screen: 2,
@@ -34,11 +34,25 @@ describe("ShowMode", () => {
         }, 0)
       }
     }
+
+    window.open = jest.fn(() => {
+      const fakeWindow = {
+        document: {
+          body: document.createElement("body"),
+          head: document.createElement("head"),
+        },
+        close: jest.fn(),
+        addEventListener: jest.fn(() => {}),
+        removeEventListener: jest.fn(),
+      }
+      return fakeWindow
+    })
   })
 
   afterAll(() => {
-    // clean up the global image mock
+    // clean up the global image and window mock
     delete global.Image
+    delete window.open
   })
 
   test("renders without crashing", async () => {
@@ -59,7 +73,7 @@ describe("ShowMode", () => {
       render(<ShowMode cues={mockCues} />)
     })
 
-    expect(screen.getByRole("heading", { name: "Cue 0" })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Index 0" })).toBeInTheDocument()
 
     expect(
       screen.getByRole("button", { name: "Open screen: 1" })
@@ -77,12 +91,12 @@ describe("ShowMode", () => {
     act(() => {
       fireEvent.click(screen.getByRole("button", { name: "Next Cue" }))
     })
-    expect(screen.getByRole("heading", { name: "Cue 1" })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Index 1" })).toBeInTheDocument()
 
     act(() => {
       fireEvent.click(screen.getByRole("button", { name: "Previous Cue" }))
     })
-    expect(screen.getByRole("heading", { name: "Cue 0" })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Index 0" })).toBeInTheDocument()
   })
 
   test("toggles screen visibility", async () => {


### PR DESCRIPTION
## #328 : Fix frontend tests

This pull fixes various frontend tests. When running `npm run test-frontend`, many tests failed because of outdated imports, DOM element names or wrong logic. Prettier was run in the first commit, so it is recommended to review only the latter commit **Fix frontend tests** so the code changes are easier to read.

### Changes

**`src/client/tests/unit/cues.test.js`**
- Added fileName field to the expected value updateCue's been called with

**`src/client/tests/unit/showmode.test.js`**
- Modified mockCues to be a right kind of object with **file.type** property
- Added mock function for window.open when Screen component calls it, because JSDOM environment that Jest renders the code in lacks many things, like **window** object. By mocking window.open the test works. Also added window.open cleanup after tests
- Changes expected "Cue 0", "Cue 1" texts to "Index 0" and "Index 1" since that's what's used in the latest version of the UI