### PR TITLE
Fix locally run presentation_api.test.js timeout failures

### DIFF
--- a/src/server/tests/presentation_api.test.js
+++ b/src/server/tests/presentation_api.test.js
@@ -17,7 +17,6 @@ const mockImageBuffer = fs.readFileSync(path.join(__dirname, "mock_image.png"))
 describe("test presentation", () => {
   beforeAll(async () => {
     await User.deleteMany({})
-    await Presentation.deleteMany({})
     await api
       .post("/api/signup")
       .send({ username: "testuser", password: "testpassword" })
@@ -30,6 +29,7 @@ describe("test presentation", () => {
   })
 
   beforeEach(async () => {
+    await Presentation.deleteMany({})
     await api
       .post("/api/home")
       .set("Authorization", authHeader)


### PR DESCRIPTION
Fix locally run presentation_api.test.js timeout failures. This was done by moving the mock presentation cleanup step from beforeAll to beforeEach, suggesting that the test slowness was caused by accumulating mock presentations.

### Change

`presentation_api.test`

- Moved `await Presentation.deleteMany({})` mock presentation cleanup step from the beforeAll function used for login setup to the correct place in the beforeEach function used for mock presentation setup.

### Result

Example of local `test-backend` run results before fix:
> Test Suites: 1 failed, 6 passed, 7 total
> Tests:       6 failed, 37 passed, 43 total
> Snapshots:   0 total
> Time:        102.428 s

Example after fix:
> Test Suites: 7 passed, 7 total
> Tests:       43 passed, 43 total
> Snapshots:   0 total
> Time:        43.365 s, estimated 47 s

Result: `presentation_api.test.js` runtime was massively reduced, `test-backend` execution time was roughly halved, and occassionally timeout-failing presentation api tests now pass consistently!