### PR TITLE
Testing frontend code

### DIFF
--- a/src/client/tests/unit/login.test.js
+++ b/src/client/tests/unit/login.test.js
@@ -1,98 +1,98 @@
-import React from 'react'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import '@testing-library/jest-dom'
-import { LoginForm } from '../../components/navbar/Login'
+import React from "react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { LoginForm } from "../../components/navbar/Login"
 
-jest.mock('../../components/utils/firebase', () => ({
-  apikey: 'testkey'
-  }))
+jest.mock("../../components/utils/firebase", () => ({
+  apikey: "testkey",
+}))
 
-describe('Login', () => {
-  test('renders content', () => {
+describe("Login", () => {
+  test("renders content", () => {
     const onSubmit = jest.fn()
     render(<LoginForm onSubmit={onSubmit} />)
-    expect(screen.getByText('Username')).toBeDefined()
-    expect(screen.getByText('Password')).toBeDefined()
-    expect(screen.getByText('Log in')).toBeDefined()
+    expect(screen.getByText("Username")).toBeDefined()
+    expect(screen.getByText("Password")).toBeDefined()
+    expect(screen.getByText("Log in")).toBeDefined()
   })
 
-  it('submits the form with provided values', async () => {
+  it("submits the form with provided values", async () => {
     const onSubmit = jest.fn()
     const { getByLabelText, getByText } = render(
       <LoginForm onSubmit={onSubmit} />
     )
 
-    fireEvent.change(getByLabelText('Username'), {
-      target: { value: 'testuser' },
+    fireEvent.change(getByLabelText("Username"), {
+      target: { value: "testuser" },
     })
-    fireEvent.change(getByLabelText('Password'), {
-      target: { value: 'testpassword' },
+    fireEvent.change(getByLabelText("Password"), {
+      target: { value: "testpassword" },
     })
 
-    fireEvent.submit(getByText('Log in'))
+    fireEvent.submit(getByText("Log in"))
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledTimes(1)
       expect(onSubmit).toHaveBeenCalledWith({
-        username: 'testuser',
-        password: 'testpassword',
+        username: "testuser",
+        password: "testpassword",
       })
     })
   })
-  test('error message when username or password is empty', async () => {
+  test("error message when username or password is empty", async () => {
     const onSubmit = jest.fn()
     const { getByLabelText, getByText } = render(
       <LoginForm onSubmit={onSubmit} />
     )
 
-    fireEvent.change(getByLabelText('Username'), {
-      target: { value: '' },
+    fireEvent.change(getByLabelText("Username"), {
+      target: { value: "" },
     })
-    fireEvent.change(getByLabelText('Password'), {
-      target: { value: '' },
+    fireEvent.change(getByLabelText("Password"), {
+      target: { value: "" },
     })
 
-    fireEvent.click(getByText('Log in'))
+    fireEvent.click(getByText("Log in"))
     await waitFor(() => {
-      expect(screen.getByText('Username and password required')).toBeDefined()
+      expect(screen.getByText("Username and password required")).toBeDefined()
     })
   })
 
-  test('error message when username is empty', async () => {
+  test("error message when username is empty", async () => {
     const onSubmit = jest.fn()
     const { getByLabelText, getByText } = render(
       <LoginForm onSubmit={onSubmit} />
     )
 
-    fireEvent.change(getByLabelText('Username'), {
-      target: { value: '' },
+    fireEvent.change(getByLabelText("Username"), {
+      target: { value: "" },
     })
-    fireEvent.change(getByLabelText('Password'), {
-      target: { value: 'testpassword' },
+    fireEvent.change(getByLabelText("Password"), {
+      target: { value: "testpassword" },
     })
 
-    fireEvent.click(getByText('Log in'))
+    fireEvent.click(getByText("Log in"))
     await waitFor(() => {
-      expect(screen.getByText('Username required')).toBeDefined()
+      expect(screen.getByText("Username required")).toBeDefined()
     })
   })
 
-  test('error message when password is empty', async () => {
+  test("error message when password is empty", async () => {
     const onSubmit = jest.fn()
     const { getByLabelText, getByText } = render(
       <LoginForm onSubmit={onSubmit} />
     )
 
-    fireEvent.change(getByLabelText('Username'), {
-      target: { value: 'testuser' },
+    fireEvent.change(getByLabelText("Username"), {
+      target: { value: "testuser" },
     })
-    fireEvent.change(getByLabelText('Password'), {
-      target: { value: '' },
+    fireEvent.change(getByLabelText("Password"), {
+      target: { value: "" },
     })
 
-    fireEvent.click(getByText('Log in'))
+    fireEvent.click(getByText("Log in"))
     await waitFor(() => {
-      expect(screen.getByText('Password required')).toBeDefined()
+      expect(screen.getByText("Password required")).toBeDefined()
     })
   })
 })

--- a/src/client/tests/unit/login.test.js
+++ b/src/client/tests/unit/login.test.js
@@ -2,6 +2,7 @@ import React from "react"
 import { render, screen, fireEvent, waitFor } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import { LoginForm } from "../../components/navbar/Login"
+import { describe } from "node:test"
 
 jest.mock("../../components/utils/firebase", () => ({
   apikey: "testkey",
@@ -93,6 +94,92 @@ describe("Login", () => {
     fireEvent.click(getByText("Log in"))
     await waitFor(() => {
       expect(screen.getByText("Password required")).toBeDefined()
+    })
+  })
+
+  test("error message when server error", async () => {
+    const mockSubmit = jest.fn().mockRejectedValue({
+      response: { data: { error: "Invalid credentials" } },
+    })
+
+    const { getByLabelText, getByText } = render(
+      <LoginForm onSubmit={mockSubmit} />
+    )
+
+    fireEvent.change(getByLabelText("Username"), {
+      target: { value: "testuser" },
+    })
+    fireEvent.change(getByLabelText("Password"), {
+      target: { value: "testpassword" },
+    })
+
+    fireEvent.click(getByText("Log in"))
+
+    await waitFor(() => {
+      expect(screen.getByText("Invalid credentials")).toBeDefined()
+    })
+  })
+})
+
+describe("HandleKeyDown", () => {
+  test("handleKeyDown shifts focus correctly from username", () => {
+    const onSubmit = jest.fn()
+    const { getByLabelText } = render(<LoginForm onSubmit={onSubmit} />)
+    const usernameInput = getByLabelText("Username")
+    const passwordInput = getByLabelText("Password")
+
+    fireEvent.keyDown(usernameInput, { key: "Tab" })
+    expect(document.activeElement).toBe(passwordInput)
+  })
+  test("handleKeyDown shifts focus correctly from password", () => {
+    const onSubmit = jest.fn()
+    const { getByLabelText } = render(<LoginForm onSubmit={onSubmit} />)
+    const passwordInput = getByLabelText("Password")
+    const submitButton = screen.getByTestId("login_inform")
+
+    fireEvent.keyDown(passwordInput, { key: "Tab" })
+    expect(document.activeElement).toBe(submitButton)
+  })
+  test("handleKeyDown calls handleSubmit when pressing enter on password", () => {
+    const onSubmit = jest.fn()
+    const { getByLabelText } = render(<LoginForm onSubmit={onSubmit} />)
+    const usernameInput = getByLabelText("Username")
+    const passwordInput = getByLabelText("Password")
+
+    fireEvent.change(usernameInput, { target: { value: "testuser" } })
+    fireEvent.change(passwordInput, { target: { value: "testpassword" } })
+
+    fireEvent.keyDown(passwordInput, { key: "Enter" })
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      username: "testuser",
+      password: "testpassword",
+    })
+  })
+  test("handleKeyDown shifts focus correctly from submit", () => {
+    const onSubmit = jest.fn()
+    const { getByLabelText } = render(<LoginForm onSubmit={onSubmit} />)
+    const usernameInput = getByLabelText("Username")
+    const submitButton = screen.getByTestId("login_inform")
+
+    fireEvent.keyDown(submitButton, { key: "Tab" })
+    expect(document.activeElement).toBe(usernameInput)
+  })
+  test("handleKeyDown calls handleSubmit when pressing enter on submit button", () => {
+    const onSubmit = jest.fn()
+    const { getByLabelText } = render(<LoginForm onSubmit={onSubmit} />)
+    const usernameInput = getByLabelText("Username")
+    const passwordInput = getByLabelText("Password")
+    const submitButton = screen.getByTestId("login_inform")
+
+    fireEvent.change(usernameInput, { target: { value: "testuser" } })
+    fireEvent.change(passwordInput, { target: { value: "testpassword" } })
+
+    fireEvent.keyDown(submitButton, { key: "Enter" })
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      username: "testuser",
+      password: "testpassword",
     })
   })
 })

--- a/src/client/tests/unit/signup.test.js
+++ b/src/client/tests/unit/signup.test.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, screen, fireEvent } from "@testing-library/react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import userEvent from "@testing-library/user-event"
 
@@ -129,5 +129,64 @@ describe("HandleKeyDown", () => {
 
     await userEvent.click(termsLink)
     expect(handleTermsClick).toHaveBeenCalledTimes(1)
+  })
+
+  test("handleKeyDown shifts focus correctly to username from submit button", () => {
+    const onSubmit = jest.fn()
+    const { getByPlaceholderText, getByTestId } = render(
+      <SignUpForm onSubmit={onSubmit} />
+    )
+    const submitButton = getByTestId("signup_inform")
+    const usernameInput = getByPlaceholderText("Username")
+
+    fireEvent.keyDown(submitButton, { key: "Tab" })
+    expect(document.activeElement).toBe(usernameInput)
+  })
+
+  test("handleKeyDown calls handleSubmit when pressing enter when focus on password confirmation", async () => {
+    const onSubmit = jest.fn()
+    const { getByTestId } = render(<SignUpForm onSubmit={onSubmit} />)
+    const usernameInput = getByTestId("username_signup")
+    const passwordInput = getByTestId("password_signup")
+    const passwordAgainInput = getByTestId("password_signup_confirmation")
+
+    fireEvent.change(usernameInput, { target: { value: "testuser" } })
+    fireEvent.change(passwordInput, { target: { value: "testpassword" } })
+    fireEvent.change(passwordAgainInput, { target: { value: "testpassword" } })
+
+    fireEvent.keyDown(passwordAgainInput, { key: "Enter" })
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+      expect(onSubmit).toHaveBeenCalledWith({
+        username: "testuser",
+        password: "testpassword",
+        password_confirmation: "testpassword",
+      })
+    })
+  })
+
+  test("handleKeyDown calls handleSubmit when pressing enter when focus on submit button", async () => {
+    const onSubmit = jest.fn()
+    const { getByTestId } = render(<SignUpForm onSubmit={onSubmit} />)
+    const usernameInput = getByTestId("username_signup")
+    const passwordInput = getByTestId("password_signup")
+    const passwordAgainInput = getByTestId("password_signup_confirmation")
+    const submitButton = getByTestId("signup_inform")
+
+    fireEvent.change(usernameInput, { target: { value: "testuser" } })
+    fireEvent.change(passwordInput, { target: { value: "testpassword" } })
+    fireEvent.change(passwordAgainInput, { target: { value: "testpassword" } })
+
+    fireEvent.keyDown(submitButton, { key: "Enter" })
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+      expect(onSubmit).toHaveBeenCalledWith({
+        username: "testuser",
+        password: "testpassword",
+        password_confirmation: "testpassword",
+      })
+    })
   })
 })

--- a/src/client/tests/unit/signup.test.js
+++ b/src/client/tests/unit/signup.test.js
@@ -4,6 +4,7 @@ import "@testing-library/jest-dom"
 import userEvent from "@testing-library/user-event"
 
 import { SignUpForm } from "../../components/navbar/SignUp"
+import { describe } from "node:test"
 
 describe("SignUp", () => {
   test("renders content", () => {
@@ -66,7 +67,9 @@ describe("SignUp", () => {
     await userEvent.click(screen.getByText("Sign up"))
     expect(screen.getByText("Passwords must match")).toBeDefined()
   })
+})
 
+describe("HandleKeyDown", () => {
   test("handleKeyDown shifts focus correctly", () => {
     const onSubmit = jest.fn()
     const { getByPlaceholderText } = render(<SignUpForm onSubmit={onSubmit} />)

--- a/src/client/tests/unit/signup.test.js
+++ b/src/client/tests/unit/signup.test.js
@@ -107,21 +107,9 @@ describe("SignUp", () => {
 
   test("handleKeyDown shifts focus correctly to submit button", () => {
     const onSubmit = jest.fn()
-    const { getByPlaceholderText } = render(<SignUpForm onSubmit={onSubmit} />)
-    const usernameInput = getByPlaceholderText("Username")
-    const passwordInput = getByPlaceholderText("Password")
-    const passwordAgainInput = getByPlaceholderText("Password_confirmation")
+    render(<SignUpForm onSubmit={onSubmit} />)
     const termsLink = screen.getByTestId("terms_link")
     const submitButton = screen.getByTestId("signup_inform")
-
-    fireEvent.keyDown(usernameInput, { key: "Tab" })
-    expect(document.activeElement).toBe(passwordInput)
-
-    fireEvent.keyDown(passwordInput, { key: "Tab" })
-    expect(document.activeElement).toBe(passwordAgainInput)
-
-    fireEvent.keyDown(passwordAgainInput, { key: "Tab" })
-    expect(document.activeElement).toBe(termsLink)
 
     fireEvent.keyDown(termsLink, { key: "Tab" })
     expect(document.activeElement).toBe(submitButton)
@@ -134,9 +122,8 @@ describe("SignUp", () => {
       <SignUpForm onSubmit={onSubmit} handleTermsClick={handleTermsClick} />
     )
     const termsLink = screen.getByTestId("terms_link")
-
-    // Assert that the terms link is present
     expect(termsLink).toBeInTheDocument()
+
     await userEvent.click(termsLink)
     expect(handleTermsClick).toHaveBeenCalledTimes(1)
   })


### PR DESCRIPTION
## #336: Testing navbar in client
Added some tests for login and signup forms. Tests make sure that handleKeyDown shifts focus correctly in the forms when pressing either tab or enter.
### Changes
`src/client/tests/unit/login.test.js`
- Added tests for handleKeyDown in LoginForm.

`src/client/tests/unit/signup.test.js`
- Added tests for handleKeyDown in SignUpForm.
