### PR TITLE
Remove copy and delete buttons in show mode

### DIFF
--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -24,7 +24,13 @@ import { useCustomToast } from "../utils/toastUtils"
 
 const theme = extendTheme({})
 
-const EditMode = ({ id, cues, isToolboxOpen, setIsToolboxOpen }) => {
+const EditMode = ({
+  id,
+  cues,
+  isToolboxOpen,
+  setIsToolboxOpen,
+  isShowMode,
+}) => {
   const bgColorHover = useColorModeValue(
     "rgba(255, 181, 181, 0.8)",
     "rgba(72, 26, 35, 0.8)"
@@ -250,11 +256,7 @@ const EditMode = ({ id, cues, isToolboxOpen, setIsToolboxOpen }) => {
       })
     } catch (error) {
       const errorMessage = error.message
-      showToast({
-        title: "Error",
-        description: errorMessage,
-        status: "error",
-      })
+      showToast({ title: "Error", description: errorMessage, status: "error" })
     }
   }
 
@@ -263,10 +265,7 @@ const EditMode = ({ id, cues, isToolboxOpen, setIsToolboxOpen }) => {
       `Index ${newCueData.index} element already exists on screen ${newCueData.screen}. Do you want to replace it?`
     )
     setConfirmAction(() => async () => {
-      const updatedCue = {
-        ...existingCue,
-        ...newCueData,
-      }
+      const updatedCue = { ...existingCue, ...newCueData }
       await dispatchUpdateCue(existingCue._id, updatedCue)
       setIsConfirmOpen(false)
     })
@@ -442,6 +441,10 @@ const EditMode = ({ id, cues, isToolboxOpen, setIsToolboxOpen }) => {
   const handleDrop = useCallback(
     async (event) => {
       event.preventDefault()
+
+      if (isShowMode) {
+        return
+      }
       const files = Array.from(event.dataTransfer.files)
       const mediaFiles = files.filter(
         (file) =>
@@ -542,8 +545,11 @@ const EditMode = ({ id, cues, isToolboxOpen, setIsToolboxOpen }) => {
               </Box>
             ))}
           </Box>
-
-          <Box position="relative" overflow="auto">
+          <Box
+            position="relative"
+            overflow="auto"
+            pointerEvents={isShowMode ? "none" : "auto"}
+          >
             <Box
               height="600px"
               width="100%"
@@ -595,6 +601,7 @@ const EditMode = ({ id, cues, isToolboxOpen, setIsToolboxOpen }) => {
                 setIsCopied={setIsCopied}
                 setCopiedCue={setCopiedCue}
                 id={id}
+                isShowMode={isShowMode}
               />
 
               {hoverPosition && !isDragging && (

--- a/src/client/components/presentation/GridLayoutComponent.jsx
+++ b/src/client/components/presentation/GridLayoutComponent.jsx
@@ -18,6 +18,7 @@ const GridLayoutComponent = ({
   columnWidth,
   rowHeight,
   gap,
+  isShowMode,
 }) => {
   const showToast = useCustomToast()
   const dispatch = useDispatch()
@@ -114,45 +115,49 @@ const GridLayoutComponent = ({
           }}
         >
           <Box position="relative" h="100%">
-            <IconButton
-              icon={<DeleteIcon />}
-              size="xs"
-              position="absolute"
-              _hover={{ bg: "red.500", color: "white" }}
-              backgroundColor="red.300"
-              draggable={false}
-              zIndex="10"
-              top="0px"
-              right="0px"
-              aria-label={`Delete ${cue.name}`}
-              onMouseDown={(e) => {
-                e.stopPropagation()
-                handleRemoveItem(cue._id)
-              }}
-            />
-            <IconButton
-              icon={<CopyIcon />}
-              size="xs"
-              position="absolute"
-              _hover={{ bg: "gray.600", color: "white" }}
-              backgroundColor="gray.500"
-              draggable={false}
-              zIndex="10"
-              top="25px"
-              right="0px"
-              aria-label={`Copy ${cue.name}`}
-              onMouseDown={(e) => {
-                e.stopPropagation()
-                setIsCopied(true)
-                setCopiedCue(cue)
-                showToast({
-                  title: `Element ${cue.name} copied`,
-                  description:
-                    "Click on available places on the grid to paste. Click outside the grid to cancel",
-                  status: "success",
-                })
-              }}
-            />
+            {!isShowMode && (
+              <>
+                <IconButton
+                  icon={<DeleteIcon />}
+                  size="xs"
+                  position="absolute"
+                  _hover={{ bg: "red.500", color: "white" }}
+                  backgroundColor="red.300"
+                  draggable={false}
+                  zIndex="10"
+                  top="0px"
+                  right="0px"
+                  aria-label={`Delete ${cue.name}`}
+                  onMouseDown={(e) => {
+                    e.stopPropagation()
+                    handleRemoveItem(cue._id)
+                  }}
+                />
+                <IconButton
+                  icon={<CopyIcon />}
+                  size="xs"
+                  position="absolute"
+                  _hover={{ bg: "gray.600", color: "white" }}
+                  backgroundColor="gray.500"
+                  draggable={false}
+                  zIndex="10"
+                  top="25px"
+                  right="0px"
+                  aria-label={`Copy ${cue.name}`}
+                  onMouseDown={(e) => {
+                    e.stopPropagation()
+                    setIsCopied(true)
+                    setCopiedCue(cue)
+                    showToast({
+                      title: `Element ${cue.name} copied`,
+                      description:
+                        "Click on available places on the grid to paste. Click outside the grid to cancel",
+                      status: "success",
+                    })
+                  }}
+                />
+              </>
+            )}
 
             {cue.file.type.startsWith("video/") ? ( // Thumbail for video
               <video
@@ -197,9 +202,7 @@ const GridLayoutComponent = ({
                 display="inline-block"
                 maxWidth="80%"
                 textAlign="center"
-                style={{
-                  textShadow: "2px 2px 4px rgba(0,0,0,1)",
-                }}
+                style={{ textShadow: "2px 2px 4px rgba(0,0,0,1)" }}
               >
                 {cue.name}
               </Text>

--- a/src/client/components/presentation/index.jsx
+++ b/src/client/components/presentation/index.jsx
@@ -119,6 +119,7 @@ const PresentationPage = () => {
               cues={presentationInfo}
               isToolboxOpen={isToolboxOpen}
               setIsToolboxOpen={setIsToolboxOpen}
+              isShowMode={showMode === true}
             />
           </Box>
           <Dialog


### PR DESCRIPTION
## #185: As a user, I do not want to have same editing options in show mode as in edit mode

This pull request removes the buttons for deleting and copying elements when the user is in show mode. It also disables the ability to move elements by dragging or clicking.

### Changes

**``presentation/index.jsx``**
- Added a variable **`isShowMode`** that checks if the show mode button is clicked and passes the value to the `EditMode.jsx` as a prop.

**``presentation/EditMode.jsx``**
- Passes the variable **``isShowMode``** to the `GridLayoutComponent` as a prop.
- Deactivated the ability to move and click elements by setting the `eventPointer` to none if **`isShowMode`** is true. The **`handleDrop`** event handler includes a conditional check to prevent dropping files when in show mode.

**``presentation/GridLayoutComponent.jsx``**
- Added a conditional block that renders both the copy and delete buttons if **`isShowMode`** is false.
