### PR TITLE
Fix "Jest did not exit" error: Add forceExit flag to backend Jest script to fix test runs getting stuck

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint 'src/**/*.js' 'src/**/*.jsx'",
     "format": "prettier --write '*.{js,json,css,md}'",
     "test-frontend": "jest --testPathPattern=src/client/tests/unit --verbose --runInBand --env=jsdom --coverage --coverageReporters=lcov --coverageDirectory=coverage/frontend",
-    "test-backend": "NODE_ENV=test jest --testPathPattern=src/server/tests/ --verbose --runInBand --env=node --coverage --coverageReporters=lcov --coverageDirectory=coverage/backend",
+    "test-backend": "NODE_ENV=test jest --testPathPattern=src/server/tests/ --verbose --runInBand --env=node --coverage --coverageReporters=lcov --coverageDirectory=coverage/backend --forceExit",
     "test-all": "npm-run-all --continue-on-error test-frontend test-backend",
     "build": "vite build",
     "test:cypress-open": "cypress open",


### PR DESCRIPTION
# Investigate and fix "Jest did not exit" errors with backend tests

## Summary

Investigated and committed a quick fix for test runs getting stuck due to `Jest did not exit` errors occurring if a backend test run encountered some unexpected problem during execution. This led to test runs getting indefinitely stuck in execution.

Example of encountered error ([source](https://github.com/MuViCo/MuViCo/actions/runs/14063500377/job/39380254014#step:6:1245)):
> Jest did not exit one second after the test run has completed.
>
>'This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.

## Changes

### `package.json`:
- Add `--forceExit` flag to the `npm test-backend` script to force exit and prevent test runs from getting stuck.
  - Note: Using `--forceExit` is a quick band-aid solution. Ideally, we should investigate and resolve the root cause of why tests sometimes encounter this problem. Some possible causes are detailed below. Due to time constraints, this quick fix will be used for now.

## Additional insights on the issue

The problem of Jest runs getting stuck likely has multiple causes.

### Possible cause 1 (resolved with `--forceExit` band-aid solution)
- A global Jest teardown file was used to make Jest always return `process.exit(0)` (success exit code), and was removed in order to make actions runs properly fail on test failures, as detailed in an earlier pull #346. 
- This previously acted as a band-aid solution, masking the problems we are currently encountering.
   - Additional note: Since this pull introduces a new band-aid solution `--forceExit`, it's worth noting that `--forceExit` differs from the previous solution `process.exit(0)` by correctly handling Jest exit codes, thus clearly indicating test failures or successes.

### Possible cause 2 (remains unresolved)
- With the current database implementation for tests, simultaneous backend test runs (such as running tests locally while a GitHub Actions test run is also executing, or Actions runs of two different Git branches running at the same time, etc.) appear to be causing test failures due to database race conditions and conflicts. These simultaneous operations on the same test database trigger Mongoose's `VersionError`. 

- Example of encountered error: ([source](https://github.com/MuViCo/MuViCo/actions/runs/14063500377/job/39380254014#step:6:1050)):
 
> VersionError: No matching document found for id "67e2cb76fb02792c8a100d2c" version 0 modifiedPaths "presentations"

- `VersionError` is intended to protect the application from two simultaneous attempts to modify the same data ([source](https://www.mongodb.com/community/forums/t/mongoose-version-error-no-matching-document-found-for-id/134781)). This results in unpredictable test failures and Jest hanging due to unresolved async operations.  Improving error handling in tests could help better catch these situations.

### Short-term solution suggestions
- Adding the `--forceExit` flag to the `npm run test-backend` script to avoid stuck test runs.
- Re-running failed tests encountering said issue and ensuring that no other test runs are simultaneously executing. This, of course, is challenging given that multiple people work on the project.

### Long-term solution suggestions
- Investigating the use of isolated test databases such as `mongodb-memory-server` to prevent simultaneous backend test runs from interfering with each other.
- Investigating if backend test error handling and cleanup (such as closing any open connections to databases) could be improved.

