### PR TITLE
Feature/issue 197 cue transition effect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@chakra-ui/icons": "^2.2.4",
         "@chakra-ui/react": "^2.8.2",
         "@chakra-ui/theme-tools": "^2.2.6",
+        "@emotion/cache": "^11.14.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@reduxjs/toolkit": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@chakra-ui/icons": "^2.2.4",
     "@chakra-ui/react": "^2.8.2",
     "@chakra-ui/theme-tools": "^2.2.6",
+    "@emotion/cache": "^11.14.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@reduxjs/toolkit": "^2.6.1",

--- a/src/client/components/presentation/Screen.jsx
+++ b/src/client/components/presentation/Screen.jsx
@@ -138,7 +138,6 @@ const ScreenContent = ({
 
 const Screen = ({ screenNumber, screenData, isVisible, onClose }) => {
   const windowRef = useRef(null)
-  const fadeOutTimerRef = useRef(null)
   const [isWindowReady, setIsWindowReady] = useState(false)
   const [currentScreenData, setCurrentScreenData] = useState(null)
   const [previousScreenData, setPreviousScreenData] = useState(null)
@@ -171,6 +170,9 @@ const Screen = ({ screenNumber, screenData, isVisible, onClose }) => {
           windowRef.current = null
           onClose(screenNumber)
           setIsWindowReady(false)
+          setEmotionCache(null)
+          setCurrentScreenData(null)
+          setPreviousScreenData(null)
         })
       }
     }
@@ -179,6 +181,9 @@ const Screen = ({ screenNumber, screenData, isVisible, onClose }) => {
       windowRef.current.close()
       windowRef.current = null
       setIsWindowReady(false)
+      setEmotionCache(null)
+      setCurrentScreenData(null)
+      setPreviousScreenData(null)
     }
 
     // Cleanup on unmount
@@ -187,6 +192,9 @@ const Screen = ({ screenNumber, screenData, isVisible, onClose }) => {
         windowRef.current.close()
         windowRef.current = null
         setIsWindowReady(false)
+        setEmotionCache(null)
+        setCurrentScreenData(null)
+        setPreviousScreenData(null)
         onClose(screenNumber)
       }
     }

--- a/src/client/components/presentation/Screen.jsx
+++ b/src/client/components/presentation/Screen.jsx
@@ -15,12 +15,6 @@ const fadeOut = keyframes`
   to { opacity: 0; }
 `
 
-/**
- * Manages the visual presentation and transitions of media on a screen.
- * - The current media always fades in.
- * - If there was previous media, it fades out before being removed.
- * - When these transitions overlap, they create a crossfade effect.
- */
 const ScreenContent = ({
   screenNumber,
   currentScreenData,
@@ -62,6 +56,7 @@ const ScreenContent = ({
         </Text>
       )}
     </Box>
+
     {/* Fade out previous cue media, if any */}
     {previousScreenData && (
       <Box
@@ -97,6 +92,7 @@ const ScreenContent = ({
           ))}
       </Box>
     )}
+
     {/* Fade in current cue media */}
     <Box
       key={`${currentScreenData?._id}-${currentScreenData?.index}-${currentScreenData?.screen}`}
@@ -218,18 +214,14 @@ const Screen = ({ screenNumber, screenData, isVisible, onClose }) => {
     }
   }, [isWindowReady])
 
-  /**
-   * Updates stored screen data to trigger transitions in `ScreenContent`.
-   * - If no current media exists, simply stores the new media.
-   * - Otherwise, moves current media to `previousScreenData` before updating `currentScreenData`.
-   */
+  // Update media states when screenData changes
   useEffect(() => {
     if (screenData) {
       if (!currentScreenData) {
-        setPreviousScreenData(null) // No previous media to transition from
-        setCurrentScreenData(screenData) // Store new media
+        setPreviousScreenData(null) // No media to be stored as previous
+        setCurrentScreenData(screenData) // Store new media as current
       } else {
-        // Skip update if media (URL and name) hasn't changed
+        // Skip update if media URL and name hasn't changed
         const currentMediaUrl = currentScreenData?.file?.url
         const newMediaUrl = screenData?.file?.url
         const currentMediaName = currentScreenData?.name
@@ -241,8 +233,8 @@ const Screen = ({ screenNumber, screenData, isVisible, onClose }) => {
           return
         }
 
-        setPreviousScreenData(currentScreenData) // Preserve current media as previous for transition
-        setCurrentScreenData(screenData) // Store new media
+        setPreviousScreenData(currentScreenData) // Store current media as previous
+        setCurrentScreenData(screenData) // Store new media as current
       }
     }
   }, [screenData, currentScreenData])

--- a/src/client/components/presentation/Screen.jsx
+++ b/src/client/components/presentation/Screen.jsx
@@ -9,8 +9,21 @@ const fadeIn = keyframes`
   to { opacity: 1; }
 `
 
-const ScreenContent = ({ screenNumber, screenData, showText }) => (
+const fadeOut = keyframes`
+  from { opacity: 1; }
+  to { opacity: 0; }
+`
+
+const ScreenContent = ({
+  screenNumber,
+  currentScreenData,
+  previousScreenData,
+  showText,
+  shouldAnimatePrevious,
+  handleFadeOutEnd,
+}) => (
   <Box
+    zIndex={3}
     bg="black"
     color="white"
     width="100vw"
@@ -26,7 +39,7 @@ const ScreenContent = ({ screenNumber, screenData, showText }) => (
       position="absolute"
       width="90vw"
       left="5vw"
-      zIndex={1}
+      zIndex={2}
     >
       <Text
         fontSize="xl"
@@ -35,17 +48,18 @@ const ScreenContent = ({ screenNumber, screenData, showText }) => (
       >
         Screen {screenNumber}
       </Text>
-      {screenData && (
+      {currentScreenData && (
         <Text
           fontSize="xl"
           textShadow="1px 0 2px #000000"
           style={{ visibility: showText ? "visible" : "hidden" }}
         >
-          Element Name: {screenData.name}
+          Element Name: {currentScreenData.name}
         </Text>
       )}
     </Box>
 
+    {/* Fade in current cue media */}
     <Box
       flex="1"
       display="flex"
@@ -53,16 +67,16 @@ const ScreenContent = ({ screenNumber, screenData, showText }) => (
       alignItems="center"
       position="absolute"
       width="100vw"
-      zIndex={0}
+      zIndex={1}
       animation={`${fadeIn} 500ms ease-in-out forwards`}
-      key={screenData?.file?.url}
+      key={`${currentScreenData?._id}-${currentScreenData?.index}-${currentScreenData?.screen}`}
     >
-      {screenData?.file?.url ? (
+      {currentScreenData?.file?.url ? (
         // If data is an image
-        isImage(screenData.file) ? (
+        isImage(currentScreenData.file) ? (
           <Image
-            src={screenData.file.url}
-            alt={screenData.name}
+            src={currentScreenData.file.url}
+            alt={currentScreenData.name}
             width="100%"
             height="100vh"
             objectFit="contain"
@@ -70,7 +84,7 @@ const ScreenContent = ({ screenNumber, screenData, showText }) => (
         ) : (
           // If data is a video
           <video
-            src={screenData.file.url}
+            src={currentScreenData.file.url}
             width="100%"
             height="100%"
             autoPlay
@@ -84,14 +98,60 @@ const ScreenContent = ({ screenNumber, screenData, showText }) => (
         <Text>No media available for this cue.</Text>
       )}
     </Box>
+
+    {/* Fade out previous cue media, if applicable */}
+    {shouldAnimatePrevious && (
+      <Box
+        flex="1"
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        position="absolute"
+        width="100vw"
+        zIndex={0}
+        animation={`${fadeOut} 500ms ease-in-out forwards`}
+        key={`${previousScreenData?._id}-${previousScreenData?.index}-${previousScreenData?.screen}`}
+        onAnimationEnd={handleFadeOutEnd}
+      >
+        {previousScreenData?.file?.url ? (
+          // If data is an image
+          isImage(previousScreenData.file) ? (
+            <Image
+              src={previousScreenData.file.url}
+              alt={previousScreenData.name}
+              width="100%"
+              height="100vh"
+              objectFit="contain"
+            />
+          ) : (
+            // If data is a video
+            <video
+              src={previousScreenData.file.url}
+              width="100%"
+              height="100%"
+              autoPlay
+              loop
+              muted
+              style={{ objectFit: "contain" }}
+            />
+          )
+        ) : (
+          // If no data
+          <Text>No media available for this cue.</Text>
+        )}
+      </Box>
+    )}
   </Box>
 )
 
 const Screen = ({ screenNumber, screenData, isVisible, onClose }) => {
   const windowRef = useRef(null)
   const [isWindowReady, setIsWindowReady] = useState(false)
+  const [currentScreenData, setCurrentScreenData] = useState(null)
   const [previousScreenData, setPreviousScreenData] = useState(null)
   const [showText, setShowText] = useState(false)
+  const [shouldAnimatePrevious, setShouldAnimatePrevious] = useState(false)
+  const [hasBeenOpened, setHasBeenOpened] = useState(false)
 
   // Function to copy the dynamic Chakra styles from the parent document to the new window
   const copyChakraStyles = () => {
@@ -111,15 +171,24 @@ const Screen = ({ screenNumber, screenData, isVisible, onClose }) => {
           `Screen ${screenNumber}`,
           "width=800,height=600"
         )
-
         windowRef.current = newWindow
         setIsWindowReady(true)
+
+        // Set `shouldAnimatePrevious` only if the screen has been opened before
+        if (hasBeenOpened) {
+          setShouldAnimatePrevious(true)
+        } else {
+          setShouldAnimatePrevious(false)
+          setHasBeenOpened(true) // Mark the screen as opened
+        }
 
         // Handle window close event to reset the reference
         newWindow.addEventListener("beforeunload", () => {
           windowRef.current = null
           onClose(screenNumber)
           setIsWindowReady(false)
+          setHasBeenOpened(false)
+          setShouldAnimatePrevious(false)
         })
       }
     }
@@ -128,6 +197,8 @@ const Screen = ({ screenNumber, screenData, isVisible, onClose }) => {
       windowRef.current.close()
       windowRef.current = null
       setIsWindowReady(false)
+      setHasBeenOpened(false)
+      setShouldAnimatePrevious(false)
     }
 
     // Cleanup on unmount
@@ -136,6 +207,8 @@ const Screen = ({ screenNumber, screenData, isVisible, onClose }) => {
         windowRef.current.close()
         windowRef.current = null
         setIsWindowReady(false)
+        setHasBeenOpened(false)
+        setShouldAnimatePrevious(false)
         onClose(screenNumber)
       }
     }
@@ -149,11 +222,35 @@ const Screen = ({ screenNumber, screenData, isVisible, onClose }) => {
   }, [isWindowReady])
 
   useEffect(() => {
-    // Update the previous screen data if new screen data is available
-    if (screenData) {
-      setPreviousScreenData(screenData)
+    if (screenData && screenData !== currentScreenData) {
+      if (!currentScreenData) {
+        setCurrentScreenData(screenData)
+        setPreviousScreenData(null)
+      } else {
+        setPreviousScreenData(currentScreenData)
+        setCurrentScreenData(screenData)
+        console.log("")
+        console.log("screendata", screenData)
+        console.log("current screen data", currentScreenData)
+        console.log("previous screen data", previousScreenData)
+        // Only animate transition if the screen has been opened before
+        setShouldAnimatePrevious(true)
+
+        // Fallback timeout to remove previous screen if onAnimationEnd doesn't fire
+        setTimeout(() => {
+          setPreviousScreenData(null)
+          setShouldAnimatePrevious(false)
+        }, 100) // Match animation duration
+      }
     }
   }, [screenData])
+
+  // Function to handle fade-out completion
+  const handleFadeOutEnd = () => {
+    console.log("handle fade out end")
+    setPreviousScreenData(null) // Remove previous screen data after fade-out
+    setShouldAnimatePrevious(false) // Stop animation flag
+  }
 
   // Listeners for shift-press to show screen data on screens
   useEffect(() => {
@@ -181,12 +278,15 @@ const Screen = ({ screenNumber, screenData, isVisible, onClose }) => {
   // Only render the portal when the window is ready
   return windowRef.current &&
     isWindowReady &&
-    (screenData || previousScreenData)
+    (currentScreenData || previousScreenData)
     ? ReactDOM.createPortal(
         <ScreenContent
           screenNumber={screenNumber}
-          screenData={screenData || previousScreenData}
+          currentScreenData={currentScreenData}
+          previousScreenData={previousScreenData}
           showText={showText}
+          shouldAnimatePrevious={shouldAnimatePrevious}
+          handleFadeOutEnd={handleFadeOutEnd}
         />,
         windowRef.current.document.body // render to new window's document.body
       )

--- a/src/client/components/presentation/Screen.jsx
+++ b/src/client/components/presentation/Screen.jsx
@@ -14,6 +14,12 @@ const fadeOut = keyframes`
   to { opacity: 0; }
 `
 
+/**
+ * Manages the visual presentation and transitions of media on a screen.
+ * - The current media always fades in.
+ * - If there was previous media, it fades out before being removed.
+ * - When these transitions overlap, they create a crossfade effect.
+ */
 const ScreenContent = ({
   screenNumber,
   currentScreenData,
@@ -192,15 +198,15 @@ const Screen = ({ screenNumber, screenData, isVisible, onClose }) => {
   }, [isWindowReady])
 
   /**
-   * Updates screen data and indirectly triggers crossfades in `ScreenContent`.
-   * - If there is current media, it moves to `previousScreenData` and fades out as new media fades in.
-   * - If there is no current media, new media simply fades in without a crossfade effect.
+   * Updates stored screen data to trigger transitions in `ScreenContent`.
+   * - If no current media exists, simply stores the new media.
+   * - Otherwise, moves current media to `previousScreenData` before updating `currentScreenData`.
    */
   useEffect(() => {
     if (screenData) {
       if (!currentScreenData) {
-        setCurrentScreenData(screenData)
-        setPreviousScreenData(null) // No previous media to fade out
+        setPreviousScreenData(null) // No previous media to transition from
+        setCurrentScreenData(screenData) // Store new media
       } else {
         // Skip update if media (URL and name) hasn't changed
         const currentMediaUrl = currentScreenData?.file?.url
@@ -214,16 +220,13 @@ const Screen = ({ screenNumber, screenData, isVisible, onClose }) => {
           return
         }
 
-        // Store current media as previous for crossfade effect
-        setPreviousScreenData(currentScreenData)
-        // Store new media
-        setCurrentScreenData(screenData)
+        setPreviousScreenData(currentScreenData) // Preserve current media as previous for transition
+        setCurrentScreenData(screenData) // Store new media
 
-        // Prevent overlapping fade-out timers
+        // Remove previous media after fade-out animation completes (500ms)
         if (fadeOutTimerRef.current) {
           clearTimeout(fadeOutTimerRef.current)
         }
-        // Clear previous media after fade-out animation (500ms)
         fadeOutTimerRef.current = setTimeout(() => {
           setPreviousScreenData(null)
           fadeOutTimerRef.current = null

--- a/src/client/components/presentation/Screen.jsx
+++ b/src/client/components/presentation/Screen.jsx
@@ -214,30 +214,31 @@ const Screen = ({ screenNumber, screenData, isVisible, onClose }) => {
     }
   }, [isWindowReady])
 
-  // Update media states when screenData changes
   useEffect(() => {
+    // Update media states when screenData changes
     if (screenData) {
+      // Skip update if screen is closed
+      if (!isWindowReady && !windowRef.current) {
+        return
+      }
+
       if (!currentScreenData) {
-        setPreviousScreenData(null) // No media to be stored as previous
-        setCurrentScreenData(screenData) // Store new media as current
+        setPreviousScreenData(null)
+        setCurrentScreenData(screenData)
       } else {
         // Skip update if media URL and name hasn't changed
-        const currentMediaUrl = currentScreenData?.file?.url
-        const newMediaUrl = screenData?.file?.url
-        const currentMediaName = currentScreenData?.name
-        const newMediaName = screenData?.name
         if (
-          currentMediaUrl === newMediaUrl &&
-          currentMediaName === newMediaName
+          currentScreenData?.file?.url === screenData?.file?.url &&
+          currentScreenData?.name === screenData?.name
         ) {
           return
         }
 
-        setPreviousScreenData(currentScreenData) // Store current media as previous
-        setCurrentScreenData(screenData) // Store new media as current
+        setPreviousScreenData(currentScreenData)
+        setCurrentScreenData(screenData)
       }
     }
-  }, [screenData, currentScreenData])
+  }, [screenData, currentScreenData, isWindowReady])
 
   // Listeners for shift-press to show screen data on screens
   useEffect(() => {

--- a/src/client/components/presentation/Screen.jsx
+++ b/src/client/components/presentation/Screen.jsx
@@ -2,6 +2,12 @@ import React, { useEffect, useRef, useState } from "react"
 import ReactDOM from "react-dom"
 import { Box, Image, Text } from "@chakra-ui/react"
 import { isImage } from "../utils/fileTypeUtils"
+import { keyframes } from "@emotion/react"
+
+const fadeIn = keyframes`
+  from { opacity: 0; }
+  to { opacity: 1; }
+`
 
 const ScreenContent = ({ screenNumber, screenData, showText }) => (
   <Box
@@ -48,6 +54,8 @@ const ScreenContent = ({ screenNumber, screenData, showText }) => (
       position="absolute"
       width="100vw"
       zIndex={0}
+      animation={`${fadeIn} 500ms ease-in-out forwards`}
+      key={screenData?.file?.url}
     >
       {screenData?.file?.url ? (
         // If data is an image


### PR DESCRIPTION
## #197: Cue transition effect

This pull request adds fade transition animations for cue media:
- Fade-out animation for previous media  (if exists)
- Fade-in animation for current media

These animations produce a crossfade as a combination of simultaneous fade-out and fade-in effects. If there is no previous media, the current media is faded in by itself without a crossfade being produced.

### Changes

**Dependency updates** (**`package.lock.json`** and **`package.json`**):
- Installed @emotion/cache for caching styles used in cue media transitions.

**`src/client/components/presentation/Screen.jsx`**
- Defined Emotion keyframes animations (fadeIn, fadeOut) for media transitions.
- Updated `ScreenContent` component:
  - Added `currentScreenData` and `previousScreenData` for crossfade management.
  - Replaced the singular `screenData` box with separate boxes for `currentScreenData` and `previousScreenData`.
  - Applied `fadeOut` to previous media and `fadeIn` to current media.
  - The box for `previousScreenData` is conditionally rendered only if previous media exists, while `currentScreenData` is always present.

- Updated `Screen` component:
  - Added state for `currentScreenData` and `emotionCache`.
  - Included resetting of `currentScreenData`, `previousScreenData`, and `emotionCache` during cleanup.
  - Injected Emotion cache into new window portal to support animations.
  - Updated useEffect hook to handle current and previous media.
    - Data updates occur only for already opened screens to ensure that the crossfade triggers appropriately. This prevents unnecessary fade-out effects when opening new screens.
