### PR TITLE
Fix: remove early return to fire mousedown in Chrome and Safari.

### DIFF
--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -90,10 +90,6 @@ const EditMode = ({
   }, [isToolboxOpen])
 
   const handleMouseDown = (event) => {
-    if (isCopied) {
-      return
-    }
-
     const { xIndex, yIndex } = getPosition(
       event,
       containerRef,


### PR DESCRIPTION
## #341: Find out why copy-paste  is not working as expected in chrome and safari.

This pull request fixes a bug in the **`handleMouseDown`** function where the mousedown event was not triggering as expected in Chrome and Safari when an element already existed. The issue stemmed from an early return that prevented the event logic from executing in such cases.

### Changes

**`presentation/EditMode.jsx`**
- Removed the early return statement so that the function always calculates the position and handles element selection, regardless of whether `isCopied` is true. This adjustment ensures the mousedown functionality works consistently across different browsers.

**Testing:**  
  The changes have been tested in both Chrome and Firefox to ensure that the mousedown event is triggered and that the elements are handled correctly in all scenarios.
