### PR TITLE
Feature merge dev

### DIFF
--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -90,10 +90,6 @@ const EditMode = ({
   }, [isToolboxOpen])
 
   const handleMouseDown = (event) => {
-    if (isCopied) {
-      return
-    }
-
     const { xIndex, yIndex } = getPosition(
       event,
       containerRef,


### PR DESCRIPTION
This pull request fixes a Chrome and Safari bug by ensuring mousedown always triggers in `handleMouseDown`.