### PR TITLE
Bugfix/issue 377 hover not working in overflow area

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17288,9 +17288,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
-      "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
+      "integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",

--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -544,6 +544,7 @@ const EditMode = ({
           height="680px"
           width="100%"
           marginTop={`${gap * 2}px`}
+          overflow="auto"
         >
           <Box
             display="grid"
@@ -613,7 +614,6 @@ const EditMode = ({
           </Box>
           <Box
             position="relative"
-            overflow="auto"
             pointerEvents={isShowMode ? "none" : "auto"}
           >
             <Box


### PR DESCRIPTION
## #377: Bugfix - Hover does not show in indexes above 10 

This pull fixes two bugs considering the grid layout
- Hover not working
- Copying elements not working

The bug occured on grid overflow area, i.e. the area of the grid only accessible by scrolling right on the grid's scrollbar (the presentation view has two scrollbars, and the scrollbar in question is the inner one). Using browser dev tools' inspector, one could see that react-grid-layout was only rendered on the non-overflow -area. This meant that both hover overlay and copying elements treated the grid's overflow area as if it's completely outside of the grid. Copying elements in overflow area triggered "Copying element has been cancelled"-toast, and in hover's case the hover layout just didn't appear.

The fix was simple one liner - just moving the property `overflow: "auto"` to the right ChakraUI Box container. Placing  `overflow: "auto"` on the GridLayoutComponent's container interfered with react-grid-layout’s position calculations due to scrolling and CSS transforms. Moving overflow to a parent element isolates the scroll behavior, ensuring the grid's rendering remain accurate despite container scrolling, solving the rendering issue.

The rendering issue was dependent on the browser viewport's zoom. On default zoom with 1920p×1080p Full HD screen the grid would render up to index 10 without scrolling - thus the hover/copying bug occured only after scrolling right and revealing more indexes after index 10.  

### Changes

**`src/client/components/presentation/EditMode.jsx`**
- Change `overflow: "auto"` to a parent container

