### PR TITLE
Feature/issue 306 keybinding instructions

### DIFF
--- a/documentation/Keybindings instructions.md
+++ b/documentation/Keybindings instructions.md
@@ -1,0 +1,19 @@
+Keyboard Navigation Guide
+
+MuViCo presentations support convenient keyboard navigation, allowing you to seamlessly move between cues during presentations.
+
+Keyboard Controls
+
+Ensure the MuViCo presentation window is active (focused) when using these keyboard shortcuts:
+
+Action
+
+Keyboard Shortcut
+
+Next Cue
+
+→ (Arrow Right), PageDown, ↑ (Arrow Up)
+
+Previous Cue
+
+← (Arrow Left), PageUp, ↓ (Arrow Down)

--- a/src/client/components/presentation/ShowModeButtons.jsx
+++ b/src/client/components/presentation/ShowModeButtons.jsx
@@ -13,7 +13,7 @@ import {
   MenuItem,
 } from "@chakra-ui/react"
 import {
-  QuestionOutlineIcon,
+  QuestionIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   ChevronDownIcon,
@@ -129,10 +129,10 @@ const CueNavigationButtons = ({ cueIndex, updateCue }) => (
     >
       <IconButton
         aria-label="Keyboard Shortcuts"
-        icon={<QuestionOutlineIcon />}
-        size="sm"
+        icon={<QuestionIcon />}
+        size="lg"
         variant="ghost"
-        colorScheme="white"
+        colorScheme="purple"
       />
     </Tooltip>
   </Box>

--- a/src/client/components/presentation/ShowModeButtons.jsx
+++ b/src/client/components/presentation/ShowModeButtons.jsx
@@ -1,6 +1,9 @@
 import React from "react"
+
 import {
   Button,
+  Tooltip,
+  Icon,
   Box,
   IconButton,
   Heading,
@@ -10,6 +13,7 @@ import {
   MenuItem,
 } from "@chakra-ui/react"
 import {
+  QuestionOutlineIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   ChevronDownIcon,
@@ -89,20 +93,48 @@ const ScreenToggleButtons = ({
 // Component for rendering the cue navigation buttons
 const CueNavigationButtons = ({ cueIndex, updateCue }) => (
   <Box display="flex" gap={4} alignItems="center">
-    {/* Cue Navigation Buttons */}
     <IconButton
       aria-label="Previous Cue"
       icon={<ChevronLeftIcon />}
       onClick={() => updateCue("Previous")}
       colorScheme="purple"
     />
+
     <Heading size="md">Index {cueIndex}</Heading>
+
     <IconButton
       aria-label="Next Cue"
       icon={<ChevronRightIcon />}
       onClick={() => updateCue("Next")}
       colorScheme="purple"
     />
+
+    <Tooltip
+      label={
+        <>
+          Make sure this window is in focus!
+          <br />
+          <br />
+          You can use the following keyboard shortcuts:
+          <br />
+          <br />
+          Next index: → ArrowRight, ↑ ArrowUp, PageDown
+          <br />
+          <br />
+          Previous index: ← ArrowLeft, ↓ ArrowDown, PageUp
+        </>
+      }
+      placement="top"
+      fontSize="sm"
+    >
+      <IconButton
+        aria-label="Keyboard Shortcuts"
+        icon={<QuestionOutlineIcon />}
+        size="sm"
+        variant="ghost"
+        colorScheme="white"
+      />
+    </Tooltip>
   </Box>
 )
 


### PR DESCRIPTION
## #306: keybinding instructions

This pull add keyboard instructions next to the showmode index controllers.

### Changes

**` src/client/components/presentation/ShowModeButtons.jsx`**
- added the questionmark icon that when hovered over with the mouse displays the instructions

