### PR TITLE
Feature/issue 352 delete presentation from homepage

### DIFF
--- a/src/client/components/homepage/PresentationsGrid.jsx
+++ b/src/client/components/homepage/PresentationsGrid.jsx
@@ -1,8 +1,19 @@
-import { SimpleGrid, Card, CardHeader, Heading } from "@chakra-ui/react"
+import {
+  SimpleGrid,
+  Card,
+  CardHeader,
+  Heading,
+  IconButton,
+} from "@chakra-ui/react"
+import { DeleteIcon } from "@chakra-ui/icons"
 import { motion } from "framer-motion"
 import randomLinearGradient from "../utils/randomGradient"
 
-const PresentationsGrid = ({ presentations, handlePresentationClick }) => (
+const PresentationsGrid = ({
+  presentations,
+  handlePresentationClick,
+  handleDeletePresentation,
+}) => (
   <>
     <Heading style={{ textAlign: "center", padding: "30px" }}>
       Presentations
@@ -33,7 +44,23 @@ const PresentationsGrid = ({ presentations, handlePresentationClick }) => (
                 {presentation.name}
               </Heading>
             </CardHeader>
-            {/* <CardBody>{assertImage(index)}</CardBody> */}
+            <IconButton
+              icon={<DeleteIcon />}
+              size="md"
+              position="absolute"
+              _hover={{ bg: "red.500", color: "white" }}
+              backgroundColor="red.300"
+              draggable={false}
+              zIndex="10"
+              top="4px"
+              right="4px"
+              aria-label={"Delete presentation"}
+              title="Delete presentation"
+              onClick={(e) => {
+                e.stopPropagation()
+                handleDeletePresentation(presentation.id)
+              }}
+            />
           </Card>
         </motion.div>
       ))}

--- a/src/client/components/homepage/index.jsx
+++ b/src/client/components/homepage/index.jsx
@@ -8,12 +8,20 @@ import PresentationsGrid from "./PresentationsGrid"
 import PresentationFormWrapper from "./PresentationFormWrapper"
 import addInitialElements from "../utils/addInitialElements"
 import { useCustomToast } from "../utils/toastUtils"
+import useDeletePresentation from "../utils/useDeletePresentation"
+import Dialog from "../utils/AlertDialog"
 
 const HomePage = ({ user }) => {
   const [presentations, setPresentations] = useState([])
   const navigate = useNavigate()
   const togglableRef = useRef(null)
   const showToast = useCustomToast()
+  const {
+    isDialogOpen,
+    handleDeletePresentation,
+    handleConfirmDelete,
+    handleCancelDelete,
+  } = useDeletePresentation()
 
   useEffect(() => {
     const getPresentationData = async () => {
@@ -64,6 +72,13 @@ const HomePage = ({ user }) => {
       <PresentationsGrid
         presentations={presentations}
         handlePresentationClick={handlePresentationClick}
+        handleDeletePresentation={handleDeletePresentation}
+      />
+      <Dialog
+        isOpen={isDialogOpen}
+        onClose={handleCancelDelete}
+        onConfirm={handleConfirmDelete}
+        message="Are you sure you want to delete this presentation?"
       />
     </Container>
   )

--- a/src/client/components/homepage/index.jsx
+++ b/src/client/components/homepage/index.jsx
@@ -21,6 +21,7 @@ const HomePage = ({ user }) => {
     handleDeletePresentation,
     handleConfirmDelete,
     handleCancelDelete,
+    presentationToDelete,
   } = useDeletePresentation()
 
   useEffect(() => {
@@ -61,6 +62,17 @@ const HomePage = ({ user }) => {
     togglableRef.current.toggleVisibility()
   }
 
+  const handleDialogConfirm = async () => {
+    try {
+      await handleConfirmDelete()
+      setPresentations(
+        presentations.filter((p) => p.id !== presentationToDelete)
+      )
+    } catch (e) {
+      console.log("Error deleting presentation: ", e)
+    }
+  }
+
   return (
     <Container maxW="container.lg">
       <AdminControls isAdmin={user.isAdmin} navigate={navigate} />
@@ -77,7 +89,7 @@ const HomePage = ({ user }) => {
       <Dialog
         isOpen={isDialogOpen}
         onClose={handleCancelDelete}
-        onConfirm={handleConfirmDelete}
+        onConfirm={handleDialogConfirm}
         message="Are you sure you want to delete this presentation?"
       />
     </Container>

--- a/src/client/components/homepage/index.jsx
+++ b/src/client/components/homepage/index.jsx
@@ -50,7 +50,7 @@ const HomePage = ({ user }) => {
       await addInitialElements(presentationId, showToast)
       navigate(`/presentation/${presentationId}`)
     } catch (error) {
-      console.error("Error creating presentation:", error)
+      console.error("Error creating presentation: ", error)
     }
   }
 
@@ -69,7 +69,7 @@ const HomePage = ({ user }) => {
         presentations.filter((p) => p.id !== presentationToDelete)
       )
     } catch (e) {
-      console.log("Error deleting presentation: ", e)
+      console.error("Error deleting presentation: ", e)
     }
   }
 

--- a/src/client/components/presentation/index.jsx
+++ b/src/client/components/presentation/index.jsx
@@ -1,30 +1,30 @@
 import { useEffect, useState } from "react"
 import { useParams, useNavigate } from "react-router-dom"
 import { Button, Flex, Box, Text } from "@chakra-ui/react"
-import {
-  fetchPresentationInfo,
-  deletePresentation,
-} from "../../redux/presentationReducer"
+import { fetchPresentationInfo } from "../../redux/presentationReducer"
 import "reactflow/dist/style.css"
 import { useDispatch, useSelector } from "react-redux"
-import { useCustomToast } from "../utils/toastUtils"
 
 import ShowMode from "./ShowMode"
 import EditMode from "./EditMode"
 import Dialog from "../utils/AlertDialog"
+import useDeletePresentation from "../utils/useDeletePresentation"
 
 const PresentationPage = () => {
   const { id } = useParams()
   const dispatch = useDispatch()
   const navigate = useNavigate()
-  const showToast = useCustomToast()
   const [cueIndex, setCueIndex] = useState(0)
+  const {
+    isDialogOpen,
+    handleDeletePresentation,
+    handleConfirmDelete,
+    handleCancelDelete,
+  } = useDeletePresentation()
 
   const [presentationSize, setPresentationSize] = useState(0)
   const [showMode, setShowMode] = useState(false)
   const [isToolboxOpen, setIsToolboxOpen] = useState(false)
-  const [isDialogOpen, setIsDialogOpen] = useState(false)
-  const [presentationToDelete, setPresentationToDelete] = useState(null)
   const [isAudioMuted, setIsAudioMuted] = useState(false)
 
   // Fetch presentation info from Redux state
@@ -54,32 +54,6 @@ const PresentationPage = () => {
       }
     }
   }, [presentationInfo, presentationSize])
-
-  const handleDeletePresentation = (presentationId) => {
-    setPresentationToDelete(presentationId)
-    setIsDialogOpen(true)
-  }
-
-  const handleConfirmDelete = async () => {
-    if (presentationToDelete) {
-      try {
-        await dispatch(deletePresentation(presentationToDelete))
-        showToast({
-          title: "Presentation deleted",
-          description: "The presentation has been deleted successfully.",
-          status: "success",
-        })
-        navigate("/home")
-      } catch (error) {
-        showToast({
-          title: "Error",
-          description: error.message || "An error occurred",
-          status: "error",
-        })
-      }
-    }
-    setIsDialogOpen(false)
-  }
 
   return (
     <>
@@ -139,7 +113,7 @@ const PresentationPage = () => {
           </Box>
           <Dialog
             isOpen={isDialogOpen}
-            onClose={() => setIsDialogOpen(false)}
+            onClose={handleCancelDelete}
             onConfirm={handleConfirmDelete}
             message="Are you sure you want to delete this presentation?"
           />

--- a/src/client/components/utils/useDeletePresentation.js
+++ b/src/client/components/utils/useDeletePresentation.js
@@ -50,6 +50,7 @@ const useDeletePresentation = () => {
     handleDeletePresentation,
     handleConfirmDelete,
     handleCancelDelete,
+    presentationToDelete,
   }
 }
 

--- a/src/client/components/utils/useDeletePresentation.js
+++ b/src/client/components/utils/useDeletePresentation.js
@@ -1,0 +1,56 @@
+import { useState } from "react"
+import { useNavigate } from "react-router-dom"
+import { useDispatch } from "react-redux"
+import { deletePresentation } from "../../redux/presentationReducer"
+import { useCustomToast } from "./toastUtils"
+
+const useDeletePresentation = () => {
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
+  const [presentationToDelete, setPresentationToDelete] = useState(null)
+  const dispatch = useDispatch()
+  const navigate = useNavigate()
+  const showToast = useCustomToast()
+
+  const handleDeletePresentation = (presentationId) => {
+    setPresentationToDelete(presentationId)
+    setIsDialogOpen(true)
+  }
+
+  const handleConfirmDelete = async () => {
+    if (presentationToDelete) {
+      try {
+        await dispatch(deletePresentation(presentationToDelete))
+        showToast({
+          title: "Presentation deleted",
+          description: "The presentation has been deleted successfully.",
+          status: "success",
+        })
+        navigate("/home")
+      } catch (error) {
+        showToast({
+          title: "Error",
+          description: error.message || "An error occurred",
+          status: "error",
+        })
+      }
+    }
+    // Clean up state
+    setIsDialogOpen(false)
+    setPresentationToDelete(null)
+  }
+
+  // Cancel deletion: Close the confirmation dialog
+  const handleCancelDelete = () => {
+    setIsDialogOpen(false)
+    setPresentationToDelete(null)
+  }
+
+  return {
+    isDialogOpen,
+    handleDeletePresentation,
+    handleConfirmDelete,
+    handleCancelDelete,
+  }
+}
+
+export default useDeletePresentation

--- a/src/client/tests/unit/homepage.test.js
+++ b/src/client/tests/unit/homepage.test.js
@@ -91,6 +91,22 @@ describe("HomePage", () => {
 
     expect(navigate).toHaveBeenCalledWith("/presentation/3")
   })
+
+  test("calls toggleVisibility when handleCancel is invoked", async () => {
+    const toggleVisibilityMock = jest.fn()
+    const fakeRef = { current: { toggleVisibility: toggleVisibilityMock } }
+    const useRefSpy = jest.spyOn(React, "useRef").mockReturnValue(fakeRef)
+
+    render(<HomePage user={{ isAdmin: true }} />)
+
+    fireEvent.click(screen.getByText("New presentation"))
+    const cancelButton = screen.getByRole("button", { name: /cancel/i })
+    fireEvent.click(cancelButton)
+
+    expect(toggleVisibilityMock).toHaveBeenCalled()
+
+    useRefSpy.mockRestore()
+  })
 })
 
 describe("PresentationForm", () => {

--- a/src/client/tests/unit/homepage.test.js
+++ b/src/client/tests/unit/homepage.test.js
@@ -37,24 +37,17 @@ jest.mock("../../components/utils/useDeletePresentation", () => ({
 }))
 
 describe("HomePage", () => {
+  let navigate = jest.fn()
+
   beforeEach(() => {
+    navigate.mockClear()
+    navigate = jest.fn()
     useNavigate.mockClear()
+    useNavigate.mockReturnValue(navigate)
+
     presentationService.create.mockClear()
     presentationService.getAll.mockClear()
     addInitialElements.mockClear()
-  })
-
-  test('navigates to /users when "All users" button is clicked', async () => {
-    const navigate = jest.fn()
-    useNavigate.mockReturnValue(navigate)
-    render(<HomePage user={{ isAdmin: true }} />)
-    fireEvent.click(screen.getByText("All users"))
-    expect(navigate).toHaveBeenCalledWith("/users")
-  })
-
-  test("creates a presentation and navigates to the new presentation", async () => {
-    const navigate = jest.fn()
-    useNavigate.mockReturnValue(navigate)
 
     const mockPresentations = [
       { id: 1, name: "Presentation 1" },
@@ -62,6 +55,15 @@ describe("HomePage", () => {
       { id: 3, name: "Presentation 3" },
     ]
     presentationService.getAll.mockResolvedValue(mockPresentations)
+  })
+
+  test("navigates to /users when All users -button is clicked", async () => {
+    render(<HomePage user={{ isAdmin: true }} />)
+    fireEvent.click(screen.getByText("All users"))
+    expect(navigate).toHaveBeenCalledWith("/users")
+  })
+
+  test("creates a presentation and navigates to the new presentation", async () => {
     presentationService.create.mockResolvedValue({
       id: 3,
       name: "Presentation 3",
@@ -109,9 +111,6 @@ describe("HomePage", () => {
   })
 
   test("navigates to / on 401 Unauthorized error", async () => {
-    const navigate = jest.fn()
-    useNavigate.mockReturnValue(navigate)
-
     presentationService.getAll.mockRejectedValue({
       response: { status: 401 },
     })
@@ -124,16 +123,6 @@ describe("HomePage", () => {
   })
 
   test("handles error when presentationService.create fails", async () => {
-    const navigate = jest.fn()
-    useNavigate.mockReturnValue(navigate)
-
-    const mockPresentations = [
-      { id: 1, name: "Presentation 1" },
-      { id: 2, name: "Presentation 2" },
-      { id: 3, name: "Presentation 3" },
-    ]
-    presentationService.getAll.mockResolvedValue(mockPresentations)
-
     const errorMessage = "Creation failed"
     presentationService.create.mockRejectedValue(new Error(errorMessage))
 
@@ -162,16 +151,6 @@ describe("HomePage", () => {
   })
 
   test("navigates to /presentation/presentationId on presentation click", async () => {
-    const navigate = jest.fn()
-    useNavigate.mockReturnValue(navigate)
-
-    const mockPresentations = [
-      { id: 1, name: "Presentation 1" },
-      { id: 2, name: "Presentation 2" },
-      { id: 3, name: "Presentation 3" },
-    ]
-    presentationService.getAll.mockResolvedValue(mockPresentations)
-
     render(<HomePage user={{ isAdmin: true }} />)
 
     const presentationElement = await waitFor(() =>

--- a/src/client/tests/unit/homepage.test.js
+++ b/src/client/tests/unit/homepage.test.js
@@ -107,6 +107,21 @@ describe("HomePage", () => {
 
     useRefSpy.mockRestore()
   })
+
+  test("navigates to / on 401 Unauthorized error", async () => {
+    const navigate = jest.fn()
+    useNavigate.mockReturnValue(navigate)
+
+    presentationService.getAll.mockRejectedValue({
+      response: { status: 401 },
+    })
+
+    render(<HomePage user={{ isAdmin: true }} />)
+
+    await waitFor(() => expect(presentationService.getAll).toHaveBeenCalled())
+
+    expect(navigate).toHaveBeenCalledWith("/")
+  })
 })
 
 describe("PresentationForm", () => {

--- a/src/client/tests/unit/homepage.test.js
+++ b/src/client/tests/unit/homepage.test.js
@@ -160,6 +160,28 @@ describe("HomePage", () => {
     })
     consoleErrorSpy.mockRestore()
   })
+
+  test("navigates to /presentation/presentationId on presentation click", async () => {
+    const navigate = jest.fn()
+    useNavigate.mockReturnValue(navigate)
+
+    const mockPresentations = [
+      { id: 1, name: "Presentation 1" },
+      { id: 2, name: "Presentation 2" },
+      { id: 3, name: "Presentation 3" },
+    ]
+    presentationService.getAll.mockResolvedValue(mockPresentations)
+
+    render(<HomePage user={{ isAdmin: true }} />)
+
+    const presentationElement = await waitFor(() =>
+      screen.getByText("Presentation 3")
+    )
+
+    fireEvent.click(presentationElement)
+
+    expect(navigate).toHaveBeenCalledWith("/presentation/3")
+  })
 })
 
 describe("PresentationForm", () => {

--- a/src/client/tests/unit/homepage.test.js
+++ b/src/client/tests/unit/homepage.test.js
@@ -25,6 +25,17 @@ jest.mock("../../services/presentations", () => ({
 
 jest.mock("../../components/utils/addInitialElements", () => jest.fn())
 
+jest.mock("../../components/utils/useDeletePresentation", () => ({
+  __esModule: true,
+  default: () => ({
+    isDialogOpen: false,
+    handleDeletePresentation: jest.fn(),
+    handleConfirmDelete: jest.fn(),
+    handleCancelDelete: jest.fn(),
+    presentationToDelete: null,
+  }),
+}))
+
 describe("HomePage", () => {
   beforeEach(() => {
     useNavigate.mockClear()

--- a/src/client/tests/unit/homepage.test.js
+++ b/src/client/tests/unit/homepage.test.js
@@ -123,6 +123,16 @@ describe("HomePage", () => {
     expect(navigate).toHaveBeenCalledWith("/")
   })
 
+  test("does not navigate to / on non-401 error", async () => {
+    presentationService.getAll.mockRejectedValue(new Error("Random error"))
+
+    render(<HomePage user={{ isAdmin: true }} />)
+
+    await waitFor(() => expect(presentationService.getAll).toHaveBeenCalled())
+
+    expect(navigate).not.toHaveBeenCalledWith("/")
+  })
+
   test("handles error when presentationService.create fails", async () => {
     const errorMessage = "Creation failed"
     presentationService.create.mockRejectedValue(new Error(errorMessage))

--- a/src/client/tests/unit/useDeletePresentation.test.js
+++ b/src/client/tests/unit/useDeletePresentation.test.js
@@ -1,0 +1,162 @@
+import { renderHook, act } from "@testing-library/react"
+import { useDispatch } from "react-redux"
+import { useNavigate } from "react-router-dom"
+import useDeletePresentation from "../../components/utils/useDeletePresentation"
+import { useCustomToast } from "../../components/utils/toastUtils"
+import { deletePresentation } from "../../redux/presentationReducer"
+
+jest.mock("react-redux", () => ({
+  useDispatch: jest.fn(),
+}))
+
+jest.mock("react-router-dom", () => ({
+  useNavigate: jest.fn(),
+}))
+
+jest.mock("../../redux/presentationReducer", () => ({
+  deletePresentation: jest.fn(),
+}))
+
+jest.mock("../../components/utils/toastUtils", () => ({
+  useCustomToast: jest.fn(),
+}))
+
+describe("useDeletePresentation", () => {
+  it("should set the presentation to delete and open the dialog when handleDeletePresentation is called", () => {
+    const dispatch = jest.fn()
+    useDispatch.mockReturnValue(dispatch)
+
+    const { result } = renderHook(() => useDeletePresentation())
+
+    act(() => {
+      result.current.handleDeletePresentation("123")
+    })
+
+    expect(result.current.presentationToDelete).toBe("123")
+    expect(result.current.isDialogOpen).toBe(true)
+  })
+
+  it("should dispatch deletePresentation and show success toast on successful deletion", async () => {
+    const dispatch = jest.fn(() => Promise.resolve())
+    const navigate = jest.fn()
+    const showToast = jest.fn()
+
+    useDispatch.mockReturnValue(dispatch)
+    useNavigate.mockReturnValue(navigate)
+    useCustomToast.mockReturnValue(showToast)
+
+    const { result } = renderHook(() => useDeletePresentation())
+
+    act(() => {
+      result.current.handleDeletePresentation("123")
+    })
+
+    await act(async () => {
+      await result.current.handleConfirmDelete()
+    })
+
+    expect(dispatch).toHaveBeenCalledWith(deletePresentation("123"))
+    expect(showToast).toHaveBeenCalledWith({
+      title: "Presentation deleted",
+      description: "The presentation has been deleted successfully.",
+      status: "success",
+    })
+    expect(navigate).toHaveBeenCalledWith("/home")
+    expect(result.current.isDialogOpen).toBe(false)
+    expect(result.current.presentationToDelete).toBe(null)
+  })
+
+  it("should show error toast on deletion failure", async () => {
+    const dispatch = jest.fn(() => Promise.reject(new Error("Deletion failed")))
+    const showToast = jest.fn()
+
+    useDispatch.mockReturnValue(dispatch)
+    useCustomToast.mockReturnValue(showToast)
+
+    const { result } = renderHook(() => useDeletePresentation())
+
+    act(() => {
+      result.current.handleDeletePresentation("123")
+    })
+
+    await act(async () => {
+      await result.current.handleConfirmDelete()
+    })
+
+    expect(dispatch).toHaveBeenCalledWith(deletePresentation("123"))
+    expect(showToast).toHaveBeenCalledWith({
+      title: "Error",
+      description: "Deletion failed",
+      status: "error",
+    })
+    expect(result.current.isDialogOpen).toBe(false)
+    expect(result.current.presentationToDelete).toBe(null)
+  })
+
+  it("should not perform any action if presentationToDelete is null", async () => {
+    const dispatch = jest.fn()
+    const showToast = jest.fn()
+    const navigate = jest.fn()
+
+    useDispatch.mockReturnValue(dispatch)
+    useCustomToast.mockReturnValue(showToast)
+    useNavigate.mockReturnValue(navigate)
+
+    const { result } = renderHook(() => useDeletePresentation())
+
+    await act(async () => {
+      await result.current.handleConfirmDelete()
+    })
+
+    expect(dispatch).not.toHaveBeenCalled()
+    expect(showToast).not.toHaveBeenCalled()
+    expect(navigate).not.toHaveBeenCalled()
+    expect(result.current.isDialogOpen).toBe(false)
+    expect(result.current.presentationToDelete).toBe(null)
+  })
+
+  it("should show a generic error toast when error message is not provided", async () => {
+    const dispatch = jest.fn(() => Promise.reject(new Error()))
+    const showToast = jest.fn()
+
+    useDispatch.mockReturnValue(dispatch)
+    useCustomToast.mockReturnValue(showToast)
+
+    const { result } = renderHook(() => useDeletePresentation())
+
+    act(() => {
+      result.current.handleDeletePresentation("123")
+    })
+
+    await act(async () => {
+      await result.current.handleConfirmDelete()
+    })
+
+    expect(dispatch).toHaveBeenCalledWith(deletePresentation("123"))
+    expect(showToast).toHaveBeenCalledWith({
+      title: "Error",
+      description: "An error occurred",
+      status: "error",
+    })
+    expect(result.current.isDialogOpen).toBe(false)
+    expect(result.current.presentationToDelete).toBe(null)
+  })
+
+  it("should close the dialog and reset presentationToDelete when handleCancelDelete is called", () => {
+    const { result } = renderHook(() => useDeletePresentation())
+
+    act(() => {
+      result.current.handleDeletePresentation("123")
+    })
+
+    expect(result.current.isDialogOpen).toBe(true)
+    expect(result.current.presentationToDelete).toBe("123")
+
+    act(() => {
+      result.current.handleCancelDelete()
+    })
+
+    expect(result.current.isDialogOpen).toBe(false)
+    expect(result.current.presentationToDelete).toBe(null)
+  })
+})


### PR DESCRIPTION
## #352 : As a user, I want to be able to delete a presentation from the homepage

This pull adds a delete button to each presentation card's top right corner in presentations grid in Home Page view. Earlier, presentations could only be deleted from Edit Mode's "Delete Presentation" button. The existing deletion logic was extracted to it's own custom hook "useDeletePresentation" that could be used in multiple places.

This means a presentation can now be deleted from
- Edit Mode
- Home Page

Also tests were written for the renewed homepage/index.jsx component and for the new utils/useDeletePresentation.js hook. 

### Changes

**`src/client/components/homepage/PresentationsGrid.jsx`**
- Icon button added that calls handleDeletePresentation on click

**`src/client/components/homepage/index.jsx`**
- Added `useDeletePresentation` hook for access to presentation deletion functions
- Added `handleDialogConfirm` function that awaits for presentation deletion in backend, and then filters out the deleted presentation from component state
- Gave `handleDeletePresentation` as a prop to `PresentationsGrid`
- Added `Dialog` component for deletion confirmation

**`src/client/components/presentation/index.jsx`**
- Extracted presentation deletion logic away to useDeletePresentation
- Added useDeletePresentation hook for access to presentation deletion functions

**`src/client/components/utils/useDeletePresentation.js`**
- Created this custom hook so presentation deletion logic can be used wherever this is imported
- No new logic was added, just refactoring the logic away from `presentation/index.jsx`

**`src/client/tests/unit/homepage.test.js`**
- Added new tests for the deletion functionality in `HomePage` component
- Mocking useDeletePresentation
- Removing repetitive code like useNavigate mock in multiple tests to only one place inside `BeforeEach` callback

**`src/client/tests/unit/useDeletePresentation.test.js`**
- Tests for the new custom hook
- 100% branch coverage of this file


