### PR TITLE
Feature/issue 381 remove cue from frontpage infocards

### DIFF
--- a/documentation/architecture/architecture-docs-review.md
+++ b/documentation/architecture/architecture-docs-review.md
@@ -50,6 +50,7 @@
 - Missing files:
   - src/client/services/admin.js
   - src/client/services/presentation.js
+  - src/client/services/users.js
 
 `src/client/components/frontpage/`
 - Missing files:
@@ -66,6 +67,8 @@
   - src/client/components/homepage/PresentationForm.jsx
   - src/client/components/homepage/PresentationFormWrapper.jsx
   - src/client/components/homepage/PresentationsGrid.jsx
+  - src/client/components/homepage/LinkGoogleDriveButton.jsx
+  - src/client/components/homepage/StorageInfoModal.jsx
 - Files that no longer exist:
   - src/client/components/homepage/Body.jsx
   - src/client/components/homepage/Togglable.jsx
@@ -88,6 +91,7 @@
   - src/client/components/presentation/ShowModeButtons.jsx
   - src/client/components/presentation/StatusToolTip.jsx
   - src/client/components/presentation/ToolBox.jsx
+  - src/client/components/presentation/SignInInfoModal.jsx
 - Files that no longer exist:
   - src/client/components/presentation/image.jsx
   - src/client/components/presentation/pdfviewer.jsx
@@ -102,9 +106,12 @@
   - src/server/routes/admin.js
   - src/server/routes/presentation.js
   - src/server/routes/terms.js
+  - src/server/routes/driveProxy.js
+  - src/server/routes/users.js
 
 `src/server/utils/`
 - Missing files:
   - src/server/utils/helper.js
   - src/server/utils/s3.js
   - src/server/utils/verifyToken.js
+  - src/server/utils/drive.js

--- a/src/client/components/frontpage/index.jsx
+++ b/src/client/components/frontpage/index.jsx
@@ -46,14 +46,14 @@ const FrontPage = () => {
             title="Ease of use"
             description="Create a presentation in just a few clicks"
             modalTitle="Ease of use"
-            modalDesc="Add your own images or gifs to the presentation and decide the order of the cues. It's that simple!"
+            modalDesc="Add your own images or gifs to the presentation and decide the order of the elements! It's that simple!"
             modalSvg={<Upload />}
           />
           <InfoCard
             title="Multiple screens"
             description="Control multiple screens at once"
             modalTitle="Multiple screens"
-            modalDesc="Traverse through multiple screens at once using the unique cue system. Control the visuals on the fly with just one device!"
+            modalDesc="Traverse through multiple screens at once using the unique index system. Control the elements on the fly with just one device!"
             modalSvg={<Desktop />}
           />
           <InfoCard


### PR DESCRIPTION
## #381: remove cue from frontpage infocards

Replaced the word cue with indexes and elements to reflect the current workings of the app

### Changes

**`src/client/components/frontpage/index.jsx`**
- removed the word cue