### PR TITLE
Enhancement/issue 438 edit button for individual elements

### DIFF
--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -720,6 +720,8 @@ const EditMode = ({
                 isShowMode={isShowMode}
                 cueIndex={cueIndex}
                 isAudioMuted={isAudioMuted}
+                setSelectedCue = {setSelectedCue}
+                setIsToolboxOpen = {setIsToolboxOpen}
               />
 
               {hoverPosition && !isDragging && (

--- a/src/client/components/presentation/GridLayoutComponent.jsx
+++ b/src/client/components/presentation/GridLayoutComponent.jsx
@@ -97,6 +97,8 @@ const GridLayoutComponent = ({
   isShowMode,
   cueIndex,
   isAudioMuted,
+  setSelectedCue,
+  setIsToolboxOpen
 }) => {
   const showToast = useCustomToast()
   const dispatch = useDispatch()
@@ -161,6 +163,14 @@ const GridLayoutComponent = ({
       }
     }
     setIsDialogOpen(false)
+  }
+
+  const handleEditItem= (cueId) => {
+    const cue = cues.find(
+      (cue) => cue._id === cueId
+    )
+    setSelectedCue(cue)
+    setIsToolboxOpen(true)
   }
 
   /**
@@ -306,6 +316,7 @@ const GridLayoutComponent = ({
                   title="Edit element"
                   onMouseDown={(e) => {
                     e.stopPropagation()
+                    handleEditItem(cue._id)
                   }}
                 />
                 <IconButton

--- a/src/client/components/presentation/GridLayoutComponent.jsx
+++ b/src/client/components/presentation/GridLayoutComponent.jsx
@@ -5,6 +5,7 @@ import {
   CopyIcon,
   RepeatIcon,
   ArrowForwardIcon,
+  EditIcon
 } from "@chakra-ui/icons"
 import GridLayout from "react-grid-layout"
 import "react-grid-layout/css/styles.css"
@@ -313,6 +314,22 @@ const GridLayoutComponent = ({
                         "Click on available places on the grid to paste. Click outside the grid to cancel",
                       status: "success",
                     })
+                  }}
+                />
+                <IconButton
+                  icon={<EditIcon />}
+                  size="xs"
+                  position="absolute"
+                  _hover={{ bg: "orange.500", color: "white" }}
+                  backgroundColor="orange.300"
+                  draggable={false}
+                  zIndex="10"
+                  top="50px"
+                  right="0px"
+                  aria-label={`Edit ${cue.name}`}
+                  title="Edit element"
+                  onMouseDown={(e) => {
+                    e.stopPropagation()
                   }}
                 />
               </>

--- a/src/client/components/presentation/GridLayoutComponent.jsx
+++ b/src/client/components/presentation/GridLayoutComponent.jsx
@@ -293,6 +293,22 @@ const GridLayoutComponent = ({
                   }}
                 />
                 <IconButton
+                  icon={<EditIcon />}
+                  size="xs"
+                  position="absolute"
+                  _hover={{ bg: "orange.500", color: "white" }}
+                  backgroundColor="orange.300"
+                  draggable={false}
+                  zIndex="10"
+                  top="25px"
+                  right="0px"
+                  aria-label={`Edit ${cue.name}`}
+                  title="Edit element"
+                  onMouseDown={(e) => {
+                    e.stopPropagation()
+                  }}
+                />
+                <IconButton
                   icon={<CopyIcon />}
                   size="xs"
                   position="absolute"
@@ -300,7 +316,7 @@ const GridLayoutComponent = ({
                   backgroundColor="gray.500"
                   draggable={false}
                   zIndex="10"
-                  top="25px"
+                  top="50px"
                   right="0px"
                   aria-label={`Copy ${cue.name}`}
                   title="Copy element"
@@ -314,22 +330,6 @@ const GridLayoutComponent = ({
                         "Click on available places on the grid to paste. Click outside the grid to cancel",
                       status: "success",
                     })
-                  }}
-                />
-                <IconButton
-                  icon={<EditIcon />}
-                  size="xs"
-                  position="absolute"
-                  _hover={{ bg: "orange.500", color: "white" }}
-                  backgroundColor="orange.300"
-                  draggable={false}
-                  zIndex="10"
-                  top="50px"
-                  right="0px"
-                  aria-label={`Edit ${cue.name}`}
-                  title="Edit element"
-                  onMouseDown={(e) => {
-                    e.stopPropagation()
                   }}
                 />
               </>
@@ -350,7 +350,7 @@ const GridLayoutComponent = ({
                 backgroundColor="gray.500"
                 draggable={false}
                 zIndex="10"
-                top="50px"
+                top="75px"
                 right="0px"
                 aria-label={`Loop audio ${cue.name}`}
                 title={cue.loop ? "Disable loop" : "Enable loop"}


### PR DESCRIPTION
## [#438](https://github.com/MuViCo/MuViCo/issues/438) Add edit button for individual elements to easier open the edit menu
Adds edit button below the delete button. Copy and loop buttons are moved down. Tested that the buttons work manually.
### Changes
`presentation/GridLayoutComponent.jsx`
- Added orange edit button
- Moved copy and loop buttons down by 25px
- Pressing the edit button opens the tool box (The edit menu) and selects the cue (The element) the clicked edit button is on

`presentation/EditMode.jsx`
- Passes state setters `setSelectedCue` and `setIsToolboxOpen` to GridLayoutComponent