### PR TITLE
Task 437 Center the editing area

### DIFF
--- a/src/client/App.jsx
+++ b/src/client/App.jsx
@@ -1,5 +1,5 @@
 import { ChakraProvider, Box, Container } from "@chakra-ui/react"
-import { Route, Routes, Navigate } from "react-router-dom"
+import { Route, Routes, Navigate, useLocation } from "react-router-dom"
 
 import { useState, useEffect } from "react"
 
@@ -21,6 +21,8 @@ const App = () => {
 
   const [isInitialized, setIsInitialized] = useState(false)
 
+  const isPresentation = useLocation().pathname.startsWith("/presentation")
+
   useEffect(() => {
     const loggedUserJSON = window.localStorage.getItem("user")
     if (loggedUserJSON) {
@@ -39,7 +41,7 @@ const App = () => {
       <Fonts />
       <Box>
         <NavBar user={user} setUser={setUser} />
-        <Container pt={20} maxW="container.xl">
+        <Container pt={20} maxW={isPresentation ? "none" : "container.xl"}>
           <Routes>
             <Route path="/" element={<FrontPage />} />
             <Route

--- a/src/client/components/presentation/index.jsx
+++ b/src/client/components/presentation/index.jsx
@@ -30,6 +30,8 @@ const PresentationPage = ({ user }) => {
   // Fetch presentation info from Redux state
   const presentationInfo = useSelector((state) => state.presentation.cues)
 
+  document.body.style.overflowX = "hidden"
+
   useEffect(() => {
     dispatch(fetchPresentationInfo(id))
   }, [id, navigate, dispatch])


### PR DESCRIPTION
## #437 Center the editing area

Adds css rules based on being in the presentation page that removes the maxWidth of the content's chakra-container element and sets overflow-x of body to hidden.

### Changes

`src/client/App.jsx`

* Now uses `useLocation` from `react-router-dom` to determine if we are inside a presentation, if so, don't set maxWidth for the intial Container.

`src/client/components/presentation/index.jsx`

* Set body `overflow-x`  style to `hidden` on page load.