### PR TITLE
Add current frame to screen title

### DIFF
--- a/e2e/gridlayout.spec.js
+++ b/e2e/gridlayout.spec.js
@@ -41,7 +41,7 @@ describe("GridLayout", () => {
         page.reload()
 
         await addBlankCue(page, "testcue_ver", "2", "2")
-        await expect(page.getByText("Element already exists on screen 2. Do you want to update it?").first()).toBeVisible()
+        await expect(page.getByText("Index 2 element already exists on screen 2. Do you want to replace it?").first()).toBeVisible()
     })
 
     test("user can delete cue", async ({ page }) => {

--- a/e2e/helper.js
+++ b/e2e/helper.js
@@ -13,9 +13,14 @@ const addPresentation = async (page, name) => {
 
 const addBlankCue = async (page, name, index, screen) => {
   await page.getByRole("button", { name: "Add element" }).click()
-  await page.getByTestId("index-number").fill(index)
+  await page.getByTestId("screen-number").fill("") 
+  await page.getByTestId("screen-number").type(screen.toString())
+
+  await page.getByTestId("index-number").fill("")
+  await page.getByTestId("index-number").type(index.toString())
+
   await page.getByTestId("cue-name").fill(name)
-  await page.getByTestId("screen-number").fill(screen)
+
   await page.getByRole("button", { name: "Submit" }).click()
 }
 

--- a/e2e/homepage.spec.js
+++ b/e2e/homepage.spec.js
@@ -56,6 +56,10 @@ describe("Homepage", () => {
     const deleteButton = await page.locator('button:has-text("Delete presentation")')
     await expect(deleteButton).toBeVisible()
     await deleteButton.click()
+
+    const confirmYes = page.getByRole("button", { name: "Yes" })
+    await expect(confirmYes).toBeVisible()
+    await confirmYes.click()
     await expect(card).not.toBeVisible()
   })
   

--- a/e2e/screen.spec.js
+++ b/e2e/screen.spec.js
@@ -1,40 +1,92 @@
 import { loginWith, addPresentation, addBlankCue } from "./helper"
-
-const { test, describe, expect, beforeEach, chromium } = require("@playwright/test")
+const { test, describe, expect, beforeEach } = require("@playwright/test")
 
 describe("Screen", () => {
-
   beforeEach(async ({ page, request }) => {
-    await request.post("http:localhost:8000/api/testing/reset")
-    await request.post("http:localhost:8000/api/signup", {
+    await request.post("http://localhost:8000/api/testing/reset")
+    await request.post("http://localhost:8000/api/signup", {
       data: {
         username: "screentestuser",
         password: "screentest",
       },
     })
+
+    await page.goto("http://localhost:3000/")
+    await loginWith(page, "screentestuser", "screentest")
   })
 
-  test("user can press shift to display screen and cue info", async () => {
-    const browser = await chromium.launch()
-    const context = await browser.newContext()
-    const page1 = await context.newPage()
-    page1.goto("http://localhost:3000/")
-    await expect(page1.getByRole("button", { name: "Login" })).toBeVisible()
-    await loginWith(page1, "screentestuser", "screentest")
-    await addPresentation(page1, "testi")
+  describe("Screen titles")
 
-    await page1.waitForTimeout(2000)
-    page1.goto("http://localhost:3000/home")
-    await page1.getByText("testi").click()
-    await addBlankCue(page1, "test cue", "1", "1")
-    await expect(page1.getByText("Element test cue added to screen").first()).toBeVisible()
-    await page1.getByRole("button", { name: "Show mode" }).click()
-    const pagePromise = context.waitForEvent("page")
-    await page1.getByRole("button", { name: "Open screen: 1" }).click()
-    const page2 = await pagePromise
-    await page1.keyboard.down("Shift")
-    await expect(page2.getByText("Element name: initial element for screen 1")).toBeVisible()
-  })
+    test("screen window title shows screen number and starting frame", async ({ page, context }) => {
+      await addPresentation(page, "title-test")
+
+      await page.goto("http://localhost:3000/home")
+      await page.getByText("title-test").click()
+      await addBlankCue(page, "test cue", "0", "1")
+      await page.getByRole("button", { name: "Show mode" }).click()
+
+      const [popup] = await Promise.all([
+        context.waitForEvent("page"),
+        page.getByRole("button", { name: "Open screen: 1" }).click(),
+      ])
+
+      await expect(popup).toHaveTitle("Screen 1, Starting Frame")
+    })
+
+    test("screen window title shows screen number and the last frame number that has an element", async ({ page, context }) => {
+      await addPresentation(page, "title-test")
+
+      await page.goto("http://localhost:3000/home")
+      await page.getByText("title-test").click()
+      await addBlankCue(page, "test cue", "0", "2")
+      await page.getByRole("button", { name: "Show mode" }).click()
+      for (let i = 0; i < 4; i++) {
+        await page.keyboard.press("ArrowRight")
+      }
+
+      const [popup] = await Promise.all([
+        context.waitForEvent("page"),
+        page.getByRole("button", { name: "Open screen: 2" }).click(),
+      ])
+
+      await expect(popup).toHaveTitle("Screen 2, Starting Frame")
+    })
+
+    test("screen window title shows screen number and the current frame number", async ({ page, context }) => {
+      await addPresentation(page, "title-test")
+
+      await page.goto("http://localhost:3000/home")
+      await page.getByText("title-test").click()
+      await addBlankCue(page, "test cue", "4", "2")
+      await page.getByRole("button", { name: "Show mode" }).click()
+      for (let i = 0; i < 4; i++) {
+        await page.keyboard.press("ArrowRight")
+      }
+
+      const [popup] = await Promise.all([
+        context.waitForEvent("page"),
+        page.getByRole("button", { name: "Open screen: 2" }).click(),
+      ])
+
+      await expect(popup).toHaveTitle("Screen 2, Frame 4")
+    })
+
+    test("open all screens and check titles", async ({ page, context }) => {
+      await addPresentation(page, "title-test")
+
+      await page.goto("http://localhost:3000/home")
+      await page.getByText("title-test").click()
+      await addBlankCue(page, "test cue", "4", "2")
+      await page.getByRole("button", { name: "Show mode" }).click()
+      for (let i = 0; i < 4; i++) {
+        await page.keyboard.press("ArrowRight")
+      }
+
+      const [popup] = await Promise.all([
+        context.waitForEvent("page"),
+        page.getByRole("button", { name: "Open screen: 2" }).click(),
+      ])
+
+      await expect(popup).toHaveTitle("Screen 2, Frame 4")
+    })
 })
-
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -7741,13 +7741,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
-      "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },

--- a/src/client/components/presentation/Screen.jsx
+++ b/src/client/components/presentation/Screen.jsx
@@ -255,9 +255,9 @@ const Screen = ({ screenNumber, screenData, isVisible, onClose }) => {
 
         setPreviousScreenData(currentScreenData)
         setCurrentScreenData(screenData)
-      
+        
       }
-    } windowRef.current.document.title =   `Screen ${screenNumber}` 
+    } windowRef.current.document.title = `Screen ${screenNumber}, ${screenData.index === 0 ? "Starting Frame" : `Frame ${screenData.index}`}` 
   }, [screenData, currentScreenData, isWindowReady])
 
   // Listeners for shift-press to show screen data on screens

--- a/src/client/tests/unit/showmode.test.js
+++ b/src/client/tests/unit/showmode.test.js
@@ -43,6 +43,7 @@ describe("ShowMode", () => {
     window.open = jest.fn(() => {
       const fakeWindow = {
         document: {
+          title: "",
           body: document.createElement("body"),
           head: document.createElement("head"),
         },
@@ -256,5 +257,16 @@ describe("ShowMode", () => {
 
     const button = screen.getByRole("button", { name: /Open screen: 1/i })
     expect(button).toHaveTextContent(/Mirroring screen: 2/)
+  })
+
+  test("when opening screen the title shows the screen and the frame number", async () => {
+    render(<ShowMode cues={mockCues} cueIndex={mockCueIndex} />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Open screen: 1" }))
+
+    await waitFor(() => {
+      const fakeWindow = window.open.mock.results[0].value
+      expect(fakeWindow.document.title).toMatch(/Screen 1/)
+    })
   })
 })


### PR DESCRIPTION
**#451 As a user, I want to see the frame number that an opened screen window is displaying**

This pull request added a feature which show current frame number in the screen title (in addition to the screen number)

**Changes**
`
MuViCo/src/client/components/presentation/Screen.jsx`

updates Screen component's window title

added unit tests and end2end tests to test this functionality , also fixed some old end to end tests
