### PR TITLE
Dynamic frames

### DIFF
--- a/src/client/components/presentation/CuesForm.jsx
+++ b/src/client/components/presentation/CuesForm.jsx
@@ -68,7 +68,7 @@ const CuesForm = ({ addCue, addAudioCue, onClose, position, cues, audioCues = []
   }, [position])
 
   useEffect(() => {
-    if (!cueData) {
+    if (!cueData && !position) {
       if (isAudioMode) {
         const newIndex = getNextAvailableIndex(0, audioCues)
         setIndex(newIndex)

--- a/src/client/components/presentation/CuesForm.jsx
+++ b/src/client/components/presentation/CuesForm.jsx
@@ -230,7 +230,7 @@ const CuesForm = ({ addCue, addAudioCue, onClose, position, cues, audioCues = []
             value={index}
             mb={4}
             min={0}
-            max={indexCount}
+            max={indexCount-1}
             onChange={handleNumericInputChange(setIndex)}
             onBlur={validateAndSetNumber(setIndex, 0, indexCount)}
             required

--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -110,22 +110,45 @@ const EditMode = ({
     }
   }, [isToolboxOpen])
 
-  const handleAddIndex = () => {
+  const handleIndexHasData = async (index) => {
+    setConfirmMessage(
+      `Frame ${index} has existing elements. Deleting this frame will also delete all elements on this frame. Delete anyway?`
+    )
+    setConfirmAction(() => async () => {
+      setIsConfirmOpen(false)
+      await performRemoveIndex(index)
+    })
+    setIsConfirmOpen(true)
+  }
+
+  const handleAddIndex = async () => {
     if (indexCount < 101) {
       setStatus("loading")
       dispatch(incrementIndexCount())
-      dispatch(saveIndexCount({ id, indexCount: indexCount + 1 }))
+      await dispatch(saveIndexCount({ id, indexCount: indexCount + 1 }))
       setStatus("saved")
     }
   }
 
-  const handleRemoveIndex = () => {
+  const handleRemoveIndex = async () => {
+    const lastIndex = indexCount - 1
+    const cuesInIndex = cues.filter(cue => cue.index === lastIndex)
+
+    if (cuesInIndex.length > 0) {
+      handleIndexHasData(lastIndex)
+      return
+    }
+
+    await performRemoveIndex(lastIndex)
+  }
+
+  const performRemoveIndex = async (indexToRemove) => {
     if (indexCount > 1) {
       setStatus("loading")
       dispatch(decrementIndexCount())
-      dispatch(saveIndexCount({ id, indexCount: indexCount - 1 }))
+      await dispatch(saveIndexCount({ id, indexCount: indexToRemove }))
       setStatus("saved")
-    } 
+    }
   }
 
   const handleIncreaseScreenCount = async () => {
@@ -944,6 +967,7 @@ const EditMode = ({
             cueData={selectedCue || null}
             updateCue={updateCue}
             screenCount={presentation.screenCount}
+            indexCount={indexCount}
           />
         </Box>
         <Box

--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -17,7 +17,7 @@ import {
   removeCue,
   updatePresentationSwappedCues,
   incrementIndexCount,
-  decrementIndexCount
+  decrementIndexCount,
   incrementScreenCount,
   decrementScreenCount,
 } from "../../redux/presentationReducer"

--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -701,20 +701,6 @@ const EditMode = ({
 
   return (
     <ChakraProvider theme={theme}>
-      <Button
-            colorScheme="gray"
-            onClick={handleAddIndex}
-            isDisabled={indexCount >= 100}
-          >
-            + Add Frame (to end)
-          </Button>
-          <Button
-            colorScheme="gray"
-            onClick={handleRemoveIndex}
-            isDisabled={indexCount <= 1}
-          >
-            - Remove Frame (from end)
-          </Button>
       <div
         onDrop={handleDrop}
         onDragOver={(e) => e.preventDefault()}
@@ -863,7 +849,7 @@ const EditMode = ({
               <Box
                 className="index-boxes"
                 display="grid"
-                gridTemplateColumns={`repeat(${xLabels.length + 1}, ${columnWidth}px)`}
+                gridTemplateColumns={`repeat(${xLabels.length}, ${columnWidth}px)`}
                 gap={`${gap}px`}
                 position="sticky"
                 top={0}
@@ -889,7 +875,30 @@ const EditMode = ({
                   </Box>
                 ))}
               </Box>
-
+            <Button
+              colorScheme="gray"
+              onClick={handleAddIndex}
+              isDisabled={indexCount >= 100}
+              position="absolute"
+              right="-50px"
+              top="5px"
+              paddingTop="20px"
+              paddingBottom="20px"
+            >
+              +
+            </Button>
+            <Button
+              colorScheme="gray"
+              onClick={handleRemoveIndex}
+              isDisabled={indexCount >= 100}
+              position="absolute"
+              right="-50px"
+              top="55px"
+              paddingTop="20px"
+              paddingBottom="20px"
+            >
+              -
+            </Button>
               <GridLayoutComponent
                 layout={layout}
                 cues={cues}
@@ -935,7 +944,6 @@ const EditMode = ({
             cueData={selectedCue || null}
             updateCue={updateCue}
             screenCount={presentation.screenCount}
-            indexCount={indexCount}
           />
         </Box>
         <Box

--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -7,6 +7,7 @@ import {
   useOutsideClick,
   useColorModeValue,
   IconButton,
+  Button
 } from "@chakra-ui/react"
 import "react-grid-layout/css/styles.css"
 import { useDispatch, useSelector } from "react-redux"
@@ -15,10 +16,12 @@ import {
   createCue,
   removeCue,
   updatePresentationSwappedCues,
+  incrementIndexCount,
+  decrementIndexCount
   incrementScreenCount,
   decrementScreenCount,
 } from "../../redux/presentationReducer"
-import { saveScreenCount } from "../../redux/presentationThunks"
+import { saveIndexCount, saveScreenCount } from "../../redux/presentationThunks"
 import { createFormData } from "../utils/formDataUtils"
 import presentationService from "../../services/presentation"
 import ToolBox from "./ToolBox"
@@ -106,6 +109,24 @@ const EditMode = ({
       setSelectedCue(null)
     }
   }, [isToolboxOpen])
+
+  const handleAddIndex = () => {
+    if (indexCount < 101) {
+      setStatus("loading")
+      dispatch(incrementIndexCount())
+      dispatch(saveIndexCount({ id, indexCount: indexCount + 1 }))
+      setStatus("saved")
+    }
+  }
+
+  const handleRemoveIndex = () => {
+    if (indexCount > 1) {
+      setStatus("loading")
+      dispatch(decrementIndexCount())
+      dispatch(saveIndexCount({ id, indexCount: indexCount - 1 }))
+      setStatus("saved")
+    } 
+  }
 
   const handleIncreaseScreenCount = async () => {
     if (presentation.screenCount >= 8) {
@@ -680,6 +701,20 @@ const EditMode = ({
 
   return (
     <ChakraProvider theme={theme}>
+      <Button
+            colorScheme="gray"
+            onClick={handleAddIndex}
+            isDisabled={indexCount >= 100}
+          >
+            + Add Frame (to end)
+          </Button>
+          <Button
+            colorScheme="gray"
+            onClick={handleRemoveIndex}
+            isDisabled={indexCount <= 1}
+          >
+            - Remove Frame (from end)
+          </Button>
       <div
         onDrop={handleDrop}
         onDragOver={(e) => e.preventDefault()}
@@ -826,8 +861,9 @@ const EditMode = ({
               onClick={handlePaste}
             >
               <Box
+                className="index-boxes"
                 display="grid"
-                gridTemplateColumns={`repeat(${xLabels.length}, ${columnWidth}px)`}
+                gridTemplateColumns={`repeat(${xLabels.length + 1}, ${columnWidth}px)`}
                 gap={`${gap}px`}
                 position="sticky"
                 top={0}

--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -727,6 +727,7 @@ const EditMode = ({
                 isAudioMuted={isAudioMuted}
                 setSelectedCue = {setSelectedCue}
                 setIsToolboxOpen = {setIsToolboxOpen}
+                indexCount={indexCount}
               />
 
               {hoverPosition && !isDragging && (

--- a/src/client/components/presentation/GridLayoutComponent.jsx
+++ b/src/client/components/presentation/GridLayoutComponent.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react"
-import { Box, IconButton, Tooltip, Text } from "@chakra-ui/react" // Ensure Text is imported
+import { Box, IconButton, Tooltip, Text, Button } from "@chakra-ui/react" // Ensure Text is imported
 import {
   DeleteIcon,
   CopyIcon,

--- a/src/client/components/presentation/GridLayoutComponent.jsx
+++ b/src/client/components/presentation/GridLayoutComponent.jsx
@@ -98,7 +98,8 @@ const GridLayoutComponent = ({
   cueIndex,
   isAudioMuted,
   setSelectedCue,
-  setIsToolboxOpen
+  setIsToolboxOpen,
+  indexCount
 }) => {
   const showToast = useCustomToast()
   const dispatch = useDispatch()
@@ -257,9 +258,9 @@ const GridLayoutComponent = ({
     <GridLayout
       className="layout"
       layout={currentLayout}
-      cols={101}
+      cols={indexCount}
       rowHeight={rowHeight}
-      width={101 * columnWidth + (101 - 1) * gap}
+      width={indexCount * columnWidth + (indexCount - 1) * gap}
       isResizable={false}
       compactType={null}
       isBounded={false}

--- a/src/client/components/presentation/ShowMode.jsx
+++ b/src/client/components/presentation/ShowMode.jsx
@@ -4,7 +4,7 @@ import ShowModeButtons from "./ShowModeButtons"
 import KeyboardHandler from "../utils/keyboardHandler"
 
 // ShowMode component
-const ShowMode = ({ cues, cueIndex, setCueIndex }) => {
+const ShowMode = ({ cues, cueIndex, setCueIndex, indexCount }) => {
   // Preload cues once on initialization
   const [preloadedCues, setPreloadedCues] = useState({})
 
@@ -180,6 +180,7 @@ const ShowMode = ({ cues, cueIndex, setCueIndex }) => {
         mirroring={mirroring}
         cueIndex={cueIndex}
         updateCue={updateCue}
+        indexCount={indexCount}
       />
 
       {/* Render screens based on visibility and cue index */}

--- a/src/client/components/presentation/ShowModeButtons.jsx
+++ b/src/client/components/presentation/ShowModeButtons.jsx
@@ -101,13 +101,14 @@ const ScreenToggleButtons = ({
 )
 
 // Component for rendering the cue navigation buttons
-const CueNavigationButtons = ({ cueIndex, updateCue }) => (
+const CueNavigationButtons = ({ cueIndex, updateCue, indexCount }) => (
   <Box display="flex" gap={4} alignItems="center">
     <IconButton
       aria-label="Previous Cue"
       icon={<ChevronLeftIcon />}
       onClick={() => updateCue("Previous")}
       colorScheme="purple"
+      isDisabled={cueIndex === 0}
     />
     
     <Heading size="md">{cueIndex === 0 ? "Starting Frame" : `Frame ${cueIndex}`}</Heading>
@@ -117,6 +118,7 @@ const CueNavigationButtons = ({ cueIndex, updateCue }) => (
       icon={<ChevronRightIcon />}
       onClick={() => updateCue("Next")}
       colorScheme="purple"
+      isDisabled={cueIndex === indexCount - 1}
     />
 
     <Tooltip
@@ -157,6 +159,7 @@ const ShowModeButtons = ({
   mirroring,
   cueIndex,
   updateCue,
+  indexCount,
 }) => (
   <Box display="flex" flexDirection="column" alignItems="center" gap={4} mt={4}>
     <ScreenToggleButtons
@@ -166,7 +169,7 @@ const ShowModeButtons = ({
       showAllScreens={showAllScreens}
       mirroring={mirroring}
     />
-    <CueNavigationButtons cueIndex={cueIndex} updateCue={updateCue} />
+    <CueNavigationButtons cueIndex={cueIndex} updateCue={updateCue} indexCount={indexCount} />
   </Box>
 )
 

--- a/src/client/components/presentation/index.jsx
+++ b/src/client/components/presentation/index.jsx
@@ -27,6 +27,7 @@ const PresentationPage = ({ user }) => {
   const [showMode, setShowMode] = useState(false)
   const [isToolboxOpen, setIsToolboxOpen] = useState(false)
   const [isAudioMuted, setIsAudioMuted] = useState(false)
+  const [status, setStatus] = useState("saved")
 
   // Fetch presentation info from Redux state
   const presentationInfo = useSelector((state) => state.presentation.cues)
@@ -51,15 +52,19 @@ const PresentationPage = ({ user }) => {
 
   const handleAddFrame = () => {
     if (indexCount < 101) {
+      setStatus("loading")
       dispatch(incrementIndexCount())
       dispatch(saveIndexCount({ id, indexCount: indexCount + 1 }))
+      setStatus("saved")
     }
   }
 
   const handleRemoveFrame = () => {
     if (indexCount > 1) {
+      setStatus("loading")
       dispatch(decrementIndexCount())
       dispatch(saveIndexCount({ id, indexCount: indexCount - 1 }))
+      setStatus("saved")
     }
   }
 

--- a/src/client/components/presentation/index.jsx
+++ b/src/client/components/presentation/index.jsx
@@ -1,8 +1,7 @@
 import { useEffect, useState } from "react"
 import { useParams, useNavigate } from "react-router-dom"
 import { Button, Flex, Box, Text } from "@chakra-ui/react"
-import { fetchPresentationInfo, incrementIndexCount, decrementIndexCount } from "../../redux/presentationReducer"
-import { saveIndexCount } from "../../redux/presentationThunks"
+import { fetchPresentationInfo } from "../../redux/presentationReducer"
 import "reactflow/dist/style.css"
 import { useDispatch, useSelector } from "react-redux"
 
@@ -27,7 +26,6 @@ const PresentationPage = ({ user }) => {
   const [showMode, setShowMode] = useState(false)
   const [isToolboxOpen, setIsToolboxOpen] = useState(false)
   const [isAudioMuted, setIsAudioMuted] = useState(false)
-  const [status, setStatus] = useState("saved")
 
   // Fetch presentation info from Redux state
   const presentationInfo = useSelector((state) => state.presentation.cues)
@@ -48,24 +46,6 @@ const PresentationPage = ({ user }) => {
 
   const toggleAudioMute = () => {
     setIsAudioMuted((prevMuted) => !prevMuted)
-  }
-
-  const handleAddFrame = () => {
-    if (indexCount < 101) {
-      setStatus("loading")
-      dispatch(incrementIndexCount())
-      dispatch(saveIndexCount({ id, indexCount: indexCount + 1 }))
-      setStatus("saved")
-    }
-  }
-
-  const handleRemoveFrame = () => {
-    if (indexCount > 1) {
-      setStatus("loading")
-      dispatch(decrementIndexCount())
-      dispatch(saveIndexCount({ id, indexCount: indexCount - 1 }))
-      setStatus("saved")
-    }
   }
 
   useEffect(() => {
@@ -114,20 +94,6 @@ const PresentationPage = ({ user }) => {
                   onClick={() => setIsToolboxOpen(true)}
                 >
                   Add Element
-                </Button>
-                <Button
-                  colorScheme="gray"
-                  onClick={handleAddFrame}
-                  isDisabled={indexCount >= 100}
-                >
-                  + Add Frame (to end)
-                </Button>
-                <Button
-                  colorScheme="gray"
-                  onClick={handleRemoveFrame}
-                  isDisabled={indexCount <= 1}
-                >
-                  - Remove Frame (from end)
                 </Button>
               </>
             )}

--- a/src/client/components/presentation/index.jsx
+++ b/src/client/components/presentation/index.jsx
@@ -115,6 +115,7 @@ const PresentationPage = ({ user }) => {
                 cues={presentationInfo}
                 cueIndex={cueIndex}
                 setCueIndex={setCueIndex}
+                indexCount={indexCount}
               />
             )}
             <EditMode

--- a/src/client/redux/presentationReducer.js
+++ b/src/client/redux/presentationReducer.js
@@ -76,9 +76,9 @@ const presentationSlice = createSlice({
       })
       .addCase(saveIndexCount.fulfilled, (state, action) => {
         state.saving = false
-        if (action.payload.indexCount !== undefined) {
-          state.indexCount = action.payload.indexCount
-        }
+        const newIndexCount = action.payload.indexCount
+        state.indexCount = newIndexCount
+        state.cues = state.cues.filter(cue => cue.index < newIndexCount)
       })
       .addCase(saveIndexCount.rejected, state => {
         state.saving = false

--- a/src/server/tests/presentation_api.test.js
+++ b/src/server/tests/presentation_api.test.js
@@ -261,7 +261,7 @@ describe("test presentation", () => {
     })
   })
 
-  describe.only("PUT /api/presentation/:id/indexCount", () => {
+  describe("PUT /api/presentation/:id/indexCount", () => {
     const validCases = [1, 5, 10, 100]
 
     test.each(validCases)(

--- a/src/server/tests/presentation_api.test.js
+++ b/src/server/tests/presentation_api.test.js
@@ -261,6 +261,39 @@ describe("test presentation", () => {
     })
   })
 
+  describe.only("PUT /api/presentation/:id/indexCount", () => {
+    const validCases = [1, 5, 10, 100]
+
+    test.each(validCases)(
+      "updates indexCount with valid count %i",
+      async (indexCount) => {
+        const response = await setIndexCount(testPresentationId, indexCount)
+        expect(response.status).toBe(200)
+      }
+    )
+
+    const invalidCases = [
+      [0, "indexCount must be between 1 and 100"],
+      [101, "indexCount must be between 1 and 100"],
+      ["asdf", "indexCount must be a number"]
+    ]
+
+    test.each(invalidCases)(
+      "throws error with invalid index count %s",
+      async (indexCount, error) => {
+        const response = await setIndexCount(testPresentationId, indexCount)
+        expect(response.status).toBe(400)
+        expect(response.body.error).toBe(error)
+      }
+    )
+
+    test("throws error with missing id", async () => {
+      const response = await setIndexCount(null, 5)
+      expect(response.status).toBe(500)
+      expect(response.body.error).toBe("Internal server error")
+    })
+  })
+
   describe("PUT /api/presentation/:id/screenCount", () => {
     beforeEach(async () => {
       const user = await User.findOne({ username: "testuser" });


### PR DESCRIPTION
## #433 Dynamic frames

Functionality implements dynamic +/- buttons for adding/removing frames in edit mode with automatic cue removal. 

Frontend changes:
- Added +/- buttons
- Implemented `handleAddIndex` and `handleRemoveIndex -> performRemoveIndex`
- Updated GridLayout to only use existing frames
- Updated ShowMode to not scroll past existing frames

Backend changes:
- Added `PUT /:id/indexCount` endpoint (#490)
- Implemented frame count validation (1-100, number type) (#490)
- Track cues in `src/server/routes/presentation.js` to remove them from the removed frame

Redux state management:
- Added `incrementIndexCount` and `decrementIndexCount` actions (#490)
- Implemented `saveIndexCount` async thunk with cue filtering logic (#490)

Services:
- Added `saveIndexCountApi` function for API communication (#490)

Fixes:
- Re-add tests related to adding frames that were erroneously removed in previous commits