### PR TITLE
Allow pasting to continue after pasting on top of another element

### DIFF
--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -27,6 +27,7 @@ import presentationService from "../../services/presentation"
 import ToolBox from "./ToolBox"
 import GridLayoutComponent from "./GridLayoutComponent"
 import StatusTooltip from "./StatusToolTip"
+import CustomAlert from "../utils/CustomAlert"
 import Dialog from "../utils/AlertDialog"
 import { useCustomToast } from "../utils/toastUtils"
 import { SpeakerIcon, SpeakerMutedIcon } from "../../lib/icons"
@@ -66,6 +67,8 @@ const EditMode = ({
   const [isConfirmOpen, setIsConfirmOpen] = useState(false)
   const [confirmMessage, setConfirmMessage] = useState("")
   const [confirmAction, setConfirmAction] = useState(() => () => {})
+  const [showAlert, setShowAlert] = useState(false)
+  const [alertData, setAlertData] = useState({})
 
   const xLabels = Array.from({ length: indexCount }, (_, index) => 
     index === 0 ? "Starting Frame" : `Frame ${index}`)
@@ -86,15 +89,17 @@ const EditMode = ({
   useOutsideClick({
     ref: containerRef,
     handler: () => {
-      if (isCopied) {
+      if (isCopied && !isConfirmOpen) {
         showToast({
           title: "Cancelled copying",
-          description: "Copying element has been cancelled.",
+          description: "Copying has been cancelled.",
           status: "info",
         })
+        setIsCopied(false)
+        setCopiedCue(null)
+        setShowAlert(false)
+        setAlertData({})
       }
-      setIsCopied(false)
-      setCopiedCue(null)
     },
   })
 
@@ -724,6 +729,10 @@ const EditMode = ({
 
   return (
     <ChakraProvider theme={theme}>
+      <CustomAlert
+        showAlert={showAlert}
+        alertData={alertData}
+      />
       <div
         onDrop={handleDrop}
         onDragOver={(e) => e.preventDefault()}
@@ -939,6 +948,8 @@ const EditMode = ({
                 setSelectedCue = {setSelectedCue}
                 setIsToolboxOpen = {setIsToolboxOpen}
                 indexCount={indexCount}
+                setShowAlert={setShowAlert}
+                setAlertData={setAlertData}
               />
 
               {hoverPosition && !isDragging && (

--- a/src/client/components/presentation/GridLayoutComponent.jsx
+++ b/src/client/components/presentation/GridLayoutComponent.jsx
@@ -99,7 +99,9 @@ const GridLayoutComponent = ({
   isAudioMuted,
   setSelectedCue,
   setIsToolboxOpen,
-  indexCount
+  indexCount,
+  setShowAlert,
+  setAlertData
 }) => {
   const showToast = useCustomToast()
   const dispatch = useDispatch()
@@ -337,11 +339,12 @@ const GridLayoutComponent = ({
                       e.stopPropagation()
                       setIsCopied(true)
                       setCopiedCue(cue)
-                      showToast({
-                        title: `Element ${cue.name} copied`,
+                      setShowAlert(true)
+                      setAlertData({
+                        title: `Copying in progress for element "${cue.name}".`,
                         description:
-                          "Click on available places on the grid to paste. Click outside the grid to cancel",
-                        status: "success",
+                          "Click on available places on the grid to paste. Click outside the grid to cancel.",
+                        status: "info",
                       })
                     }}
                   />

--- a/src/client/components/utils/CustomAlert.jsx
+++ b/src/client/components/utils/CustomAlert.jsx
@@ -1,0 +1,29 @@
+import React from "react"
+import { Slide, Alert, AlertIcon, AlertTitle, AlertDescription, Box } from "@chakra-ui/react"
+
+const CustomAlert = ({ showAlert = false, alertData = {} }) => {
+  const { title = "", description = "", status = "info" } = alertData
+
+  if (!showAlert || !title) return null
+
+  return (
+    <Box position="fixed" bottom="80px" right="20px" zIndex={2000}>
+      <Slide direction="bottom" in={showAlert} style={{ position: "relative" }}>
+        <Alert
+          status={status}
+          borderRadius="md"
+          boxShadow="lg"
+          role="status"
+        >
+          <AlertIcon />
+          <Box flex="1">
+            <AlertTitle>{title}</AlertTitle>
+            <AlertDescription display="block">{description}</AlertDescription>
+          </Box>
+        </Alert>
+      </Slide>
+    </Box>
+  )
+}
+
+export default CustomAlert


### PR DESCRIPTION
#469 Allow pasting to continue after pasting on top of another element

Changes:

`src/client/components/utils/CustomAlert.jsx`

- Added new file for static (non-timed) alert used when copying is in progress

`EditMode.jsx`, `GridLayoutComponent.jsx`

- Set to use the new CustomAlert
- Adjusted `useOutsideClick` to only exit pasting if there is no open confirm dialog