### PR TITLE
Feature merge dev

### DIFF
--- a/src/client/components/presentation/GridLayoutComponent.jsx
+++ b/src/client/components/presentation/GridLayoutComponent.jsx
@@ -14,14 +14,14 @@ import { updatePresentation, removeCue } from "../../redux/presentationReducer"
 import { useCustomToast } from "../utils/toastUtils"
 import Dialog from "../utils/AlertDialog"
 
-const renderElementBasedOnIndex = (currentIndex, cues, cue) => {
+const renderElementBasedOnIndex = (currentIndex, cues, cue, screenCount) => {
   if (cue.index > currentIndex) {
     return false
   } else if (cue.index === currentIndex) {
     return true
   } else if (cue.index < currentIndex) {
     const audioElementIndexes = cues
-      .filter((c) => c.screen === 5)
+      .filter((c) => c.screen === screenCount + 1)
       .map((c) => c.index)
       .sort((a, b) => a - b)
     if (
@@ -37,7 +37,7 @@ const renderElementBasedOnIndex = (currentIndex, cues, cue) => {
   }
 }
 
-const renderMedia = (cue, cueIndex, cues, isShowMode, isAudioMuted) => {
+const renderMedia = (cue, cueIndex, cues, isShowMode, isAudioMuted, screenCount) => {
   if (cue.file.type.startsWith("video/")) {
     return (
       <video
@@ -69,7 +69,7 @@ const renderMedia = (cue, cueIndex, cues, isShowMode, isAudioMuted) => {
   } else if (
     isShowMode &&
     cue.file.type.startsWith("audio/") &&
-    renderElementBasedOnIndex(cueIndex, cues, cue)
+    renderElementBasedOnIndex(cueIndex, cues, cue, screenCount)
   ) {
     return (
       <audio
@@ -101,7 +101,8 @@ const GridLayoutComponent = ({
   setIsToolboxOpen,
   indexCount,
   setShowAlert,
-  setAlertData
+  setAlertData,
+  screenCount
 }) => {
   const showToast = useCustomToast()
   const dispatch = useDispatch()
@@ -184,9 +185,9 @@ const GridLayoutComponent = ({
     if (oldItem.x === newItem.x && oldItem.y === newItem.y) {
       return
     }
-    // y is 4 because screen 1 is 0 in y axis.
-    if (oldItem.y === 4 || newItem.y === 4) {
-      if (!(oldItem.y === 4 && newItem.y === 4)) {
+    
+    if (oldItem.y === screenCount || newItem.y === screenCount) {
+      if (!(oldItem.y === screenCount && newItem.y === screenCount)) {
         showToast({
           title: "Cannot move audio files to or from the audio row",
           description: "Audio files are only meant to be in the audio row.",
@@ -271,7 +272,7 @@ const GridLayoutComponent = ({
       containerPadding={[0, 0]}
       useCSSTransforms={true}
       onDragStop={handlePositionChange}
-      maxRows={Math.max(...cues.map((cue) => cue.screen), 5)}
+      maxRows={Math.max(...cues.map((cue) => cue.screen), screenCount + 1)}
     >
       {cues.map((cue) => (
         <div
@@ -394,7 +395,7 @@ const GridLayoutComponent = ({
               </>
             )}
 
-            {renderMedia(cue, cueIndex, cues, isShowMode, isAudioMuted)}
+            {renderMedia(cue, cueIndex, cues, isShowMode, isAudioMuted, screenCount)}
 
             <Tooltip label={cue.name} placement="top" hasArrow>
               <Text


### PR DESCRIPTION
Bugfix that fixes the bug where audio files didn't stick to the audio screen when adding/deleting visual screens.

Changes in src/client/components/presentation/EditMode.jsx:
When adding or removing a visual screen:

identify audio cues
update the screen count
update backend with new screen count
calculate new position for audio cue
update backend again with cues
update local state
refetch
If new screen, add inital element
If screen deleted, remove all related cues
Changes in src/client/components/presentation/GridLayoutComponent.jsx:
Use screenCount instead of hard coded screen amount