### PR TITLE
Add error message for trying to add visual elements to audio screen

### DIFF
--- a/src/client/components/presentation/CuesForm.jsx
+++ b/src/client/components/presentation/CuesForm.jsx
@@ -147,10 +147,17 @@ const CuesForm = ({ addCue, addAudioCue, onClose, position, cues, audioCues = []
       return
     }
 
-    if (isAudioMode && !isAudioFile() || isBlankImage) {
-      setError("Please select a valid audio file for the audio cue")
-      setTimeout(() => setError(null), 5000)
-      return
+    if (isAudioMode || screen === screenCount + 1) {
+      if (isBlankImage) {
+        setError("Blank elements are not allowed on the audio screen")
+        setTimeout(() => setError(null), 5000)
+        return
+      }
+      if (!isAudioFile()) {
+        setError("Please select a valid audio file for the audio cue")
+        setTimeout(() => setError(null), 5000)
+        return
+      }
     }
 
     if (isAudioMode && addAudioCue) {


### PR DESCRIPTION
Added error messages that tell the user that visual elements or blank elements cannot be added to audio screen. Added a ref (fileInputRef) for hidden file input. Now when changing between chosen files when adding a new element (e.g. first choose audio file, then choose blank element instead (which is not allowed), then delete the blank element and add the audio file again) the file names are cleared.