### PR TITLE
Fixed the 2 bugs related to copying frames

### DIFF
--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -340,6 +340,19 @@ const EditMode = ({
   const handlePaste = async (event) => {
     if (!isCopied || !copiedCue) return
 
+    if (event.target.closest(".x-index-label")) {
+      setIsCopied(false)
+      setCopiedCue(null)
+      setShowAlert(false)
+      setAlertData({})
+      showToast({
+        title: "Cancelled copying",
+        description: "Copying has been cancelled.",
+        status: "info",
+      })
+      return
+    }
+
     if (!containerRef?.current) {
       console.error("Container ref is not available")
       return
@@ -353,11 +366,27 @@ const EditMode = ({
       gap
     )
 
+    if (yIndex < 1 || yIndex > presentation.screenCount + 1 || xIndex < 0 || xIndex >= indexCount) {
+      setIsCopied(false)
+      setCopiedCue(null)
+      setShowAlert(false)
+      setAlertData({})
+      showToast({
+        title: "Cancelled copying",
+        description: "Copying has been cancelled.",
+        status: "info",
+      })
+      return
+    }
+
     if (xIndex === copiedCue.index && yIndex === copiedCue.screen) {
       return
-    } else if (
-      (yIndex === 5 && copiedCue.screen !== 5) ||
-      (copiedCue.screen === 5 && yIndex !== 5)
+    } 
+    
+    const audioRowIndex = presentation.screenCount + 1
+    if (
+      (yIndex === audioRowIndex && copiedCue.screen !== audioRowIndex) ||
+      (copiedCue.screen === audioRowIndex && yIndex !== audioRowIndex)
     ) {
       showToast({
         title: "Only audio files on the audio row.",
@@ -410,7 +439,7 @@ const EditMode = ({
     if (
       !cueExists &&
       xIndex >= 0 &&
-      xIndex <= indexCount &&
+      xIndex < indexCount &&
       yIndex <= presentation.screenCount + 1 &&
       yIndex >= 1
     ) {
@@ -598,7 +627,7 @@ const EditMode = ({
       return
     }
 
-    if (xIndex < 0 || xIndex > indexCount) {
+    if (xIndex < 0 || xIndex >= indexCount) {
       return
     }
 


### PR DESCRIPTION
https://github.com/MuViCo/MuViCo/issues/518 and https://github.com/MuViCo/MuViCo/issues/526 
Fixed a bug that raised an error when clicked a frame box when copying. 
Fixed a bug that didn't allow pasting to screens 5+

Changes
`presentation/EditMode.jsx`

- Modified the valid grid area to only include elements of the correct type
- Added a frame label detection to detect when you are clicking frame boxes or screens.

