### PR TITLE
Autoplay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ dist-ssr
 /playwright/.cache/
 
 /src/server/utils/serviceAccountKey.json
+
+# Playwright
+/playwright/.auth/

--- a/e2e/screen.spec.js
+++ b/e2e/screen.spec.js
@@ -15,7 +15,7 @@ describe("Screen", () => {
     await loginWith(page, "screentestuser", "screentest")
   })
 
-  describe("Screen titles")
+  describe("Screen titles", () => {
 
     test("screen window title shows screen number and starting frame", async ({ page, context }) => {
       await addPresentation(page, "title-test")
@@ -89,4 +89,5 @@ describe("Screen", () => {
 
       await expect(popup).toHaveTitle("Screen 2, Frame 4")
     })
+})
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "@babel/preset-env": "^7.26.9",
         "@babel/preset-react": "^7.26.3",
         "@eslint/compat": "^1.2.7",
-        "@playwright/test": "^1.51.0",
+        "@playwright/test": "^1.56.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.2.0",
         "@testing-library/user-event": "^14.6.1",
@@ -5092,13 +5092,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.0.tgz",
-      "integrity": "sha512-dJ0dMbZeHhI+wb77+ljx/FeC8VBP6j/rj9OAojO08JI80wTZy6vRk9KvHKiDCUh4iMpEiseMgqRBIeW+eKX6RA==",
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
+      "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.51.0"
+        "playwright": "1.56.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -14745,12 +14745,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.0.tgz",
-      "integrity": "sha512-442pTfGM0xxfCYxuBa/Pu6B2OqxqqaYq39JS8QDMGThUvIOCd6s0ANDog3uwA0cHavVlnTQzGCN7Id2YekDSXA==",
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
+      "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.51.0"
+        "playwright-core": "1.56.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -14763,9 +14763,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.0.tgz",
-      "integrity": "sha512-x47yPE3Zwhlil7wlNU/iktF7t2r/URR3VLbH6EknJd/04Qc/PSJ0EY3CMXipmglLG+zyRxW6HNo2EGbKLHPWMg==",
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
+      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@babel/preset-env": "^7.26.9",
     "@babel/preset-react": "^7.26.3",
     "@eslint/compat": "^1.2.7",
-    "@playwright/test": "^1.51.0",
+    "@playwright/test": "^1.56.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^14.6.1",

--- a/src/client/components/data/presentationPageData.js
+++ b/src/client/components/data/presentationPageData.js
@@ -121,9 +121,21 @@ export const showModeFeaturesData = [
     title:
       "Screen selection (purple buttons on the top labeled Open screen 1, Open screen 2, etc.)",
     items: [
-      "You can display a specific screen by clicking the Open screen button. An adjacent arrow opens a dropdown where you can mirror another screen's elements, ensuring that if a monitor fails during a presentation, those elements remain visible on another screen.",
+      "You can display a specific screen by clicking the Open screen button or open them all at the same time clicking Open all Screens button. An adjacent arrow opens a dropdown where you can mirror another screen's elements, ensuring that if a monitor fails during a presentation, those elements remain visible on another screen.",
       "Note that the audio row cannot be opened. The presentation's audio will play on the speaker corresponding to its index, as specified on the controlling computer's output device.",
     ],
+  },
+  {
+    title:
+      "Autoplay",
+    items: [
+      "Autoplay allows you to automatically progress through the frames at a set interval.",
+      "Each frame is displayed for the number of seconds you enter in the box.",
+      "Open the wanted screens and click “Start Autoplay” to begin playing the frames automatically.  Autoplay always starts from the Starting Frame.",
+      "You can also switch the frames manually and change the sec/frame during the Autoplay.",
+      "Autoplay stops automatically after the last frame.",
+      "You can stop it manually at anytime by clicking “Stop Autoplay.”"
+    ]
   },
   {
     title: "Help button",

--- a/src/client/components/presentation/Screen.jsx
+++ b/src/client/components/presentation/Screen.jsx
@@ -258,9 +258,8 @@ const Screen = ({ screenNumber, screenData, isVisible, onClose }) => {
 
         setPreviousScreenData(currentScreenData)
         setCurrentScreenData(screenData)
-        
       }
-    } windowRef.current.document.title = `Screen ${screenNumber}, ${screenData.index === 0 ? "Starting Frame" : `Frame ${screenData.index}`}` 
+    } windowRef.current.document.title = `Screen ${screenNumber} • ${screenData.index === 0 ? "Starting Frame" : `Frame ${screenData.index}`}` 
   }, [screenData, currentScreenData, isWindowReady])
 
   // Listeners for shift-press to show screen data on screens

--- a/src/client/components/presentation/ShowMode.jsx
+++ b/src/client/components/presentation/ShowMode.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react"
+import React, { useState, useEffect, useCallback, useRef } from "react"
 import Screen from "./Screen"
 import ShowModeButtons from "./ShowModeButtons"
 import KeyboardHandler from "../utils/keyboardHandler"
@@ -18,6 +18,9 @@ const ShowMode = ({ cues, cueIndex, setCueIndex, indexCount }) => {
   })
 
   const [mirroring, setMirroring] = useState({})
+  const [isAutoplaying, setIsAutoplaying] = useState(false)
+  const [autoplayInterval, setAutoplayInterval] = useState(5)
+  const autoplayTimerRef = useRef(null)
 
   useEffect(() => {
     const preloadImage = (url) => {
@@ -167,6 +170,46 @@ const ShowMode = ({ cues, cueIndex, setCueIndex, indexCount }) => {
     return {}
   }
 
+  useEffect(() => {
+    if (isAutoplaying) {
+      autoplayTimerRef.current = setInterval(() => {
+        setCueIndex((prevIndex) => {
+          if (prevIndex < indexCount - 1) {
+            return prevIndex + 1
+          } else {
+            setIsAutoplaying(false)
+            return prevIndex
+          }
+        })
+      }, autoplayInterval * 1000)
+    } else {
+      if (autoplayTimerRef.current) {
+        clearInterval(autoplayTimerRef.current)
+      }
+    }
+    return () => {
+      if (autoplayTimerRef.current) {
+        clearInterval(autoplayTimerRef.current)
+      }
+    }
+  }, [isAutoplaying, autoplayInterval, indexCount, setCueIndex])
+
+
+  const toggleAutoplay = () => {
+    setIsAutoplaying(prev => {
+      const next = !prev
+      if (next) {
+        setCueIndex(0)
+      }
+      return next
+    })
+  }
+
+  const toggleAutoplayInterval = (valueString) => {
+      setAutoplayInterval(Number(valueString))
+  }
+
+
   return (
     <div className="show-mode">
       {/* Pass screen visibility and cue navigation to ShowModeButtons */}
@@ -184,6 +227,10 @@ const ShowMode = ({ cues, cueIndex, setCueIndex, indexCount }) => {
         cueIndex={cueIndex}
         updateCue={updateCue}
         indexCount={indexCount}
+        autoplayInterval={autoplayInterval}
+        toggleAutoplay={toggleAutoplay}
+        isAutoplaying={isAutoplaying}
+        toggleAutoplayInterval={toggleAutoplayInterval}
       />
 
       {/* Render screens based on visibility and cue index */}

--- a/src/client/components/presentation/ShowModeButtons.jsx
+++ b/src/client/components/presentation/ShowModeButtons.jsx
@@ -11,6 +11,12 @@ import {
   MenuButton,
   MenuList,
   MenuItem,
+  NumberInput,
+  NumberInputField,
+  NumberInputStepper,
+  NumberIncrementStepper,
+  NumberDecrementStepper,
+  Text,
 } from "@chakra-ui/react"
 import {
   QuestionIcon,
@@ -50,6 +56,61 @@ const DropdownButton = ({ screenNumber, screens, toggleScreenMirroring }) => (
   </Menu>
 )
 
+
+const AutoplayControls = ({
+  autoplayInterval, 
+  toggleAutoplay,
+  isAutoplaying,
+  toggleAutoplayInterval,
+}) => {
+
+  return (
+    <Box display="flex" alignItems="center" gap="10px">
+      <Button colorScheme={isAutoplaying ? "red" : "blue"} onClick={toggleAutoplay}>
+        {isAutoplaying ? "Stop Autoplay" : "Start Autoplay"}
+      </Button>
+      <NumberInput id="autoplaytime"
+       value={autoplayInterval} width="70px" onChange={(valueString) => toggleAutoplayInterval(valueString)} >
+        <NumberInputField placeholder="sec" />
+        <NumberInputStepper>
+          <NumberIncrementStepper />
+          <NumberDecrementStepper />
+        </NumberInputStepper>
+      </NumberInput>
+    <Text fontSize="sm" fontWeight="bold">sec / frame</Text>
+    <Tooltip
+      label={
+          <>
+            <b>Autoplay</b>
+            <br /><br />
+            Each frame is displayed for the number of seconds you enter in the box.
+            <br /><br />
+            Open the wanted screens and click “Start Autoplay” to begin playing the frames automatically.  
+            Autoplay always starts from the Starting Frame.
+            <br /><br />
+            You can also switch the frames manually and change the sec/frame during the Autoplay.
+            <br /><br />
+            Autoplay stops automatically after the last frame.
+            You can stop it manually at anytime by clicking “Stop Autoplay.”
+            </>
+      }
+      placement="top"
+      fontSize="sm"
+    >
+      <IconButton
+        aria-label="Keyboard Shortcuts"
+        icon={<QuestionIcon />}
+        size="lg"
+        variant="ghost"
+        colorScheme="purple"
+      />
+    </Tooltip>
+
+
+    </Box>
+  )
+}
+
 const ScreenToggleButtons = ({
   screens,
   toggleScreenVisibility,
@@ -71,7 +132,7 @@ const ScreenToggleButtons = ({
       >
         {hasOpenScreen ? "Close all screens" : "Open all screens"}
       </Button>
-      <Box display="flex" flexWrap="wrap" gap={2}>
+    <Box display="flex" flexWrap="wrap" gap={2}>
     {Object.keys(screens)
       .filter((screenNumber) => screenNumber !== "5")
       .map((screenNumber) => (
@@ -109,6 +170,7 @@ const ScreenToggleButtons = ({
 // Component for rendering the cue navigation buttons
 const CueNavigationButtons = ({ cueIndex, updateCue, indexCount }) => (
   <Box display="flex" gap={4} alignItems="center">
+
     <IconButton
       aria-label="Previous Cue"
       icon={<ChevronLeftIcon />}
@@ -126,6 +188,7 @@ const CueNavigationButtons = ({ cueIndex, updateCue, indexCount }) => (
       colorScheme="purple"
       isDisabled={cueIndex === indexCount - 1}
     />
+
 
     <Tooltip
       label={
@@ -156,6 +219,8 @@ const CueNavigationButtons = ({ cueIndex, updateCue, indexCount }) => (
   </Box>
 )
 
+
+
 // ShowModeButtons component to handle screen visibility and cue navigation
 const ShowModeButtons = ({
   screens,
@@ -166,6 +231,10 @@ const ShowModeButtons = ({
   cueIndex,
   updateCue,
   indexCount,
+  autoplayInterval,
+  toggleAutoplay,
+  isAutoplaying,
+  toggleAutoplayInterval
 }) => (
   <Box display="flex" flexDirection="column" alignItems="center" gap={4} mt={4}>
     <ScreenToggleButtons
@@ -174,6 +243,12 @@ const ShowModeButtons = ({
       toggleScreenMirroring={toggleScreenMirroring}
       toggleAllScreens={toggleAllScreens}
       mirroring={mirroring}
+    />
+    <AutoplayControls
+      autoplayInterval={autoplayInterval}
+      toggleAutoplay={toggleAutoplay}
+      isAutoplaying={isAutoplaying}
+      toggleAutoplayInterval={toggleAutoplayInterval}
     />
     <CueNavigationButtons cueIndex={cueIndex} updateCue={updateCue} indexCount={indexCount} />
   </Box>

--- a/src/client/tests/unit/presentation.test.js
+++ b/src/client/tests/unit/presentation.test.js
@@ -1,4 +1,7 @@
+import { render, screen } from "@testing-library/react"
+import { ChakraProvider } from "@chakra-ui/react"
 import presentation from "../../services/presentation"
+import PresentationManual from "../../components/presentation/PresentationManual"
 import "@testing-library/jest-dom"
 
 
@@ -78,4 +81,16 @@ describe("services tests", () => {
     expect(response).toEqual({ screenCount: 2, removedCuesCount: 3 })
     expect(saveScreenCountApi).toHaveBeenCalledWith("presentation-id", 2)
   })
+  describe("PresentationManual", () => {
+  test("Checks that the presentation returns first sentence", () => {
+    render(
+      <ChakraProvider>
+        <PresentationManual />
+      </ChakraProvider>
+    )
+
+    expect(screen.getByText(/Welcome to the user manual/i)).toBeInTheDocument()
+ 
+  })
+})
 })


### PR DESCRIPTION
#533 As a user I can use autoplay to show the presentation

Added a feature where you dont need to manually change the frames during show. 
Choose how many seconds you want each frame to be displayed, open wanted screen(s) and click "Start Autoplay". 
You can change the seconds or frame during the autoplay. You can stop it using Stop Autoplay button, or wait as  autoplay automatically stops when reached to the last frame.

**Changes:**
**src/client/components/presentation/ShowMode.jsx**

- Add useStates for seconds in autoplay and if autoplay is on or off
- Add functions to handle the things metntioned above
- Add logic to autoplay

**src/client/components/presentation/ShowModeButtons.jsx**
- Button for autoplay
- Number input field for seconds 
- Tooltip box for instructions next to the autoplay button

**src/client/components/presentation/Screen.jsx**
- change `Screen ${screenNumber},  ${screenData.index` to this 'Screen ${screenNumber} • ${screenData.index}' (Shows on top of the open screens)

**src/client/components/data/presentationPageData.js**
Updated Presentation manual with Autoplay instructions


**_Tests:_**
**src/client/tests/unit/showmode.test.js**
- Tests for autoplay

**src/client/tests/unit/presentation.test.js**
- One test to test the presentation manual functions


