### PR TITLE
Fix inconsistent MuViCo and Logout button fonts

### DIFF
--- a/src/client/components/presentation/CuesForm.jsx
+++ b/src/client/components/presentation/CuesForm.jsx
@@ -11,8 +11,6 @@ import {
   Heading,
   Divider,
   Tooltip,
-  ChakraProvider,
-  extendTheme,
   Select
 } from "@chakra-ui/react"
 import { CheckIcon, CloseIcon, InfoOutlineIcon } from "@chakra-ui/icons"
@@ -24,7 +22,6 @@ import {
   getNextAvailableIndex,
 } from "../utils/numberInputUtils"
 
-const theme = extendTheme({})
 
 const CuesForm = ({ addCue, addAudioCue, onClose, position, cues, audioCues = [], cueData, updateCue, screenCount, isAudioMode = false, indexCount }) => {
   const [file, setFile] = useState("")
@@ -225,7 +222,6 @@ const CuesForm = ({ addCue, addAudioCue, onClose, position, cues, audioCues = []
   }
 
   return (
-    <ChakraProvider theme={theme}>
       <form onSubmit={cueData ? handleUpdateSubmit : onAddCue}>
         <FormControl as="fieldset">
           {cueData ? (
@@ -392,7 +388,6 @@ const CuesForm = ({ addCue, addAudioCue, onClose, position, cues, audioCues = []
           Submit
         </Button>
       </form>
-    </ChakraProvider>
   )
 }
 

--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -2,8 +2,6 @@ import React, { useState, useRef, useCallback, useEffect } from "react"
 import {
   Box,
   Text,
-  ChakraProvider,
-  extendTheme,
   useOutsideClick,
   useColorModeValue,
   IconButton,
@@ -41,7 +39,7 @@ import { useCustomToast } from "../utils/toastUtils"
 import { SpeakerIcon, SpeakerMutedIcon } from "../../lib/icons"
 import { AddIcon, ChevronDownIcon, MinusIcon } from "@chakra-ui/icons"
 
-const theme = extendTheme({})
+
 
 const EditMode = ({
   id,
@@ -960,7 +958,7 @@ const EditMode = ({
   )
 
   return (
-    <ChakraProvider theme={theme}>
+    <>
       <CustomAlert
         showAlert={showAlert}
         alertData={alertData}
@@ -1301,7 +1299,7 @@ const EditMode = ({
           message={confirmMessage}
         />
       </div>
-    </ChakraProvider>
+    </>
   )
 }
 


### PR DESCRIPTION
From both files **ChakraProvider** and **extendTheme** imports were removed, since they caused the MuViCo-button and Logout-button to look inconsistent compared to other pages' button fonts.