### PR TITLE
Automatically fill element name in form when adding a file/blank

### DIFF
--- a/src/client/components/presentation/CuesForm.jsx
+++ b/src/client/components/presentation/CuesForm.jsx
@@ -358,12 +358,12 @@ const CuesForm = ({ addCue, addAudioCue, onClose, position, cues, audioCues = []
               </>
             ))}
           {error && <Error error={error} />}
-          <FormHelperText mb={2}>or add blank element</FormHelperText>
+          <FormHelperText mb={2}>or select a blank element</FormHelperText>
           <Select
             data-testid="add-blank"
             value={file}
             onChange={blankSelected}
-            placeholder="Add blank"
+            placeholder="Select blank"
           >
             <option value="/blank.png" style={{backgroundColor: "black", color: "white"}}>Black</option>
             <option value="/blank-white.png" style={{backgroundColor: "white", color: "black"}}>White</option>

--- a/src/client/tests/unit/cues.test.js
+++ b/src/client/tests/unit/cues.test.js
@@ -24,8 +24,8 @@ describe("CuesForm new element", () => {
     )
     expect(foundScreenText).toBe(true)
     expect(screen.getAllByText("Upload media")).toHaveLength(2)
-    expect(screen.getByText("or add blank element")).toBeInTheDocument()
-    expect(screen.getByText("Add blank")).toBeInTheDocument()
+    expect(screen.getByText("or select a blank element")).toBeInTheDocument()
+    expect(screen.getByText("Select blank")).toBeInTheDocument()
     expect(screen.getByText("Submit")).toBeInTheDocument()
   })
 


### PR DESCRIPTION
## [Issue #467](https://github.com/MuViCo/MuViCo/issues/467) As a user, I don't have to name an element I add 

New element form automatically fills element name when adding a file or choosing a blank. Uses file name as the element name when uploading a file and "Blank" when choosing a blank. Also updates the name when changing the file and when going between files and blanks if the field contains "Blank", the previous file name, or is empty. Does not change if anything else has been entered. User could manually enter "Blank" though and it would still update with the next change but I think this is fine to keep the logic simple.

### Changes
`presentation/CuesForm.jsx`
- Refactor blank selection onChange event handler.
- Set element name to file name when selecting a file if element name field is empty or contains previous file name or "Blank".
- Set element name to "Blank" when choosing a blank if element name field is empty or contains previous file name.
- Change "Add blank" in form to "Select blank"

`tests/unit/cues.test.js`
- Add tests testing the automatic element name updates.
- Update render test to match "Select blank" strings
