### PR TITLE
Add color to and adjust placement of element button

### DIFF
--- a/src/client/components/presentation/GridLayoutComponent.jsx
+++ b/src/client/components/presentation/GridLayoutComponent.jsx
@@ -208,11 +208,14 @@ const GridLayoutComponent = ({
         as={IconButton}
         aria-label='Options'
         icon={<ChevronDownIcon />}
+        backgroundColor="var(--chakra-colors-gray-700)" 
+        _hover={{ backgroundColor: "var(--chakra-colors-gray-600)" }}  
+        _active={{ backgroundColor: "var(--chakra-colors-gray-600)" }} 
         variant='outline'
         position="absolute"
         zIndex="10"
-        top="0px"
-        right="0px"
+        top="3px"
+        right="3px"
         size="xs"
       />
       <Portal>


### PR DESCRIPTION
Adds color to element button so it's also visible on white elements, also slightly adjusts placement of the button.
Issue [#561](https://github.com/MuViCo/MuViCo/issues/561) Add background color to element menu button