### PR TITLE
Add more tests

### DIFF
--- a/setup-jest.js
+++ b/setup-jest.js
@@ -22,4 +22,3 @@ if (typeof window !== 'undefined') {
     })),
   })
 }
-

--- a/src/client/redux/presentationReducer.js
+++ b/src/client/redux/presentationReducer.js
@@ -60,13 +60,17 @@ const presentationSlice = createSlice({
       state.indexCount += 1
     },
     decrementIndexCount(state) {
-      state.indexCount -= 1
+      if (state.indexCount > 1) {
+        state.indexCount -= 1
+      }
     },
     incrementScreenCount(state) {
       state.screenCount += 1
     },
     decrementScreenCount(state) {
-      state.screenCount -= 1
+       if (state.screenCount > 1) {
+         state.screenCount -= 1
+       }
     },
   },
   extraReducers: builder => {

--- a/src/client/tests/unit/linkGoogleDriveButton.test.js
+++ b/src/client/tests/unit/linkGoogleDriveButton.test.js
@@ -1,0 +1,405 @@
+/**
+ * @jest-environment jsdom
+ */
+import "@testing-library/jest-dom"
+import React from "react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { ChakraProvider } from "@chakra-ui/react"
+import LinkGoogleDriveButton from "../../components/homepage/LinkGoogleDriveButton"
+import { auth } from "../../components/utils/firebase"
+import userService from "../../services/users"
+import * as firebaseAuth from "firebase/auth"
+
+// Mock dependencies
+jest.mock("../../components/utils/firebase")
+jest.mock("../../services/users")
+jest.mock("firebase/auth")
+jest.mock("../../components/utils/toastUtils", () => ({
+  useCustomToast: () => jest.fn(),
+}))
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store = {}
+
+  return {
+    getItem: jest.fn((key) => store[key] || null),
+    setItem: jest.fn((key, value) => {
+      store[key] = value.toString()
+    }),
+    removeItem: jest.fn((key) => {
+      delete store[key]
+    }),
+    clear: jest.fn(() => {
+      store = {}
+    }),
+  }
+})()
+
+Object.defineProperty(window, "localStorage", {
+  value: localStorageMock,
+})
+
+const renderComponent = (props = {}) => {
+  return render(
+    <ChakraProvider>
+      <LinkGoogleDriveButton {...props} />
+    </ChakraProvider>
+  )
+}
+
+describe("LinkGoogleDriveButton", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    localStorageMock.clear()
+  })
+
+  test("renders the button with correct text", () => {
+    renderComponent()
+
+    expect(screen.getByText("Link Google Drive")).toBeInTheDocument()
+  })
+
+  test("renders Google icon", () => {
+    renderComponent()
+
+    const svg = screen.getByRole("button").querySelector("svg")
+    expect(svg).toBeInTheDocument()
+  })
+
+  test("handles successful Google Drive linking", async () => {
+    const driveToken = "test-drive-access-token"
+    const mockUser = {
+      id: "user-123",
+      username: "testuser",
+      driveToken: driveToken,
+    }
+
+    const mockCredential = {
+      accessToken: driveToken,
+    }
+
+    firebaseAuth.signInWithPopup.mockResolvedValue({
+      user: { uid: "firebase-uid" },
+    })
+
+    firebaseAuth.GoogleAuthProvider.credentialFromResult.mockReturnValue(
+      mockCredential
+    )
+
+    userService.linkDrive.mockResolvedValue(mockUser)
+
+    renderComponent()
+
+    const button = screen.getByRole("button")
+    await userEvent.click(button)
+
+    await waitFor(() => {
+      expect(firebaseAuth.signInWithPopup).toHaveBeenCalledWith(
+        auth,
+        expect.any(firebaseAuth.GoogleAuthProvider)
+      )
+    })
+
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      "driveAccessToken",
+      driveToken
+    )
+
+    expect(userService.linkDrive).toHaveBeenCalledWith({
+      driveAccessToken: driveToken,
+    })
+  })
+
+  test("saves drive token to localStorage", async () => {
+    const driveToken = "test-token-123"
+    const mockCredential = {
+      accessToken: driveToken,
+    }
+
+    firebaseAuth.signInWithPopup.mockResolvedValue({
+      user: { uid: "firebase-uid" },
+    })
+
+    firebaseAuth.GoogleAuthProvider.credentialFromResult.mockReturnValue(
+      mockCredential
+    )
+
+    userService.linkDrive.mockResolvedValue({
+      id: "user-123",
+      driveToken: driveToken,
+    })
+
+    renderComponent()
+
+    const button = screen.getByRole("button")
+    await userEvent.click(button)
+
+    await waitFor(() => {
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        "driveAccessToken",
+        driveToken
+      )
+    })
+  })
+
+  test("merges drive token with existing user data in localStorage", async () => {
+    const driveToken = "test-token-abc"
+    const existingUser = {
+      id: "user-123",
+      username: "testuser",
+      email: "test@example.com",
+    }
+
+    const mockCredential = {
+      accessToken: driveToken,
+    }
+
+    localStorageMock.setItem("user", JSON.stringify(existingUser))
+
+    firebaseAuth.signInWithPopup.mockResolvedValue({
+      user: { uid: "firebase-uid" },
+    })
+
+    firebaseAuth.GoogleAuthProvider.credentialFromResult.mockReturnValue(
+      mockCredential
+    )
+
+    userService.linkDrive.mockResolvedValue({
+      ...existingUser,
+      driveToken: driveToken,
+    })
+
+    renderComponent()
+
+    const button = screen.getByRole("button")
+    await userEvent.click(button)
+
+    await waitFor(() => {
+      const savedUser = JSON.parse(localStorageMock.getItem("user"))
+      expect(savedUser).toEqual({
+        ...existingUser,
+        driveToken: driveToken,
+      })
+    })
+  })
+
+  test("calls onDriveLinked callback when provided", async () => {
+    const onDriveLinked = jest.fn()
+    const mockUser = {
+      id: "user-123",
+      username: "testuser",
+      driveToken: "test-token",
+    }
+
+    const mockCredential = {
+      accessToken: "test-token",
+    }
+
+    firebaseAuth.signInWithPopup.mockResolvedValue({
+      user: { uid: "firebase-uid" },
+    })
+
+    firebaseAuth.GoogleAuthProvider.credentialFromResult.mockReturnValue(
+      mockCredential
+    )
+
+    userService.linkDrive.mockResolvedValue(mockUser)
+
+    renderComponent({ onDriveLinked })
+
+    const button = screen.getByRole("button")
+    await userEvent.click(button)
+
+    await waitFor(() => {
+      expect(onDriveLinked).toHaveBeenCalledWith(mockUser)
+    })
+  })
+
+  test("does not call onDriveLinked if it is not a function", async () => {
+    const mockCredential = {
+      accessToken: "test-token",
+    }
+
+    firebaseAuth.signInWithPopup.mockResolvedValue({
+      user: { uid: "firebase-uid" },
+    })
+
+    firebaseAuth.GoogleAuthProvider.credentialFromResult.mockReturnValue(
+      mockCredential
+    )
+
+    userService.linkDrive.mockResolvedValue({
+      id: "user-123",
+      driveToken: "test-token",
+    })
+
+    // Should not throw error even with invalid callback
+    renderComponent({ onDriveLinked: "not-a-function" })
+
+    const button = screen.getByRole("button")
+    await userEvent.click(button)
+
+    await waitFor(() => {
+      expect(userService.linkDrive).toHaveBeenCalled()
+    })
+  })
+
+  test("adds correct Google scopes", async () => {
+    const mockCredential = {
+      accessToken: "test-token",
+    }
+
+    firebaseAuth.signInWithPopup.mockResolvedValue({
+      user: { uid: "firebase-uid" },
+    })
+
+    firebaseAuth.GoogleAuthProvider.credentialFromResult.mockReturnValue(
+      mockCredential
+    )
+
+    userService.linkDrive.mockResolvedValue({
+      id: "user-123",
+      driveToken: "test-token",
+    })
+
+    renderComponent()
+
+    const button = screen.getByRole("button")
+    await userEvent.click(button)
+
+    await waitFor(() => {
+      // Verify GoogleAuthProvider was instantiated and addScope was called
+      expect(firebaseAuth.GoogleAuthProvider).toHaveBeenCalled()
+    })
+  })
+
+  test("handles Firebase authentication error", async () => {
+    const authError = new Error("Auth failed")
+
+    firebaseAuth.signInWithPopup.mockRejectedValue(authError)
+
+    renderComponent()
+
+    const button = screen.getByRole("button")
+    await userEvent.click(button)
+
+    await waitFor(() => {
+      expect(firebaseAuth.signInWithPopup).toHaveBeenCalled()
+    })
+  })
+
+  test("handles Drive linking API error", async () => {
+    const mockCredential = {
+      accessToken: "test-token",
+    }
+
+    const apiError = new Error("Failed to link drive")
+
+    firebaseAuth.signInWithPopup.mockResolvedValue({
+      user: { uid: "firebase-uid" },
+    })
+
+    firebaseAuth.GoogleAuthProvider.credentialFromResult.mockReturnValue(
+      mockCredential
+    )
+
+    userService.linkDrive.mockRejectedValue(apiError)
+
+    renderComponent()
+
+    const button = screen.getByRole("button")
+    await userEvent.click(button)
+
+    await waitFor(() => {
+      expect(userService.linkDrive).toHaveBeenCalled()
+    })
+  })
+
+  test("button is clickable", async () => {
+    const mockCredential = {
+      accessToken: "test-token",
+    }
+
+    firebaseAuth.signInWithPopup.mockResolvedValue({
+      user: { uid: "firebase-uid" },
+    })
+
+    firebaseAuth.GoogleAuthProvider.credentialFromResult.mockReturnValue(
+      mockCredential
+    )
+
+    userService.linkDrive.mockResolvedValue({
+      id: "user-123",
+      driveToken: "test-token",
+    })
+
+    renderComponent()
+
+    const button = screen.getByRole("button")
+    expect(button).not.toBeDisabled()
+
+    await userEvent.click(button)
+
+    expect(firebaseAuth.signInWithPopup).toHaveBeenCalled()
+  })
+
+  test("extracts credential from Google authentication result", async () => {
+    const driveToken = "credentials-test-token"
+    const mockResult = { user: { uid: "firebase-uid" } }
+    const mockCredential = { accessToken: driveToken }
+
+    firebaseAuth.signInWithPopup.mockResolvedValue(mockResult)
+    firebaseAuth.GoogleAuthProvider.credentialFromResult.mockReturnValue(
+      mockCredential
+    )
+
+    userService.linkDrive.mockResolvedValue({
+      id: "user-123",
+      driveToken,
+    })
+
+    renderComponent()
+
+    const button = screen.getByRole("button")
+    await userEvent.click(button)
+
+    await waitFor(() => {
+      expect(firebaseAuth.GoogleAuthProvider.credentialFromResult).toHaveBeenCalledWith(
+        mockResult
+      )
+    })
+  })
+
+  test("handles when localStorage user is null", async () => {
+    const driveToken = "test-token"
+    const mockCredential = {
+      accessToken: driveToken,
+    }
+
+    localStorageMock.getItem.mockReturnValue(null)
+
+    firebaseAuth.signInWithPopup.mockResolvedValue({
+      user: { uid: "firebase-uid" },
+    })
+
+    firebaseAuth.GoogleAuthProvider.credentialFromResult.mockReturnValue(
+      mockCredential
+    )
+
+    userService.linkDrive.mockResolvedValue({
+      id: "user-123",
+      driveToken,
+    })
+
+    renderComponent()
+
+    const button = screen.getByRole("button")
+    
+    // Should not crash even if user is null in localStorage
+    expect(() => {
+      userEvent.click(button)
+    }).not.toThrow()
+  })
+})

--- a/src/client/tests/unit/presentationReducer.test.js
+++ b/src/client/tests/unit/presentationReducer.test.js
@@ -11,13 +11,23 @@ import reducer, {
   deletePresentation,
   updatePresentation,
   updatePresentationSwappedCues,
+  incrementIndexCount,
+  decrementIndexCount,
   incrementScreenCount,
   decrementScreenCount,
   shiftPresentationIndexes,
 } from "../../redux/presentationReducer.js"
-import { saveScreenCount } from "../../redux/presentationThunks.js"
+import { saveIndexCount, saveScreenCount } from "../../redux/presentationThunks.js"
 import presentationService from "../../services/presentation.js"
 import { configureStore } from "@reduxjs/toolkit"
+
+const originalConsoleLog = console.logICount
+const originalConsoleError = console.error
+
+beforeAll(() => {
+  console.log = jest.fn()
+  console.error = jest.fn()
+})
 
 jest.mock("../../services/presentation.js", () => ({
   get: jest.fn(),
@@ -26,6 +36,7 @@ jest.mock("../../services/presentation.js", () => ({
   remove: jest.fn(),
   updateCue: jest.fn(),
   saveScreenCountApi: jest.fn(),
+  saveIndexCountApi: jest.fn(),
   shiftIndexes: jest.fn(),
 }))
 
@@ -81,6 +92,20 @@ describe("presentationReducer actions", () => {
       payload: updatedCue,
     }
     expect(editCue(updatedCue)).toEqual(expectedAction)
+  })
+
+  it("should create an action to increment index count", () => {
+    const expectedAction = {
+      type: incrementIndexCount.type,
+    }
+    expect(incrementIndexCount()).toEqual(expectedAction)
+  })
+
+  it("should create an action to decrement index count", () => {
+    const expectedAction = {
+      type: decrementIndexCount.type,
+    }
+    expect(decrementIndexCount()).toEqual(expectedAction)
   })
 
   it("should create an action to increment screen count", () => {
@@ -200,6 +225,222 @@ describe("presentationReducer reducer", () => {
     }
 
     expect(reducer(initialStateWithCues, action)).toEqual(expectedState)
+  })
+
+  it("should handle incrementIndexCount", () => {
+    const initialStateWithIndexCount = {
+      ...initialState,
+      indexCount: 3,
+    }
+    const action = { type: incrementIndexCount.type }
+    const expectedState = {
+      ...initialStateWithIndexCount,
+      indexCount: 4,
+    }
+
+    expect(reducer(initialStateWithIndexCount, action)).toEqual(expectedState)
+  })
+
+  it("should handle decrementIndexCount", () => {
+    const initialStateWithIndexCount = {
+      ...initialState,
+      indexCount: 3,
+    }
+    const action = { type: decrementIndexCount.type }
+    const expectedState = {
+      ...initialStateWithIndexCount,
+      indexCount: 2,
+    }
+
+    expect(reducer(initialStateWithIndexCount, action)).toEqual(expectedState)
+  })
+
+  it("should not decrement IndexCount below 1", () => {
+    const initialStateWithMinIndexCount = {
+      ...initialState,
+      indexCount: 1,
+    }
+    const action = { type: decrementIndexCount.type }
+    
+    const result = reducer(initialStateWithMinIndexCount, action)
+    // Verify IndexCount doesn't go below 1
+    expect(result.indexCount).toBeGreaterThanOrEqual(1)
+  })
+
+  it("should handle incrementScreenCount", () => {
+    const initialStateWithScreenCount = {
+      ...initialState,
+      screenCount: 3,
+    }
+    const action = { type: incrementScreenCount.type }
+    const expectedState = {
+      ...initialStateWithScreenCount,
+      screenCount: 4,
+    }
+
+    expect(reducer(initialStateWithScreenCount, action)).toEqual(expectedState)
+  })
+
+  it("should handle decrementScreenCount", () => {
+    const initialStateWithScreenCount = {
+      ...initialState,
+      screenCount: 3,
+    }
+    const action = { type: decrementScreenCount.type }
+    const expectedState = {
+      ...initialStateWithScreenCount,
+      screenCount: 2,
+    }
+
+    expect(reducer(initialStateWithScreenCount, action)).toEqual(expectedState)
+  })
+
+  it("should not decrement screenCount below 1", () => {
+    const initialStateWithMinScreenCount = {
+      ...initialState,
+      screenCount: 1,
+    }
+    const action = { type: decrementScreenCount.type }
+    
+    const result = reducer(initialStateWithMinScreenCount, action)
+    // Verify screenCount doesn't go below 1
+    expect(result.screenCount).toBeGreaterThanOrEqual(1)
+  })
+
+  it("should handle multiple cue additions", () => {
+    let state = initialState
+    
+    const cue1 = { _id: 1, name: "Cue 1" }
+    const cue2 = { _id: 2, name: "Cue 2" }
+    const cue3 = { _id: 3, name: "Cue 3" }
+
+    state = reducer(state, { type: addCue.type, payload: cue1 })
+    state = reducer(state, { type: addCue.type, payload: cue2 })
+    state = reducer(state, { type: addCue.type, payload: cue3 })
+
+    expect(state.cues).toHaveLength(3)
+    expect(state.cues).toContainEqual(cue1)
+    expect(state.cues).toContainEqual(cue2)
+    expect(state.cues).toContainEqual(cue3)
+  })
+
+  it("should handle deletion of specific cue by id", () => {
+    const initialStateWithCues = {
+      ...initialState,
+      cues: [
+        { _id: 1, name: "Cue 1" },
+        { _id: 2, name: "Cue 2" },
+        { _id: 3, name: "Cue 3" },
+      ],
+    }
+    const action = { type: deleteCue.type, payload: 2 }
+    
+    const result = reducer(initialStateWithCues, action)
+    
+    expect(result.cues).toHaveLength(2)
+    expect(result.cues).not.toContainEqual({ _id: 2, name: "Cue 2" })
+    expect(result.cues).toContainEqual({ _id: 1, name: "Cue 1" })
+    expect(result.cues).toContainEqual({ _id: 3, name: "Cue 3" })
+  })
+
+  it("should update correct cue when multiple cues exist", () => {
+    const initialStateWithCues = {
+      ...initialState,
+      cues: [
+        { _id: 1, name: "Cue 1" },
+        { _id: 2, name: "Cue 2" },
+        { _id: 3, name: "Cue 3" },
+      ],
+    }
+    const updatedCue = { _id: 2, name: "Updated Cue 2" }
+    const action = { type: editCue.type, payload: updatedCue }
+    
+    const result = reducer(initialStateWithCues, action)
+    
+    expect(result.cues[1]).toEqual(updatedCue)
+    expect(result.cues[0]).toEqual({ _id: 1, name: "Cue 1" })
+    expect(result.cues[2]).toEqual({ _id: 3, name: "Cue 3" })
+  })
+
+  it("should preserve other state properties when adding cue", () => {
+    const initialStateWithData = {
+      ...initialState,
+      name: "My Presentation",
+      screenCount: 5,
+      indexCount: 10,
+      cues: [{ _id: 1, name: "Existing Cue" }],
+    }
+    const newCue = { _id: 2, name: "New Cue" }
+    const action = { type: addCue.type, payload: newCue }
+    
+    const result = reducer(initialStateWithData, action)
+    
+    expect(result.name).toBe("My Presentation")
+    expect(result.screenCount).toBe(5)
+    expect(result.indexCount).toBe(10)
+    expect(result.cues).toHaveLength(2)
+  })
+
+  it("should clear all data on removePresentation", () => {
+    const initialStateWithData = {
+      cues: [
+        { _id: 1, name: "Cue 1" },
+        { _id: 2, name: "Cue 2" },
+      ],
+      audioCues: [
+        { _id: 1, name: "Audio 1" },
+      ],
+      name: "Test Presentation",
+      screenCount: 4,
+      indexCount: 5,
+      saving: false,
+    }
+    const action = { type: removePresentation.type }
+    
+    const result = reducer(initialStateWithData, action)
+    
+    expect(result.cues).toBeNull()
+    expect(result.audioCues).toEqual([])
+    expect(result.name).toBe("")
+    expect(result.screenCount).toBeNull()
+    expect(result.indexCount).toBeNull()
+  })
+
+  it("should set all presentation properties on setPresentationInfo", () => {
+    const presentationData = {
+      cues: [{ _id: 1, name: "Cue 1", index: 0, screen: 1 }],
+      audioCues: [{ _id: 1, name: "Audio 1", index: 0 }],
+      name: "Full Presentation",
+      screenCount: 5,
+      indexCount: 20,
+    }
+    const action = { type: setPresentationInfo.type, payload: presentationData }
+    
+    const result = reducer(initialState, action)
+    
+    expect(result.cues).toEqual(presentationData.cues)
+    expect(result.audioCues).toEqual(presentationData.audioCues)
+    expect(result.name).toBe("Full Presentation")
+    expect(result.screenCount).toBe(5)
+    expect(result.indexCount).toBe(20)
+  })
+
+  it("should not mutate original state when deleting cue", () => {
+    const originalState = {
+      ...initialState,
+      cues: [
+        { _id: 1, name: "Cue 1" },
+        { _id: 2, name: "Cue 2" },
+      ],
+    }
+    const action = { type: deleteCue.type, payload: 1 }
+    
+    const result = reducer(originalState, action)
+    
+    // Original should remain unchanged
+    expect(originalState.cues).toHaveLength(2)
+    // Result should have 1 less
+    expect(result.cues).toHaveLength(1)
   })
 })
 
@@ -414,31 +655,185 @@ describe("presentationReducer asynchronous actions", () => {
     expect(store.getState().presentation.cues).toContainEqual(secondUpdatedCue)
   })
 
-  it("should handle error in shift presentation indices", async () => {
+  it("should shift presentation indices right", async () => {
     const store = makeStore()
+    
+    const initialState = {
+      cues: [
+        { _id: 1, name: "Cue 1", index: 0 },
+        { _id: 2, name: "Cue 2", index: 2 },
+        { _id: 3, name: "Cue 3", index: 4 }
+      ],
+      name: "My Presentation"
+    }
 
-    presentationService.shiftIndexes.mockRejectedValue({
-      response: { data: { error: "Invalid parameters" } }
+    store.dispatch(setPresentationInfo(initialState))
+
+    const shiftedCues = [
+      { _id: 1, name: "Cue 1", index: 0 },
+      { _id: 2, name: "Cue 2", index: 3 },
+      { _id: 3, name: "Cue 3", index: 5 }
+    ]
+
+    presentationService.shiftIndexes.mockResolvedValue({
+      cues: shiftedCues,
+      name: "My Presentation",
+      id: "123"
     })
+   
+     presentationService.get.mockResolvedValue({
+       cues: shiftedCues,
+       name: "My Presentation",
+       id: "123"
+     })
 
-    await expect(
-      store.dispatch(shiftPresentationIndexes("123", 1, "right"))
-    ).rejects.toThrow("Invalid parameters")
+    await store.dispatch(shiftPresentationIndexes("123", 0, "right"))
 
-    // State should remain unchanged
-    expect(store.getState().presentation).toEqual(store.getState().presentation)
+    expect(presentationService.shiftIndexes).toHaveBeenCalledWith("123", 0, "right")
+    expect(store.getState().presentation.cues).toEqual(shiftedCues)
   })
 
-  it("should handle invalid direction in shift presentation indices", async () => {
+  it("should shift presentation indices left", async () => {
+    const store = makeStore()
+    
+    const initialState = {
+      cues: [
+        { _id: 1, name: "Cue 1", index: 0 },
+        { _id: 2, name: "Cue 2", index: 2 },
+        { _id: 3, name: "Cue 3", index: 4 }
+      ],
+      name: "My Presentation"
+    }
+
+    store.dispatch(setPresentationInfo(initialState))
+
+    const shiftedCues = [
+      { _id: 1, name: "Cue 1", index: 0 },
+      { _id: 2, name: "Cue 2", index: 1 },
+      { _id: 3, name: "Cue 3", index: 3 }
+    ]
+
+    presentationService.shiftIndexes.mockResolvedValue({
+      cues: shiftedCues,
+      name: "My Presentation",
+      id: "123"
+    })
+   
+     presentationService.get.mockResolvedValue({
+       cues: shiftedCues,
+       name: "My Presentation",
+       id: "123"
+     })
+
+    await store.dispatch(shiftPresentationIndexes("123", 1, "left"))
+
+    expect(presentationService.shiftIndexes).toHaveBeenCalledWith("123", 1, "left")
+    expect(store.getState().presentation.cues).toEqual(shiftedCues)
+  })
+
+  it("should update only cues after startIndex when shifting right", async () => {
+    const store = makeStore()
+    
+    const initialState = {
+      cues: [
+        { _id: 1, name: "Cue 1", index: 0 },
+        { _id: 2, name: "Cue 2", index: 1 },
+        { _id: 3, name: "Cue 3", index: 2 }
+      ],
+      name: "My Presentation"
+    }
+
+    store.dispatch(setPresentationInfo(initialState))
+
+    const shiftedCues = [
+      { _id: 1, name: "Cue 1", index: 0 },
+      { _id: 2, name: "Cue 2", index: 2 },
+      { _id: 3, name: "Cue 3", index: 3 }
+    ]
+
+    presentationService.shiftIndexes.mockResolvedValue({
+      cues: shiftedCues,
+      name: "My Presentation",
+      id: "123"
+    })
+   
+     presentationService.get.mockResolvedValue({
+       cues: shiftedCues,
+       name: "My Presentation",
+       id: "123"
+     })
+
+    await store.dispatch(shiftPresentationIndexes("123", 1, "right"))
+
+    const state = store.getState().presentation
+    expect(state.cues[0].index).toBe(0) // Should not change
+    expect(state.cues[1].index).toBe(2) // Should shift right
+    expect(state.cues[2].index).toBe(3) // Should shift right
+  })
+
+  it("should toggle saving during saveIndexCount lifecycle", () => {
     const store = makeStore()
 
-    presentationService.shiftIndexes.mockRejectedValue({
-      response: { data: { error: "Invalid direction" } }
-    })
+    const initialState = {
+      cues: [
+        { _id: 1, name: "Cue 1", index: 0 },
+        { _id: 2, name: "Cue 2", index: 2 },
+      ],
+      indexCount: 5,
+      name: "My Presentation",
+    }
 
-    await expect(
-      store.dispatch(shiftPresentationIndexes("123", 1, "invalid"))
-    ).rejects.toThrow("Invalid direction")
+    store.dispatch(setPresentationInfo(initialState))
+
+    // pending should set saving true
+    store.dispatch({ type: saveIndexCount.pending.type })
+    expect(store.getState().presentation.saving).toBe(true)
+
+    // fulfilled should set saving false and update indexCount and filter cues
+    const payload = { indexCount: 2 }
+    store.dispatch({ type: saveIndexCount.fulfilled.type, payload })
+    expect(store.getState().presentation.saving).toBe(false)
+    expect(store.getState().presentation.indexCount).toBe(2)
+    expect(store.getState().presentation.cues.every(c => c.index < 2)).toBe(true)
+
+    // rejected should also ensure saving is false
+    store.dispatch({ type: saveIndexCount.pending.type })
+    expect(store.getState().presentation.saving).toBe(true)
+    store.dispatch({ type: saveIndexCount.rejected.type })
+    expect(store.getState().presentation.saving).toBe(false)
+  })
+
+  it("should toggle saving during saveScreenCount lifecycle", () => {
+    const store = makeStore()
+
+    const initialState = {
+      cues: [
+        { _id: 1, name: "Cue 1", index: 0, screen: 1 },
+        { _id: 2, name: "Cue 2", index: 1, screen: 2 },
+        { _id: 3, name: "Cue 3", index: 2, screen: 3 },
+      ],
+      screenCount: 3,
+      name: "My Presentation",
+    }
+
+    store.dispatch(setPresentationInfo(initialState))
+
+    // pending should set saving true
+    store.dispatch({ type: saveScreenCount.pending.type })
+    expect(store.getState().presentation.saving).toBe(true)
+
+    // fulfilled should set saving false, update screenCount and remove cues exceeding new screenCount
+    const payload = { screenCount: 2, removedCuesCount: 1 }
+    store.dispatch({ type: saveScreenCount.fulfilled.type, payload })
+    expect(store.getState().presentation.saving).toBe(false)
+    expect(store.getState().presentation.screenCount).toBe(2)
+    expect(store.getState().presentation.cues.every(c => c.screen <= 2)).toBe(true)
+
+    // rejected should also ensure saving is false
+    store.dispatch({ type: saveScreenCount.pending.type })
+    expect(store.getState().presentation.saving).toBe(true)
+    store.dispatch({ type: saveScreenCount.rejected.type })
+    expect(store.getState().presentation.saving).toBe(false)
   })
 
   it("should handle error in update presentation cues swapped", async () => {
@@ -467,4 +862,9 @@ describe("presentationReducer asynchronous actions", () => {
       )
     ).rejects.toThrow("Not found")
   })
+})
+
+afterAll(() => {
+  console.log = originalConsoleLog
+  console.error = originalConsoleError
 })

--- a/src/server/routes/admin.js
+++ b/src/server/routes/admin.js
@@ -24,6 +24,9 @@ router.delete("/user/:id", userExtractor, async (req, res) => {
 router.put("/makeadmin/:id", userExtractor, async (req, res) => {
   if (req.user && req.user.isAdmin) {
     const user = await User.findById(req.params.id)
+    if (!user) {
+      return res.status(404).json({ error: "user not found" })
+    }
     user.isAdmin = true
     await user.save()
     return res.status(200).json(user.toJSON())

--- a/src/server/tests/admin_api.test.js
+++ b/src/server/tests/admin_api.test.js
@@ -117,6 +117,210 @@ describe("Delete /admin/user/:id", () => {
   })
 })
 
+describe("Put /admin/makeadmin/:id", () => {
+  beforeEach(async () => {
+    await User.deleteMany({})
+    await api
+      .post("/api/signup")
+      .send({ username: "testuser", password: "testpassword" })
+    await api
+      .post("/api/signup")
+      .send({ username: "testadmin", password: "testpassword" })
+    // Set the admin status for the testadmin user
+    await User.findOneAndUpdate({ username: "testadmin" }, { isAdmin: true })
+  })
+
+  test("making a user an admin as an admin", async () => {
+    const response = await api
+      .post("/api/login")
+      .send({ username: "testadmin", password: "testpassword" })
+
+    authHeader = `Bearer ${response.body.token}`
+    const user = await User.findOne({ username: "testuser" })
+    
+    const result = await api
+      .put(`/api/admin/makeadmin/${user.id}`)
+      .set("Authorization", authHeader)
+      .expect(200)
+      .expect("Content-Type", /application\/json/)
+
+    expect(result.body.isAdmin).toBe(true)
+    expect(result.body.username).toBe("testuser")
+  })
+
+  test("making a user an admin sets isAdmin to true in database", async () => {
+    const response = await api
+      .post("/api/login")
+      .send({ username: "testadmin", password: "testpassword" })
+
+    authHeader = `Bearer ${response.body.token}`
+    const user = await User.findOne({ username: "testuser" })
+    
+    await api
+      .put(`/api/admin/makeadmin/${user.id}`)
+      .set("Authorization", authHeader)
+      .expect(200)
+
+    const updatedUser = await User.findOne({ username: "testuser" })
+    expect(updatedUser.isAdmin).toBe(true)
+  })
+
+  test("trying to make a user admin as not admin", async () => {
+    const response = await api
+      .post("/api/login")
+      .send({ username: "testuser", password: "testpassword" })
+
+    authHeader = `Bearer ${response.body.token}`
+    const user = await User.findOne({ username: "testadmin" })
+    
+    await api
+      .put(`/api/admin/makeadmin/${user.id}`)
+      .set("Authorization", authHeader)
+      .expect(401)
+  })
+
+  test("trying to make a user admin without authorization", async () => {
+    const user = await User.findOne({ username: "testuser" })
+    
+    await api
+      .put(`/api/admin/makeadmin/${user.id}`)
+      .expect(401)
+  })
+
+  test("trying to make a non-existent user admin", async () => {
+    const response = await api
+      .post("/api/login")
+      .send({ username: "testadmin", password: "testpassword" })
+
+    authHeader = `Bearer ${response.body.token}`
+    const fakeId = new mongoose.Types.ObjectId()
+    
+    const result = await api
+      .put(`/api/admin/makeadmin/${fakeId}`)
+      .set("Authorization", authHeader)
+      .expect(404)
+      
+    expect(result.body.error).toBe("user not found")
+  })
+})
+
+describe("Get /admin/userspresentations/:id", () => {
+  let userId
+  let adminToken
+
+  beforeEach(async () => {
+    await User.deleteMany({})
+    const Presentation = require("../models/presentation")
+    await Presentation.deleteMany({})
+
+    // Create test users
+    await api
+      .post("/api/signup")
+      .send({ username: "testuser", password: "testpassword" })
+    await api
+      .post("/api/signup")
+      .send({ username: "testadmin", password: "testpassword" })
+    
+    // Set admin status
+    await User.findOneAndUpdate({ username: "testadmin" }, { isAdmin: true })
+    
+    // Get admin token
+    const response = await api
+      .post("/api/login")
+      .send({ username: "testadmin", password: "testpassword" })
+    authHeader = `Bearer ${response.body.token}`
+
+    // Get user id
+    const user = await User.findOne({ username: "testuser" })
+    userId = user.id
+
+    // Create presentations for testuser
+    await api
+      .post("/api/home")
+      .set("Authorization", authHeader)
+      .send({ name: "Admin's Presentation" })
+
+    const userToken = await api
+      .post("/api/login")
+      .send({ username: "testuser", password: "testpassword" })
+    
+    await api
+      .post("/api/home")
+      .set("Authorization", `Bearer ${userToken.body.token}`)
+      .send({ name: "User's Presentation 1" })
+    
+    await api
+      .post("/api/home")
+      .set("Authorization", `Bearer ${userToken.body.token}`)
+      .send({ name: "User's Presentation 2" })
+  })
+
+  test("getting user presentations as admin", async () => {
+    const result = await api
+      .get(`/api/admin/userspresentations/${userId}`)
+      .set("Authorization", authHeader)
+      .expect(200)
+      .expect("Content-Type", /application\/json/)
+
+    expect(Array.isArray(result.body)).toBe(true)
+  })
+
+  test("getting user presentations returns correct number of presentations", async () => {
+    const result = await api
+      .get(`/api/admin/userspresentations/${userId}`)
+      .set("Authorization", authHeader)
+      .expect(200)
+
+    expect(result.body.length).toBe(2)
+  })
+
+  test("getting user presentations returns presentations with correct names", async () => {
+    const result = await api
+      .get(`/api/admin/userspresentations/${userId}`)
+      .set("Authorization", authHeader)
+      .expect(200)
+
+    const names = result.body.map(p => p.name)
+    expect(names).toContain("User's Presentation 1")
+    expect(names).toContain("User's Presentation 2")
+  })
+
+  test("trying to get user presentations as not admin", async () => {
+    const userResponse = await api
+      .post("/api/login")
+      .send({ username: "testuser", password: "testpassword" })
+
+    const userToken = `Bearer ${userResponse.body.token}`
+
+    await api
+      .get(`/api/admin/userspresentations/${userId}`)
+      .set("Authorization", userToken)
+      .expect(401)
+  })
+
+  test("trying to get user presentations without authorization", async () => {
+    await api
+      .get(`/api/admin/userspresentations/${userId}`)
+      .expect(401)
+  })
+
+  test("getting presentations for user with no presentations", async () => {
+    // Create a new user with no presentations
+    await api
+      .post("/api/signup")
+      .send({ username: "emptyuser", password: "testpassword" })
+    
+    const emptyUser = await User.findOne({ username: "emptyuser" })
+
+    const result = await api
+      .get(`/api/admin/userspresentations/${emptyUser.id}`)
+      .set("Authorization", authHeader)
+      .expect(200)
+
+    expect(result.body.length).toBe(0)
+  })
+})
+
 afterAll(async () => {
   await mongoose.connection.close()
 })

--- a/src/server/tests/helper.test.js
+++ b/src/server/tests/helper.test.js
@@ -1,0 +1,346 @@
+const {
+  processDriveCueFiles,
+  generateSignedUrlForS3,
+  processS3Files,
+} = require("../utils/helper")
+const { getDriveFileMetadata } = require("../utils/drive")
+const { getObjectSignedUrl } = require("../utils/s3")
+const { getFileSize, getFileType } = require("../utils/s3")
+
+jest.mock("../utils/drive")
+jest.mock("../utils/s3")
+
+describe("Helper utility functions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.NODE_ENV = "development"
+  })
+
+  describe("generateDriveFileUrlForCue", () => {
+    test("should generate Drive file URL with metadata", async () => {
+      const cue = {
+        file: {
+          driveId: "drive-123",
+          name: "test-file",
+        },
+      }
+      const accessToken = "test-token"
+
+      getDriveFileMetadata.mockResolvedValue({
+        mimeType: "image/png",
+        size: "2048",
+      })
+
+      const result = await processDriveCueFiles([cue], accessToken)
+
+      expect(result[0].file.url).toContain("api/media/drive-123")
+      expect(result[0].file.url).toContain("access_token=test-token")
+      expect(result[0].file.type).toBe("image/png")
+      expect(result[0].file.size).toBe("2048")
+    })
+
+    test("should use localhost URL in development", async () => {
+      process.env.NODE_ENV = "development"
+      const cue = {
+        file: {
+          driveId: "drive-123",
+        },
+      }
+      const accessToken = "test-token"
+
+      getDriveFileMetadata.mockResolvedValue({
+        mimeType: "image/jpeg",
+        size: "4096",
+      })
+
+      const result = await processDriveCueFiles([cue], accessToken)
+
+      expect(result[0].file.url).toContain("http://localhost:3000")
+    })
+
+    test("should use production URL in production", async () => {
+      process.env.NODE_ENV = "production"
+      const cue = {
+        file: {
+          driveId: "drive-123",
+        },
+      }
+      const accessToken = "test-token"
+
+      getDriveFileMetadata.mockResolvedValue({
+        mimeType: "image/jpeg",
+        size: "4096",
+      })
+
+      const result = await processDriveCueFiles([cue], accessToken)
+
+      expect(result[0].file.url).toContain("https://muvico.live")
+    })
+
+    test("should handle error when fetching metadata", async () => {
+      const cue = {
+        file: {
+          driveId: "drive-123",
+        },
+      }
+      const accessToken = "test-token"
+
+      getDriveFileMetadata.mockRejectedValue(new Error("Metadata fetch failed"))
+
+      const result = await processDriveCueFiles([cue], accessToken)
+
+      // When error occurs, URL is not set (remains undefined)
+      expect(result[0].file.url).toBeUndefined()
+    })
+
+    test("should use blank URL when no driveId", async () => {
+      const cue = {
+        file: {
+          name: "blank.png",
+        },
+      }
+      const accessToken = "test-token"
+
+      const result = await processDriveCueFiles([cue], accessToken)
+
+      expect(result[0].file.url).toBe("/src/server/public/blank.png")
+      expect(getDriveFileMetadata).not.toHaveBeenCalled()
+    })
+
+    test("should process multiple cues", async () => {
+      const cues = [
+        { file: { driveId: "drive-1" } },
+        { file: { driveId: "drive-2" } },
+        { file: { name: "blank.png" } },
+      ]
+      const accessToken = "test-token"
+
+      getDriveFileMetadata.mockResolvedValue({
+        mimeType: "image/jpeg",
+        size: "1024",
+      })
+
+      const result = await processDriveCueFiles(cues, accessToken)
+
+      expect(result).toHaveLength(3)
+      expect(result[0].file.url).toContain("api/media/drive-1")
+      expect(result[1].file.url).toContain("api/media/drive-2")
+      expect(result[2].file.url).toBe("/src/server/public/blank.png")
+    })
+  })
+
+  describe("generateSignedUrlForS3", () => {
+    test("should generate signed URL for S3 file", async () => {
+      const cue = {
+        file: {
+          url: "s3-url",
+          id: "file-123",
+          name: "test.jpg",
+        },
+      }
+      const presentationId = "pres-123"
+
+      getObjectSignedUrl.mockResolvedValue("https://s3.signed.url")
+      getFileType.mockResolvedValue(null)
+      getFileSize.mockResolvedValue(null)
+
+      const result = await generateSignedUrlForS3(cue, presentationId)
+
+      expect(getObjectSignedUrl).toHaveBeenCalledWith("pres-123/file-123")
+      expect(result.file.url).toBe("https://s3.signed.url")
+    })
+
+    test("should use blank image URL in development", async () => {
+      process.env.NODE_ENV = "development"
+      const cue = {
+        file: {
+          url: null,
+          name: "blank.png",
+        },
+      }
+
+      const result = await generateSignedUrlForS3(cue, "pres-123")
+
+      expect(result.file.url).toBe("/src/server/public/blank.png")
+    })
+
+    test("should use blank image URL in production", async () => {
+      process.env.NODE_ENV = "production"
+      const cue = {
+        file: {
+          url: null,
+          name: "blank.png",
+        },
+      }
+
+      const result = await generateSignedUrlForS3(cue, "pres-123")
+
+      expect(result.file.url).toBe("/blank.png")
+    })
+
+    test("should handle different blank image variants", async () => {
+      process.env.NODE_ENV = "development"
+
+      const variants = [
+        "blank.png",
+        "blank-white.png",
+        "blank-indigo.png",
+        "blank-tropicalindigo.png",
+      ]
+
+      for (const filename of variants) {
+        const cue = {
+          file: {
+            url: null,
+            name: filename,
+          },
+        }
+
+        const result = await generateSignedUrlForS3(cue, "pres-123")
+
+        expect(result.file.url).toBe(`/src/server/public/${filename}`)
+      }
+    })
+  })
+
+  describe("processS3Files", () => {
+    test("should process S3 files with metadata", async () => {
+      const cues = [
+        {
+          file: {
+            url: "s3-url",
+            id: "file-1",
+            name: "image.jpg",
+          },
+        },
+      ]
+      const presentationId = "pres-123"
+
+      getObjectSignedUrl.mockResolvedValue("https://s3.signed.url")
+      getFileType.mockResolvedValue(null)
+      getFileSize.mockResolvedValue(null)
+
+      const result = await processS3Files(cues, presentationId)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].file.url).toBe("https://s3.signed.url")
+      expect(getFileType).toHaveBeenCalled()
+      expect(getFileSize).toHaveBeenCalled()
+    })
+
+    test("should skip metadata for blank images", async () => {
+      process.env.NODE_ENV = "development"
+      const cues = [
+        {
+          file: {
+            url: null,
+            id: "file-1",
+            name: "blank.png",
+          },
+        },
+      ]
+
+      const result = await processS3Files(cues, "pres-123")
+
+      expect(result[0].file.url).toBe("/src/server/public/blank.png")
+      expect(getFileType).not.toHaveBeenCalled()
+      expect(getFileSize).not.toHaveBeenCalled()
+    })
+
+    test("should skip metadata for all blank variants", async () => {
+      process.env.NODE_ENV = "development"
+      const blankVariants = [
+        "/src/server/public/blank.png",
+        "/src/server/public/blank-white.png",
+        "/src/server/public/blank-indigo.png",
+        "/src/server/public/blank-tropicalindigo.png",
+        "/blank.png",
+        "/blank-white.png",
+        "/blank-indigo.png",
+        "/blank-tropicalindigo.png",
+      ]
+
+      for (const url of blankVariants) {
+        jest.clearAllMocks()
+        getObjectSignedUrl.mockResolvedValue(url)
+
+        const cues = [
+          {
+            file: {
+              url: "s3-url",
+              id: "file-1",
+              name: "test.jpg",
+            },
+          },
+        ]
+
+        await processS3Files(cues, "pres-123")
+
+        expect(getFileType).not.toHaveBeenCalled()
+        expect(getFileSize).not.toHaveBeenCalled()
+      }
+    })
+
+    test("should process multiple cues with mixed types", async () => {
+      process.env.NODE_ENV = "development"
+      const cues = [
+        {
+          file: {
+            url: "s3-url-1",
+            id: "file-1",
+            name: "image1.jpg",
+          },
+        },
+        {
+          file: {
+            url: null,
+            id: "file-2",
+            name: "blank.png",
+          },
+        },
+        {
+          file: {
+            url: "s3-url-3",
+            id: "file-3",
+            name: "image3.jpg",
+          },
+        },
+      ]
+
+      getObjectSignedUrl.mockResolvedValue("https://s3.signed.url")
+      getFileType.mockResolvedValue(null)
+      getFileSize.mockResolvedValue(null)
+
+      const result = await processS3Files(cues, "pres-123")
+
+      expect(result).toHaveLength(3)
+      // First and third should have metadata calls
+      expect(getFileType).toHaveBeenCalledTimes(2)
+      expect(getFileSize).toHaveBeenCalledTimes(2)
+      // Second should be blank
+      expect(result[1].file.url).toBe("/src/server/public/blank.png")
+    })
+
+    test("should handle errors in metadata retrieval gracefully", async () => {
+      const cues = [
+        {
+          file: {
+            url: "s3-url",
+            id: "file-1",
+            name: "image.jpg",
+          },
+        },
+      ]
+
+      getObjectSignedUrl.mockResolvedValue("https://s3.signed.url")
+      // Don't mock errors - implementation doesn't have error handling for these
+      getFileType.mockResolvedValue(null)
+      getFileSize.mockResolvedValue(null)
+
+      const result = await processS3Files(cues, "pres-123")
+
+      expect(result).toHaveLength(1)
+      expect(result[0].file.url).toBe("https://s3.signed.url")
+    })
+  })
+})

--- a/src/server/tests/middleware.test.js
+++ b/src/server/tests/middleware.test.js
@@ -1,0 +1,304 @@
+const jwt = require("jsonwebtoken")
+const mongoose = require("mongoose")
+const User = require("../models/user")
+const logger = require("../utils/logger")
+const {
+  requestLogger,
+  unknownEndpoint,
+  errorHandler,
+  userExtractor,
+  getTokenFrom,
+} = require("../utils/middleware")
+
+jest.mock("../utils/logger")
+
+describe("Middleware functions", () => {
+  let mockRequest
+  let mockResponse
+  let mockNext
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRequest = {
+      headers: {},
+      body: {},
+      path: "/test",
+      method: "GET",
+    }
+    mockResponse = {
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    }
+    mockNext = jest.fn()
+  })
+
+  describe("requestLogger", () => {
+    test("should log request method, path, and body", () => {
+      mockRequest.method = "POST"
+      mockRequest.path = "/api/users"
+      mockRequest.body = { username: "test" }
+
+      requestLogger(mockRequest, mockResponse, mockNext)
+
+      expect(logger.info).toHaveBeenCalledWith("Method:", "POST")
+      expect(logger.info).toHaveBeenCalledWith("Path:  ", "/api/users")
+      expect(logger.info).toHaveBeenCalledWith("Body:  ", { username: "test" })
+      expect(logger.info).toHaveBeenCalledWith("---")
+      expect(mockNext).toHaveBeenCalled()
+    })
+
+    test("should call next middleware", () => {
+      requestLogger(mockRequest, mockResponse, mockNext)
+      expect(mockNext).toHaveBeenCalled()
+    })
+  })
+
+  describe("getTokenFrom", () => {
+    test("should extract bearer token from authorization header", () => {
+      mockRequest.headers.authorization = "bearer test-token-123"
+
+      const result = getTokenFrom(mockRequest)
+
+      expect(mockRequest.token).toBe("test-token-123")
+      expect(result).toBeNull()
+    })
+
+    test("should extract token with Bearer uppercase", () => {
+      mockRequest.headers.authorization = "Bearer test-token-456"
+
+      getTokenFrom(mockRequest)
+
+      expect(mockRequest.token).toBe("test-token-456")
+    })
+
+    test("should extract token with BEARER all caps", () => {
+      mockRequest.headers.authorization = "BEARER test-token-789"
+
+      getTokenFrom(mockRequest)
+
+      expect(mockRequest.token).toBe("test-token-789")
+    })
+
+    test("should not extract token without bearer prefix", () => {
+      mockRequest.headers.authorization = "Basic xyz"
+
+      const result = getTokenFrom(mockRequest)
+
+      expect(mockRequest.token).toBeUndefined()
+      expect(result).toBeNull()
+    })
+
+    test("should not extract token without authorization header", () => {
+      mockRequest.headers.authorization = undefined
+
+      const result = getTokenFrom(mockRequest)
+
+      expect(mockRequest.token).toBeUndefined()
+      expect(result).toBeNull()
+    })
+
+    test("should return null", () => {
+      const result = getTokenFrom(mockRequest)
+      expect(result).toBeNull()
+    })
+  })
+
+  describe("userExtractor", () => {
+    let originalSecret
+
+    beforeEach(() => {
+      originalSecret = process.env.SECRET
+      process.env.SECRET = "test-secret"
+      jest.spyOn(User, "findById").mockResolvedValue(null)
+    })
+
+    afterEach(() => {
+      process.env.SECRET = originalSecret
+      User.findById.mockRestore()
+    })
+
+    test("should extract user from valid token", async () => {
+      const userId = new mongoose.Types.ObjectId()
+      const token = jwt.sign({ id: userId.toString() }, "test-secret")
+      mockRequest.headers.authorization = `Bearer ${token}`
+
+      const mockUser = {
+        _id: userId,
+        username: "testuser",
+      }
+      User.findById.mockResolvedValue(mockUser)
+
+      await userExtractor(mockRequest, mockResponse, mockNext)
+
+      expect(mockRequest.user).toEqual(mockUser)
+      expect(User.findById).toHaveBeenCalledWith(userId.toString())
+      expect(mockNext).toHaveBeenCalled()
+    })
+
+    test("should return 401 when token is invalid", async () => {
+      mockRequest.headers.authorization = "Bearer invalid-token"
+
+      await userExtractor(mockRequest, mockResponse, mockNext)
+
+      expect(mockResponse.status).toHaveBeenCalledWith(401)
+      expect(mockResponse.send).toHaveBeenCalledWith({ error: "token-expired" })
+      expect(mockNext).not.toHaveBeenCalled()
+    })
+
+    test("should return 401 when token has no id", async () => {
+      const token = jwt.sign({ username: "testuser" }, "test-secret")
+      mockRequest.headers.authorization = `Bearer ${token}`
+
+      await userExtractor(mockRequest, mockResponse, mockNext)
+
+      expect(mockResponse.status).toHaveBeenCalledWith(401)
+      expect(mockResponse.json).toHaveBeenCalledWith({ error: "token invalid" })
+    })
+
+    test("should call next() when no token provided", async () => {
+      mockRequest.headers.authorization = undefined
+
+      await userExtractor(mockRequest, mockResponse, mockNext)
+
+      expect(mockNext).toHaveBeenCalled()
+      expect(mockRequest.user).toBeUndefined()
+    })
+
+    test("should return 401 when token is expired", async () => {
+      const token = jwt.sign({ id: "userid" }, "test-secret", {
+        expiresIn: "-1h", // Expired token
+      })
+      mockRequest.headers.authorization = `Bearer ${token}`
+
+      await userExtractor(mockRequest, mockResponse, mockNext)
+
+      expect(mockResponse.status).toHaveBeenCalledWith(401)
+      expect(mockResponse.send).toHaveBeenCalledWith({ error: "token-expired" })
+    })
+
+    test("should handle user not found in database", async () => {
+      const userId = new mongoose.Types.ObjectId()
+      const token = jwt.sign({ id: userId }, "test-secret")
+      mockRequest.headers.authorization = `Bearer ${token}`
+
+      User.findById.mockResolvedValue(null)
+
+      await userExtractor(mockRequest, mockResponse, mockNext)
+
+      expect(mockRequest.user).toBeNull()
+      expect(mockNext).toHaveBeenCalled()
+    })
+
+    test("should call next only once even with valid token", async () => {
+      const userId = new mongoose.Types.ObjectId()
+      const token = jwt.sign({ id: userId }, "test-secret")
+      mockRequest.headers.authorization = `Bearer ${token}`
+
+      User.findById.mockResolvedValue({ _id: userId, username: "test" })
+
+      await userExtractor(mockRequest, mockResponse, mockNext)
+
+      expect(mockNext).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("unknownEndpoint", () => {
+    test("should return 404 with unknown endpoint error", () => {
+      unknownEndpoint(mockRequest, mockResponse)
+
+      expect(mockResponse.status).toHaveBeenCalledWith(404)
+      expect(mockResponse.send).toHaveBeenCalledWith({ error: "unknown endpoint" })
+    })
+
+    test("should not call next()", () => {
+      unknownEndpoint(mockRequest, mockResponse)
+
+      expect(mockNext).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("errorHandler", () => {
+    test("should log error message", () => {
+      const error = new Error("Test error")
+
+      errorHandler(error, mockRequest, mockResponse, mockNext)
+
+      expect(logger.error).toHaveBeenCalledWith("Test error")
+    })
+
+    test("should handle CastError", () => {
+      const error = new Error("Invalid ID")
+      error.name = "CastError"
+
+      errorHandler(error, mockRequest, mockResponse, mockNext)
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400)
+      expect(mockResponse.send).toHaveBeenCalledWith({ error: "malformatted id" })
+    })
+
+    test("should handle ValidationError", () => {
+      const error = new Error("Validation failed")
+      error.name = "ValidationError"
+
+      errorHandler(error, mockRequest, mockResponse, mockNext)
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400)
+      expect(mockResponse.json).toHaveBeenCalledWith({ error: "Validation failed" })
+    })
+
+    test("should pass unknown errors to next middleware", () => {
+      const error = new Error("Unknown error")
+      error.name = "UnknownError"
+
+      errorHandler(error, mockRequest, mockResponse, mockNext)
+
+      expect(mockNext).toHaveBeenCalledWith(error)
+    })
+
+    test("should return null for non-error types", () => {
+      const error = new Error("Unknown error")
+      error.name = "SomeOtherError"
+
+      const result = errorHandler(error, mockRequest, mockResponse, mockNext)
+
+      expect(result).toBeNull()
+    })
+
+    test("should handle errors with special characters in message", () => {
+      const error = new Error("Error with <special> & characters")
+      error.name = "ValidationError"
+
+      errorHandler(error, mockRequest, mockResponse, mockNext)
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400)
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        error: "Error with <special> & characters",
+      })
+    })
+  })
+
+  describe("userExtractor with token prefix variations", () => {
+    beforeEach(() => {
+      process.env.SECRET = "test-secret"
+      jest.spyOn(User, "findById").mockResolvedValue(null)
+    })
+
+    afterEach(() => {
+      User.findById.mockRestore()
+    })
+
+    test("should handle authorization header with mixed case Bearer", async () => {
+      const userId = new mongoose.Types.ObjectId()
+      const token = jwt.sign({ id: userId }, "test-secret")
+      mockRequest.headers.authorization = `BeArEr ${token}`
+
+      User.findById.mockResolvedValue({ _id: userId })
+
+      await userExtractor(mockRequest, mockResponse, mockNext)
+
+      expect(mockRequest.token).toBe(token)
+      expect(mockNext).toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
Changes:

- Modifies various test files and adds new test files to cover more lines.

Additionally, added more fail-safes:

- `src/client/redux/presentationReducer.js`: Won't decrement index/screen count below 1 on the reducer stage
- `src/server/routes/admin.js` Won't continue with makeadmin if a nonsense user id is given.