### PR TITLE
fixed 2 bugs related to showmode and screen 5

### DIFF
--- a/src/client/components/presentation/ShowMode.jsx
+++ b/src/client/components/presentation/ShowMode.jsx
@@ -134,12 +134,9 @@ const ShowMode = ({ cues, cueIndex, setCueIndex, indexCount }) => {
       const updatedVisibility = { ...prevVisibility }
       const allScreenNumbers = Object.keys(updatedVisibility)
       
-      const maxScreenNumber = Math.max(...allScreenNumbers.map(Number)).toString()
-      const screenNumbers = allScreenNumbers.filter((screenNumber) => screenNumber !== maxScreenNumber)
+      const hasOpenScreen = allScreenNumbers.some((screenNumber) => updatedVisibility[screenNumber])
       
-      const hasOpenScreen = screenNumbers.some((screenNumber) => updatedVisibility[screenNumber])
-      
-      screenNumbers.forEach((screenNumber) => {
+      allScreenNumbers.forEach((screenNumber) => {
         updatedVisibility[screenNumber] = !hasOpenScreen
       })
       

--- a/src/client/components/presentation/ShowModeButtons.jsx
+++ b/src/client/components/presentation/ShowModeButtons.jsx
@@ -27,7 +27,6 @@ import {
 
 const DropdownButton = ({ screenNumber, screens, toggleScreenMirroring }) => {
   const allScreenNumbers = Object.keys(screens)
-  const maxScreenNumber = Math.max(...allScreenNumbers.map(Number)).toString()
   
   return (
     <Menu>
@@ -46,7 +45,7 @@ const DropdownButton = ({ screenNumber, screens, toggleScreenMirroring }) => {
         {allScreenNumbers
           .filter(
             (targetScreen) =>
-              targetScreen !== screenNumber && targetScreen !== maxScreenNumber
+              targetScreen !== screenNumber
           )
           .map((targetScreen) => (
           <MenuItem
@@ -125,10 +124,8 @@ const ScreenToggleButtons = ({
 }) => {
 
   const allScreenNumbers = Object.keys(screens)
-  const maxScreenNumber = Math.max(...allScreenNumbers.map(Number)).toString()
   
   const hasOpenScreen = allScreenNumbers
-    .filter((screenNumber) => screenNumber !== maxScreenNumber)
     .some((screenNumber) => screens[screenNumber])
 
   return (
@@ -142,7 +139,6 @@ const ScreenToggleButtons = ({
       </Button>
     <Box display="flex" flexWrap="wrap" gap={2}>
     {allScreenNumbers
-      .filter((screenNumber) => screenNumber !== maxScreenNumber)
       .map((screenNumber) => (
         <Box key={screenNumber}>
           <Button

--- a/src/client/tests/unit/showmode.test.js
+++ b/src/client/tests/unit/showmode.test.js
@@ -29,15 +29,6 @@ const mockCues = [
     _id: "987654321",
     loop: false,
   },
-  {
-    file: { url: "http://example.com/audio1.mp3", type: "audio/mp3" },
-
-    index: 2,
-    name: "audio_cue",
-    screen: 3,
-    _id: "111222333",
-    loop: false,
-  },
 ]
 
 const mockemptyCues = []


### PR DESCRIPTION
Changes:

FIxed 2 bugs that were related to showmode.

`presentation/showmode.jsx`
- Removed the hardcoded ignoring of screen 5, and madde the last screen (audio screen) not show up as an openable screen.

`presentation/showmodebuttons.jsx`
- Removed the hardcoded hiding of show screen 5 and hid the audio screen from showing up as an openable screen.