### PR TITLE
Keep opened screens open when moving between modes

### DIFF
--- a/src/client/components/presentation/ShowMode.jsx
+++ b/src/client/components/presentation/ShowMode.jsx
@@ -4,7 +4,7 @@ import ShowModeButtons from "./ShowModeButtons"
 import KeyboardHandler from "../utils/keyboardHandler"
 
 // ShowMode component
-const ShowMode = ({ cues, cueIndex, setCueIndex, indexCount, transitionType }) => {
+const ShowMode = ({ cues, cueIndex, setCueIndex, indexCount, transitionType, isHidden }) => {
   // Preload cues once on initialization
   const [preloadedCues, setPreloadedCues] = useState({})
 
@@ -211,7 +211,7 @@ const ShowMode = ({ cues, cueIndex, setCueIndex, indexCount, transitionType }) =
 
 
   return (
-    <div className="show-mode">
+    <div className="show-mode" style={isHidden ? { display: "none" } : undefined}>
       {/* Pass screen visibility and cue navigation to ShowModeButtons */}
       <KeyboardHandler
         onNext={() => updateCue("Next")}

--- a/src/client/components/presentation/index.jsx
+++ b/src/client/components/presentation/index.jsx
@@ -184,15 +184,14 @@ const PresentationPage = ({ user }) => {
           <Box flex="1" padding={4} marginLeft="0px" overflow="auto" id="presentations-grid">
             {" "}
             {/* Adjust marginLeft to move the grid to the left */}
-            {showMode && (
-              <ShowMode
-                cues={presentationInfo}
-                cueIndex={cueIndex}
-                setCueIndex={setCueIndex}
-                indexCount={indexCount}
-                transitionType={transitionType}
-              />
-            )}
+            <ShowMode
+              cues={presentationInfo}
+              cueIndex={cueIndex}
+              setCueIndex={setCueIndex}
+              indexCount={indexCount}
+              transitionType={transitionType}
+              isHidden={!showMode}
+            />
             <EditMode
               id={id}
               cues={presentationInfo}


### PR DESCRIPTION
## [#489 ](https://github.com/MuViCo/MuViCo/issues/489) Keep opened screens open when moving between modes

Keeps show mode open in edit mode but hides the elements from show mode so opened screens remain open. Arrow keys can also be used to preview the presentation while in EditMode.

This change works similar to how edit mode is also open in show mode (Because the grid from EditMode is shown in ShowMode). These components ShowMode and EditMode don't by themselves represent the entire modes but (as of now) rather components that are used in both (Only the grid from EditMode was used in both previously (By keeping EditMode always open), after this change the screens from ShowMode are used in both as well (Too, by keeping ShowMode always open). It's confusing and unnecessary to have both modes always open and could (and should) be fixed by further refactoring by separating the modes properly.

### Changes
`presentation/index.jsx`
- Keep the functionality of ShowMode open
- Let ShowMode know if it should be hidden (When in edit mode)

`presentation/ShowMode.jsx`
- Hide components if they should be hidden (When in edit mode)
