### PR TITLE
638 - As a user I can toggle to see my password when signing up (to check for typos) 

### DIFF
--- a/src/client/components/navbar/SignUp.jsx
+++ b/src/client/components/navbar/SignUp.jsx
@@ -9,7 +9,11 @@ import {
   FormControl,
   FormLabel,
   Input,
+  InputGroup,
+  InputRightElement,
+  IconButton,
 } from "@chakra-ui/react"
+import { ViewIcon, ViewOffIcon } from "@chakra-ui/icons"
 import Error from "../utils/Error"
 import signupService from "../../services/signup"
 import loginService from "../../services/login"
@@ -38,6 +42,7 @@ const validationSchema = yup.object().shape({
 export const SignUpForm = ({ onSubmit, error, handleTermsClick }) => {
   const [formData, setFormData] = useState(initialValues)
   const [formErrors, setFormErrors] = useState({})
+  const [showPasswords, setShowPasswords] = useState(false)
   const usernameRef = useRef(null)
   const passwordRef = useRef(null)
   const passwordagainRef = useRef(null)
@@ -113,17 +118,29 @@ export const SignUpForm = ({ onSubmit, error, handleTermsClick }) => {
 
         <FormControl mt={4}>
           <FormLabel htmlFor="password">Password</FormLabel>
-          <Input
-            id="password_signup"
-            data-testid="password_signup"
-            type="password"
-            name="password"
-            placeholder="Password"
-            value={formData.password}
-            onChange={handleChange}
-            ref={passwordRef}
-            onKeyDown={handleKeyDown}
-          />
+          <InputGroup>
+            <Input
+              id="password_signup"
+              data-testid="password_signup"
+              type={showPasswords ? "text" : "password"}
+              name="password"
+              placeholder="Password"
+              value={formData.password}
+              onChange={handleChange}
+              ref={passwordRef}
+              onKeyDown={handleKeyDown}
+            />
+            <InputRightElement>
+              <IconButton
+                aria-label={showPasswords ? "Hide password" : "Show password"}
+                icon={showPasswords ? <ViewOffIcon /> : <ViewIcon />}
+                onClick={() => setShowPasswords(!showPasswords)}
+                variant="ghost"
+                size="sm"
+                tabIndex={-1}
+              />
+            </InputRightElement>
+          </InputGroup>
           {formErrors.password && <Error error={formErrors.password} />}
         </FormControl>
 
@@ -131,17 +148,29 @@ export const SignUpForm = ({ onSubmit, error, handleTermsClick }) => {
           <FormLabel htmlFor="password_confirmation">
             Confirm Password
           </FormLabel>
-          <Input
-            id="password_confirmation_signup"
-            data-testid="password_signup_confirmation"
-            type="password"
-            name="password_confirmation"
-            placeholder="Password_confirmation"
-            value={formData.password_confirmation}
-            onChange={handleChange}
-            ref={passwordagainRef}
-            onKeyDown={handleKeyDown}
-          />
+          <InputGroup>
+            <Input
+              id="password_confirmation_signup"
+              data-testid="password_signup_confirmation"
+              type={showPasswords ? "text" : "password"}
+              name="password_confirmation"
+              placeholder="Password_confirmation"
+              value={formData.password_confirmation}
+              onChange={handleChange}
+              ref={passwordagainRef}
+              onKeyDown={handleKeyDown}
+            />
+            <InputRightElement>
+              <IconButton
+                aria-label={showPasswords ? "Hide password" : "Show password"}
+                icon={showPasswords ? <ViewOffIcon /> : <ViewIcon />}
+                onClick={() => setShowPasswords(!showPasswords)}
+                variant="ghost"
+                size="sm"
+                tabIndex={-1}
+              />
+            </InputRightElement>
+          </InputGroup>
           {formErrors.password_confirmation && (
             <Error error={formErrors.password_confirmation} />
           )}

--- a/src/client/tests/unit/signup.test.js
+++ b/src/client/tests/unit/signup.test.js
@@ -190,3 +190,86 @@ describe("HandleKeyDown", () => {
     })
   })
 })
+
+describe("Password visibility toggle", () => {
+  test("renders password visibility toggle buttons", () => {
+    const onSubmit = jest.fn()
+    render(<SignUpForm onSubmit={onSubmit} />)
+
+    const showButtons = screen.getAllByLabelText("Show password")
+    expect(showButtons).toHaveLength(2)
+  })
+
+  test("password input is hidden by default", () => {
+    const onSubmit = jest.fn()
+    const { getByTestId } = render(<SignUpForm onSubmit={onSubmit} />)
+    const passwordInput = getByTestId("password_signup")
+    expect(passwordInput).toHaveAttribute("type", "password")
+  })
+
+  test("password confirmation input is hidden by default", () => {
+    const onSubmit = jest.fn()
+    const { getByTestId } = render(<SignUpForm onSubmit={onSubmit} />)
+    const passwordConfirmInput = getByTestId("password_signup_confirmation")
+    expect(passwordConfirmInput).toHaveAttribute("type", "password")
+  })
+
+  test("clicking show password button makes both password fields visible", async () => {
+    const onSubmit = jest.fn()
+    const { getByTestId, getAllByLabelText } = render(
+      <SignUpForm onSubmit={onSubmit} />
+    )
+    const passwordInput = getByTestId("password_signup")
+    const passwordConfirmInput = getByTestId("password_signup_confirmation")
+
+    const showButtons = getAllByLabelText("Show password")
+
+    // Click the first button (on password field)
+    fireEvent.click(showButtons[0])
+
+    await waitFor(() => {
+      expect(passwordInput).toHaveAttribute("type", "text")
+      expect(passwordConfirmInput).toHaveAttribute("type", "text")
+    })
+  })
+
+  test("clicking show password button again hides both password fields", async () => {
+    const onSubmit = jest.fn()
+    const { getByTestId, getAllByLabelText } = render(
+      <SignUpForm onSubmit={onSubmit} />
+    )
+    const passwordInput = getByTestId("password_signup")
+    const passwordConfirmInput = getByTestId("password_signup_confirmation")
+
+    const showButtons = getAllByLabelText("Show password")
+    fireEvent.click(showButtons[0])
+
+    await waitFor(() => {
+      expect(passwordInput).toHaveAttribute("type", "text")
+    })
+
+    const hideButtons = getAllByLabelText("Hide password")
+    fireEvent.click(hideButtons[0])
+
+    await waitFor(() => {
+      expect(passwordInput).toHaveAttribute("type", "password")
+      expect(passwordConfirmInput).toHaveAttribute("type", "password")
+    })
+  })
+
+  test("both password toggle buttons toggle the same state", async () => {
+    const onSubmit = jest.fn()
+    const { getByTestId, getAllByLabelText } = render(
+      <SignUpForm onSubmit={onSubmit} />
+    )
+    const passwordInput = getByTestId("password_signup")
+
+    // Click second button (on password confirmation field)
+    const showButtons = getAllByLabelText("Show password")
+    fireEvent.click(showButtons[1])
+
+    await waitFor(() => {
+      expect(passwordInput).toHaveAttribute("type", "text")
+    })
+  })
+})


### PR DESCRIPTION
feat: Add password visibility toggle to Sign Up form

- Add show/hide password buttons to both password fields
- Implement single state to control both fields simultaneously
- Add unit tests for toggle functionality