### PR TITLE
692 bug swapping two cues can cause them to share the same edit mode grid position

### DIFF
--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -20,7 +20,7 @@ import {
   updatePresentation,
   createCue,
   removeCue,
-  updatePresentationSwappedCues,
+  swapCues,
   incrementIndexCount,
   decrementIndexCount,
   incrementScreenCount,
@@ -831,15 +831,16 @@ const EditMode = ({
     }
   }
 
-  const dispatchUpdateSwappedCues = async (newTargetCue, newSelectedCue) => {
+  const dispatchSwapCues = async (newTargetCue, newSelectedCue) => {
     setStatus("loading")
     try {
       await dispatch(
-        updatePresentationSwappedCues(id, newTargetCue, newSelectedCue)
+        swapCues(id, newTargetCue, newSelectedCue)
       )
       setStatus("saved")
     } catch (error) {
       console.error(error)
+      setStatus("saved")
       showToast({
         title: "Error",
         description: error.message || "An error occurred",
@@ -891,11 +892,11 @@ const EditMode = ({
         setSelectedCue(null)
         return
       } else {
-        await dispatchUpdateSwappedCues(newTargetCue, newSelectedCue)
+        await dispatchSwapCues(newTargetCue, newSelectedCue)
         setSelectedCue(null)
       }
     } else {
-      await dispatchUpdateSwappedCues(newTargetCue, newSelectedCue)
+      await dispatchSwapCues(newTargetCue, newSelectedCue)
       setSelectedCue(null)
     }
   }

--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -1141,6 +1141,7 @@ const EditMode = ({
               height={`${(yLabels.length + 1) * (rowHeight + gap)}px`}
               width="100%"
               position="relative"
+              data-testid="edit-mode-grid-container"
               ref={containerRef}
               onDoubleClick={handleDoubleClick}
               onMouseDown={handleMouseDown}

--- a/src/client/components/presentation/GridLayoutComponent.jsx
+++ b/src/client/components/presentation/GridLayoutComponent.jsx
@@ -375,6 +375,18 @@ const GridLayoutComponent = ({
       return
     }
 
+    const targetCue = cues.find(
+      (cue) =>
+        cue._id !== newItem.i &&
+        Number(cue.index) === Number(newItem.x) &&
+        Number(cue.screen) === Number(newItem.y + 1)
+    )
+
+    if (targetCue) {
+      setCurrentLayout(newLayout)
+      return
+    }
+
     const movedCue = {
       cueId: newItem.i,
       index: newItem.x,

--- a/src/client/redux/presentationReducer.js
+++ b/src/client/redux/presentationReducer.js
@@ -188,7 +188,7 @@ export const updatePresentation =
     }
   }
 
-export const updatePresentationSwappedCues =
+export const swapCues =
   (presentationId, firstUpdatedCue, secondUpdatedCue) => async (dispatch) => {
     try {
       const { firstCue: updatedFirstCue, secondCue: updatedSecondCue } =

--- a/src/client/redux/presentationReducer.js
+++ b/src/client/redux/presentationReducer.js
@@ -191,38 +191,15 @@ export const updatePresentation =
 export const updatePresentationSwappedCues =
   (presentationId, firstUpdatedCue, secondUpdatedCue) => async (dispatch) => {
     try {
-      const firstFormData = createFormData(
-        firstUpdatedCue.index,
-        firstUpdatedCue.name,
-        firstUpdatedCue.screen,
-        firstUpdatedCue.file,
-        firstUpdatedCue._id,
-        firstUpdatedCue.color,
-        firstUpdatedCue.loop
-      )
-
-      const secondFormData = createFormData(
-        secondUpdatedCue.index,
-        secondUpdatedCue.name,
-        secondUpdatedCue.screen,
-        secondUpdatedCue.file,
-        secondUpdatedCue._id,
-        secondUpdatedCue.color,
-        secondUpdatedCue.loop
-      )
-
-      const [updatedFirstCue, updatedSecondCue] = await Promise.all([
-        presentationService.updateCue(
-          presentationId,
-          firstUpdatedCue._id,
-          firstFormData
-        ),
-        presentationService.updateCue(
-          presentationId,
-          secondUpdatedCue._id,
-          secondFormData
-        ),
-      ])
+      const { firstCue: updatedFirstCue, secondCue: updatedSecondCue } =
+        await presentationService.swapCues(presentationId, {
+          firstCueId: firstUpdatedCue._id,
+          secondCueId: secondUpdatedCue._id,
+          firstIndex: firstUpdatedCue.index,
+          firstScreen: firstUpdatedCue.screen,
+          secondIndex: secondUpdatedCue.index,
+          secondScreen: secondUpdatedCue.screen,
+        })
 
       dispatch(editCue(updatedFirstCue))
       dispatch(editCue(updatedSecondCue))

--- a/src/client/services/presentation.js
+++ b/src/client/services/presentation.js
@@ -115,6 +115,17 @@ const updatePresentationName = async (id, newName) => {
   return response.data
 }
 
+const swapCues = async (id, payload) => {
+  const config = {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `bearer ${getToken()}`,
+    },
+  }
+  const response = await axios.put(`${baseUrl}${id}/swap`, payload, config)
+  return response.data
+}
+
 export default {
   get,
   remove,
@@ -125,4 +136,5 @@ export default {
   saveScreenCountApi,
   shiftIndexes,
   updatePresentationName,
+  swapCues,
 }

--- a/src/client/services/presentation.js
+++ b/src/client/services/presentation.js
@@ -122,7 +122,7 @@ const swapCues = async (id, payload) => {
       Authorization: `bearer ${getToken()}`,
     },
   }
-  const response = await axios.put(`${baseUrl}${id}/swap`, payload, config)
+  const response = await axios.put(`${baseUrl}${id}/swapCues`, payload, config)
   return response.data
 }
 

--- a/src/client/tests/unit/EditMode.test.jsx
+++ b/src/client/tests/unit/EditMode.test.jsx
@@ -1,0 +1,210 @@
+import React from "react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import EditMode from "../../components/presentation/EditMode"
+import { useDispatch, useSelector } from "react-redux"
+import {
+  swapCues,
+  updatePresentation,
+} from "../../redux/presentationReducer"
+
+const mockDispatch = jest.fn(() => Promise.resolve({}))
+const mockShowToast = jest.fn()
+let mockDragScenario = null
+
+jest.mock("react-redux", () => ({
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+}))
+
+jest.mock("../../redux/presentationReducer", () => ({
+  updatePresentation: jest.fn(() => ({ type: "MOCK_UPDATE_PRESENTATION" })),
+  createCue: jest.fn(() => ({ type: "MOCK_CREATE_CUE" })),
+  removeCue: jest.fn(() => ({ type: "MOCK_REMOVE_CUE" })),
+  swapCues: jest.fn(() => ({ type: "MOCK_SWAP_CUES" })),
+  incrementIndexCount: jest.fn(() => ({ type: "MOCK_INCREMENT_INDEX_COUNT" })),
+  decrementIndexCount: jest.fn(() => ({ type: "MOCK_DECREMENT_INDEX_COUNT" })),
+  incrementScreenCount: jest.fn(() => ({ type: "MOCK_INCREMENT_SCREEN_COUNT" })),
+  decrementScreenCount: jest.fn(() => ({ type: "MOCK_DECREMENT_SCREEN_COUNT" })),
+  editCue: jest.fn(() => ({ type: "MOCK_EDIT_CUE" })),
+  shiftPresentationIndexes: jest.fn(() => ({ type: "MOCK_SHIFT_INDEXES" })),
+  fetchPresentationInfo: jest.fn(() => ({ type: "MOCK_FETCH_PRESENTATION_INFO" })),
+}))
+
+jest.mock("../../redux/presentationThunks", () => ({
+  saveIndexCount: jest.fn(() => ({ type: "MOCK_SAVE_INDEX_COUNT" })),
+  saveScreenCount: jest.fn(() => ({ type: "MOCK_SAVE_SCREEN_COUNT" })),
+}))
+
+jest.mock("../../components/utils/toastUtils", () => ({
+  useCustomToast: () => mockShowToast,
+}))
+
+jest.mock("../../components/presentation/ToolBox", () => {
+  return function MockToolBox() {
+    return <div data-testid="toolbox" />
+  }
+})
+
+jest.mock("../../components/presentation/StatusToolTip", () => {
+  return function MockStatusToolTip() {
+    return <div data-testid="status-tooltip" />
+  }
+})
+
+jest.mock("../../components/utils/CustomAlert", () => {
+  return function MockCustomAlert() {
+    return <div data-testid="custom-alert" />
+  }
+})
+
+jest.mock("../../components/utils/AlertDialog", () => {
+  return function MockAlertDialog() {
+    return null
+  }
+})
+
+jest.mock("../../services/presentation", () => ({
+  __esModule: true,
+  default: {},
+}))
+
+jest.mock("react-grid-layout", () => {
+  const mockReact = require("react")
+
+  return function MockGridLayout({ children, onDragStop }) {
+    const scenarios = {
+      visualSwapVisual: {
+        oldItem: { i: "visual-1", x: 0, y: 0 },
+        newItem: { i: "visual-1", x: 1, y: 0 },
+      },
+    }
+
+    const runScenario = () => {
+      const scenario = scenarios[mockDragScenario]
+      if (!scenario) {
+        return
+      }
+
+      onDragStop([], scenario.oldItem, scenario.newItem)
+    }
+
+    return (
+      <div>
+        <button
+          type="button"
+          data-testid="trigger-drag-stop"
+          onClick={runScenario}
+        >
+          trigger
+        </button>
+        {mockReact.Children.map(children, (child) => (
+          <div className="react-grid-item">{child}</div>
+        ))}
+      </div>
+    )
+  }
+})
+
+describe("EditMode drag swapping", () => {
+  const cues = [
+    {
+      _id: "visual-1",
+      index: 0,
+      screen: 1,
+      name: "Visual cue 1",
+      color: "#ffffff",
+      cueType: "visual",
+      file: { type: "image/png", url: "https://example.com/1.png", name: "1.png" },
+    },
+    {
+      _id: "visual-2",
+      index: 1,
+      screen: 1,
+      name: "Visual cue 2",
+      color: "#000000",
+      cueType: "visual",
+      file: { type: "image/png", url: "https://example.com/2.png", name: "2.png" },
+    },
+  ]
+
+  const renderEditMode = () => {
+    return render(
+      <EditMode
+        id="presentation-1"
+        cues={cues}
+        isToolboxOpen={false}
+        setIsToolboxOpen={jest.fn()}
+        isShowMode={false}
+        cueIndex={0}
+        isAudioMuted={false}
+        toggleAudioMute={jest.fn()}
+        indexCount={3}
+      />
+    )
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    useDispatch.mockReturnValue(mockDispatch)
+    useSelector.mockImplementation((selector) => selector({
+      presentation: {
+        cues,
+        name: "Test presentation",
+        screenCount: 2,
+        indexCount: 3,
+      },
+    }))
+    mockDragScenario = null
+  })
+
+  it("swaps cues after drag collision without dispatching a direct move update", async () => {
+    mockDragScenario = "visualSwapVisual"
+
+    renderEditMode()
+
+    const gridContainer = screen.getByTestId("edit-mode-grid-container")
+    Object.defineProperty(gridContainer, "scrollLeft", {
+      configurable: true,
+      value: 0,
+    })
+    gridContainer.getBoundingClientRect = jest.fn(() => ({
+      left: 0,
+      top: 0,
+      right: 480,
+      bottom: 440,
+      width: 480,
+      height: 440,
+    }))
+
+    fireEvent.mouseDown(screen.getByTestId("cue-Visual cue 1"), {
+      clientX: 10,
+      clientY: 120,
+    })
+
+    fireEvent.click(screen.getByTestId("trigger-drag-stop"))
+
+    fireEvent.mouseUp(gridContainer, {
+      clientX: 170,
+      clientY: 120,
+    })
+
+    await waitFor(() => {
+      expect(swapCues).toHaveBeenCalledWith(
+        "presentation-1",
+        expect.objectContaining({
+          _id: "visual-2",
+          index: 0,
+          screen: 1,
+        }),
+        expect.objectContaining({
+          _id: "visual-1",
+          index: 1,
+          screen: 1,
+        })
+      )
+    })
+
+    expect(updatePresentation).not.toHaveBeenCalled()
+  })
+})

--- a/src/client/tests/unit/GridLayoutComponent.test.jsx
+++ b/src/client/tests/unit/GridLayoutComponent.test.jsx
@@ -1,0 +1,275 @@
+import React from "react"
+import { render, fireEvent, screen, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import GridLayoutComponent from "../../components/presentation/GridLayoutComponent"
+import { useDispatch } from "react-redux"
+import { updatePresentation, removeCue } from "../../redux/presentationReducer"
+
+const mockDispatch = jest.fn(() => Promise.resolve({}))
+const mockShowToast = jest.fn()
+let mockDragScenario = null
+
+jest.mock("react-redux", () => ({
+  useDispatch: jest.fn(),
+}))
+
+jest.mock("../../redux/presentationReducer", () => ({
+  updatePresentation: jest.fn(() => ({ type: "MOCK_UPDATE_PRESENTATION" })),
+  removeCue: jest.fn(() => ({ type: "MOCK_REMOVE_CUE" })),
+}))
+
+jest.mock("../../components/utils/toastUtils", () => ({
+  useCustomToast: () => mockShowToast,
+}))
+
+jest.mock("react-grid-layout", () => {
+  return function MockGridLayout({ children, onDragStop }) {
+    const scenarios = {
+      visualToEmptyVisual: {
+        oldItem: { i: "visual-1", x: 0, y: 8 },
+        newItem: { i: "visual-1", x: 0, y: 0 },
+      },
+      visualSwapVisual: {
+        oldItem: { i: "visual-1", x: 0, y: 0 },
+        newItem: { i: "visual-1", x: 1, y: 0 },
+      },
+      visualToAudio: {
+        oldItem: { i: "visual-1", x: 0, y: 0 },
+        newItem: { i: "visual-1", x: 0, y: 8 },
+      },
+      audioToEmptyAudio: {
+        oldItem: { i: "audio-1", x: 0, y: 8 },
+        newItem: { i: "audio-1", x: 1, y: 8 },
+      },
+      audioSwapAudio: {
+        oldItem: { i: "audio-1", x: 0, y: 8 },
+        newItem: { i: "audio-1", x: 2, y: 8 },
+      },
+    }
+
+    const runScenario = () => {
+      const scenario = scenarios[mockDragScenario]
+      if (!scenario) {
+        return
+      }
+      onDragStop([], scenario.oldItem, scenario.newItem)
+    }
+
+    return (
+      <div>
+        <button
+          type="button"
+          data-testid="trigger-drag-stop"
+          onClick={runScenario}
+        >
+          trigger
+        </button>
+        {children}
+      </div>
+    )
+  }
+})
+
+describe("GridLayoutComponent drag constraints", () => {
+  const baseProps = {
+    id: "presentation-1",
+    setStatus: jest.fn(),
+    setCopiedCue: jest.fn(),
+    setIsCopied: jest.fn(),
+    columnWidth: 150,
+    rowHeight: 100,
+    gap: 10,
+    isShowMode: false,
+    cueIndex: 0,
+    isAudioMuted: false,
+    setSelectedCue: jest.fn(),
+    setIsToolboxOpen: jest.fn(),
+    indexCount: 10,
+    setShowAlert: jest.fn(),
+    setAlertData: jest.fn(),
+    screenCount: 8,
+  }
+
+  const renderGrid = (cues, layout) => {
+    return render(
+      <GridLayoutComponent
+        {...baseProps}
+        cues={cues}
+        layout={layout}
+      />
+    )
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    useDispatch.mockReturnValue(mockDispatch)
+    mockDragScenario = null
+  })
+
+  it("visual cue can be moved to an empty visual row slot", async () => {
+    mockDragScenario = "visualToEmptyVisual"
+
+    const cues = [
+      {
+        _id: "visual-1",
+        index: 0,
+        screen: 9,
+        name: "Visual cue",
+        color: "#ffffff",
+        loop: false,
+        file: {
+          type: "image/png",
+          url: "https://example.com/image.png",
+          name: "image.png",
+        },
+      },
+    ]
+
+    renderGrid(cues, [{ i: "visual-1", x: 0, y: 8, w: 1, h: 1, static: false }])
+
+    fireEvent.click(screen.getByTestId("trigger-drag-stop"))
+
+    await waitFor(() => {
+      expect(updatePresentation).toHaveBeenCalledWith("presentation-1", {
+        cueId: "visual-1",
+        index: 0,
+        screen: 1,
+        cueName: "Visual cue",
+        color: "#ffffff",
+      })
+    })
+
+    expect(mockDispatch).toHaveBeenCalled()
+    expect(removeCue).not.toHaveBeenCalled()
+    expect(mockShowToast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Cannot move this file type here" })
+    )
+  })
+
+  it("visual cue can be swapped with another visual cue", () => {
+    mockDragScenario = "visualSwapVisual"
+
+    const cues = [
+      {
+        _id: "visual-1",
+        index: 0,
+        screen: 1,
+        name: "Visual cue 1",
+        color: "#ffffff",
+        file: { type: "image/png", url: "https://example.com/1.png", name: "1.png" },
+      },
+      {
+        _id: "visual-2",
+        index: 1,
+        screen: 1,
+        name: "Visual cue 2",
+        color: "#000000",
+        file: { type: "image/png", url: "https://example.com/2.png", name: "2.png" },
+      },
+    ]
+
+    renderGrid(cues, [
+      { i: "visual-1", x: 0, y: 0, w: 1, h: 1, static: false },
+      { i: "visual-2", x: 1, y: 0, w: 1, h: 1, static: false },
+    ])
+
+    fireEvent.click(screen.getByTestId("trigger-drag-stop"))
+
+    expect(updatePresentation).not.toHaveBeenCalled()
+    expect(mockShowToast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Cannot move this file type here" })
+    )
+  })
+
+  it("visual cue cannot be moved to audio row", () => {
+    mockDragScenario = "visualToAudio"
+
+    const cues = [
+      {
+        _id: "visual-1",
+        index: 0,
+        screen: 1,
+        name: "Visual cue",
+        color: "#ffffff",
+        file: { type: "image/png", url: "https://example.com/image.png", name: "image.png" },
+      },
+    ]
+
+    renderGrid(cues, [{ i: "visual-1", x: 0, y: 0, w: 1, h: 1, static: false }])
+
+    fireEvent.click(screen.getByTestId("trigger-drag-stop"))
+
+    expect(updatePresentation).not.toHaveBeenCalled()
+    expect(mockShowToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Cannot move this file type here" })
+    )
+  })
+
+  it("audio cue can be moved to an empty audio row slot", async () => {
+    mockDragScenario = "audioToEmptyAudio"
+
+    const cues = [
+      {
+        _id: "audio-1",
+        index: 0,
+        screen: 9,
+        name: "Audio cue",
+        color: "#ffffff",
+        file: { type: "audio/mpeg", url: "https://example.com/audio.mp3", name: "audio.mp3" },
+      },
+    ]
+
+    renderGrid(cues, [{ i: "audio-1", x: 0, y: 8, w: 1, h: 1, static: false }])
+
+    fireEvent.click(screen.getByTestId("trigger-drag-stop"))
+
+    await waitFor(() => {
+      expect(updatePresentation).toHaveBeenCalledWith("presentation-1", {
+        cueId: "audio-1",
+        index: 1,
+        screen: 9,
+        cueName: "Audio cue",
+        color: "#ffffff",
+      })
+    })
+
+    expect(mockShowToast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Cannot move this file type here" })
+    )
+  })
+
+  it("audio cue can be swapped with audio cue", () => {
+    mockDragScenario = "audioSwapAudio"
+
+    const cues = [
+      {
+        _id: "audio-1",
+        index: 0,
+        screen: 9,
+        name: "Audio cue 1",
+        color: "#ffffff",
+        file: { type: "audio/mpeg", url: "https://example.com/a1.mp3", name: "a1.mp3" },
+      },
+      {
+        _id: "audio-2",
+        index: 2,
+        screen: 9,
+        name: "Audio cue 2",
+        color: "#000000",
+        file: { type: "audio/mpeg", url: "https://example.com/a2.mp3", name: "a2.mp3" },
+      },
+    ]
+
+    renderGrid(cues, [
+      { i: "audio-1", x: 0, y: 8, w: 1, h: 1, static: false },
+      { i: "audio-2", x: 2, y: 8, w: 1, h: 1, static: false },
+    ])
+
+    fireEvent.click(screen.getByTestId("trigger-drag-stop"))
+
+    expect(updatePresentation).not.toHaveBeenCalled()
+    expect(mockShowToast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Cannot move this file type here" })
+    )
+  })
+})

--- a/src/client/tests/unit/GridLayoutComponent.test.jsx
+++ b/src/client/tests/unit/GridLayoutComponent.test.jsx
@@ -117,6 +117,7 @@ describe("GridLayoutComponent drag constraints", () => {
         name: "Visual cue",
         color: "#ffffff",
         loop: false,
+        cueType: "visual",
         file: {
           type: "image/png",
           url: "https://example.com/image.png",
@@ -156,6 +157,7 @@ describe("GridLayoutComponent drag constraints", () => {
         screen: 1,
         name: "Visual cue 1",
         color: "#ffffff",
+        cueType: "visual",
         file: { type: "image/png", url: "https://example.com/1.png", name: "1.png" },
       },
       {
@@ -164,6 +166,7 @@ describe("GridLayoutComponent drag constraints", () => {
         screen: 1,
         name: "Visual cue 2",
         color: "#000000",
+        cueType: "visual",
         file: { type: "image/png", url: "https://example.com/2.png", name: "2.png" },
       },
     ]
@@ -191,6 +194,7 @@ describe("GridLayoutComponent drag constraints", () => {
         screen: 1,
         name: "Visual cue",
         color: "#ffffff",
+        cueType: "visual",
         file: { type: "image/png", url: "https://example.com/image.png", name: "image.png" },
       },
     ]
@@ -215,6 +219,7 @@ describe("GridLayoutComponent drag constraints", () => {
         screen: 9,
         name: "Audio cue",
         color: "#ffffff",
+        cueType: "audio",
         file: { type: "audio/mpeg", url: "https://example.com/audio.mp3", name: "audio.mp3" },
       },
     ]
@@ -248,6 +253,7 @@ describe("GridLayoutComponent drag constraints", () => {
         screen: 9,
         name: "Audio cue 1",
         color: "#ffffff",
+        cueType: "audio",
         file: { type: "audio/mpeg", url: "https://example.com/a1.mp3", name: "a1.mp3" },
       },
       {
@@ -256,6 +262,7 @@ describe("GridLayoutComponent drag constraints", () => {
         screen: 9,
         name: "Audio cue 2",
         color: "#000000",
+        cueType: "audio",
         file: { type: "audio/mpeg", url: "https://example.com/a2.mp3", name: "a2.mp3" },
       },
     ]

--- a/src/client/tests/unit/presentationReducer.test.js
+++ b/src/client/tests/unit/presentationReducer.test.js
@@ -10,7 +10,7 @@ import reducer, {
   createCue,
   deletePresentation,
   updatePresentation,
-  updatePresentationSwappedCues,
+  swapCues,
   incrementIndexCount,
   decrementIndexCount,
   incrementScreenCount,
@@ -868,7 +868,7 @@ describe("presentationReducer asynchronous actions", () => {
     })
 
     await store.dispatch(
-      updatePresentationSwappedCues("123", firstUpdatedCue, secondUpdatedCue)
+      swapCues("123", firstUpdatedCue, secondUpdatedCue)
     )
 
     expect(presentationService.swapCues).toHaveBeenCalledWith("123", {
@@ -1087,7 +1087,7 @@ describe("presentationReducer asynchronous actions", () => {
 
     await expect(
       store.dispatch(
-        updatePresentationSwappedCues("123", firstUpdatedCue, secondUpdatedCue)
+        swapCues("123", firstUpdatedCue, secondUpdatedCue)
       )
     ).rejects.toThrow("Not found")
   })

--- a/src/client/tests/unit/presentationReducer.test.js
+++ b/src/client/tests/unit/presentationReducer.test.js
@@ -37,6 +37,7 @@ jest.mock("../../services/presentation.js", () => ({
   addCue: jest.fn(),
   remove: jest.fn(),
   updateCue: jest.fn(),
+  swapCues: jest.fn(),
   saveScreenCountApi: jest.fn(),
   saveIndexCountApi: jest.fn(),
   shiftIndexes: jest.fn(),
@@ -861,25 +862,23 @@ describe("presentationReducer asynchronous actions", () => {
       screen: 1,
     }
 
-    presentationService.updateCue
-      .mockResolvedValueOnce(firstUpdatedCue)
-      .mockResolvedValueOnce(secondUpdatedCue)
+    presentationService.swapCues.mockResolvedValue({
+      firstCue: firstUpdatedCue,
+      secondCue: secondUpdatedCue,
+    })
 
     await store.dispatch(
       updatePresentationSwappedCues("123", firstUpdatedCue, secondUpdatedCue)
     )
 
-    expect(presentationService.updateCue).toHaveBeenCalledWith(
-      "123",
-      firstUpdatedCue._id,
-      expect.any(FormData)
-    )
-
-    expect(presentationService.updateCue).toHaveBeenCalledWith(
-      "123",
-      secondUpdatedCue._id,
-      expect.any(FormData)
-    )
+    expect(presentationService.swapCues).toHaveBeenCalledWith("123", {
+      firstCueId: firstUpdatedCue._id,
+      secondCueId: secondUpdatedCue._id,
+      firstIndex: firstUpdatedCue.index,
+      firstScreen: firstUpdatedCue.screen,
+      secondIndex: secondUpdatedCue.index,
+      secondScreen: secondUpdatedCue.screen,
+    })
 
     expect(store.getState().presentation.cues).toContainEqual(firstUpdatedCue)
     expect(store.getState().presentation.cues).toContainEqual(secondUpdatedCue)
@@ -1082,7 +1081,7 @@ describe("presentationReducer asynchronous actions", () => {
       screen: 1,
     }
 
-    presentationService.updateCue.mockRejectedValue({
+    presentationService.swapCues.mockRejectedValue({
       response: { data: { error: "Not found" } },
     })
 

--- a/src/server/routes/presentation.js
+++ b/src/server/routes/presentation.js
@@ -39,6 +39,29 @@ const hasPositionConflict = (cues, index, screen, excludedCueId = null) => {
   })
 }
 
+const hasSwapTargetConflict = (
+  cues,
+  firstCueId,
+  secondCueId,
+  firstTargetIndex,
+  firstTargetScreen,
+  secondTargetIndex,
+  secondTargetScreen
+) => {
+  return cues.some((cue) => {
+    const cueId = cue._id.toString()
+
+    if (cueId === firstCueId.toString() || cueId === secondCueId.toString()) {
+      return false
+    }
+
+    return (
+      (Number(cue.index) === firstTargetIndex && Number(cue.screen) === firstTargetScreen) ||
+      (Number(cue.index) === secondTargetIndex && Number(cue.screen) === secondTargetScreen)
+    )
+  })
+}
+
 const deletObject = async (id, cueId, driveToken) => {
   const cue = await Presentation.findOne(
     { _id: id, "cues._id": cueId },
@@ -460,7 +483,9 @@ router.put("/:id/swapCues", userExtractor, requirePresentationAccess, async (req
     const parsedFirstScreen = Number(firstScreen)
     const parsedSecondIndex = Number(secondIndex)
     const parsedSecondScreen = Number(secondScreen)
+    const maxScreen = presentation.screenCount + 1
 
+    // Validate request payload.
     if (
       !firstCueId ||
       !secondCueId ||
@@ -485,7 +510,6 @@ router.put("/:id/swapCues", userExtractor, requirePresentationAccess, async (req
       return res.status(400).json({ error: "Cannot swap a cue with itself" })
     }
 
-    const maxScreen = presentation.screenCount + 1
     if (
       parsedFirstIndex < 0 ||
       parsedFirstIndex >= presentation.indexCount ||
@@ -499,6 +523,7 @@ router.put("/:id/swapCues", userExtractor, requirePresentationAccess, async (req
       return res.status(400).json({ error: "Invalid swap target position" })
     }
 
+    // Resolve and validate the cues being swapped.
     const firstCue = presentation.cues.id(firstCueId)
     const secondCue = presentation.cues.id(secondCueId)
 
@@ -506,29 +531,43 @@ router.put("/:id/swapCues", userExtractor, requirePresentationAccess, async (req
       return res.status(404).json({ error: "Cue not found" })
     }
 
-    const hasThirdCueConflict = presentation.cues.some((cue) => {
-      const cueId = cue._id.toString()
-      if (cueId === firstCueId.toString() || cueId === secondCueId.toString()) {
-        return false
-      }
+    const firstTargetCueType = getCueTypeFromScreen(parsedFirstScreen, presentation.screenCount)
+    const secondTargetCueType = getCueTypeFromScreen(parsedSecondScreen, presentation.screenCount)
+    const firstCurrentCueType = firstCue.cueType ?? getCueTypeFromScreen(firstCue.screen, presentation.screenCount)
+    const secondCurrentCueType = secondCue.cueType ?? getCueTypeFromScreen(secondCue.screen, presentation.screenCount)
+    const firstCueMatchesTargetRow = firstCurrentCueType === firstTargetCueType
+    const secondCueMatchesTargetRow = secondCurrentCueType === secondTargetCueType
 
-      return (
-        (Number(cue.index) === parsedFirstIndex && Number(cue.screen) === parsedFirstScreen) ||
-        (Number(cue.index) === parsedSecondIndex && Number(cue.screen) === parsedSecondScreen)
+    if (!firstCueMatchesTargetRow || !secondCueMatchesTargetRow) {
+      return res.status(400).json({ error: "Cue type does not match swap target screen" })
+    }
+
+    // Reject swaps that would collide with a third cue.
+    if (
+      hasSwapTargetConflict(
+        presentation.cues,
+        firstCueId,
+        secondCueId,
+        parsedFirstIndex,
+        parsedFirstScreen,
+        parsedSecondIndex,
+        parsedSecondScreen
       )
-    })
-
-    if (hasThirdCueConflict) {
+    ) {
       return res.status(400).json({ error: "Swap target position is already occupied by another cue." })
     }
 
+    // Apply the swap and persist the normalized cue types.
     firstCue.index = parsedFirstIndex
     firstCue.screen = parsedFirstScreen
+    firstCue.cueType = firstTargetCueType
     secondCue.index = parsedSecondIndex
     secondCue.screen = parsedSecondScreen
+    secondCue.cueType = secondTargetCueType
 
     await presentation.save({ validateModifiedOnly: true })
 
+    // Rehydrate file URLs for the response.
     if (user.driveToken) {
       const [updatedFirstCue, updatedSecondCue] = await processDriveCueFiles(
         [firstCue, secondCue],

--- a/src/server/routes/presentation.js
+++ b/src/server/routes/presentation.js
@@ -443,7 +443,7 @@ router.put("/:id/shiftIndexes", userExtractor, requirePresentationAccess, async 
   }
 })
 
-router.put("/:id/swap", userExtractor, requirePresentationAccess, async (req, res, next) => {
+router.put("/:id/swapCues", userExtractor, requirePresentationAccess, async (req, res, next) => {
   try {
     const { id } = req.params
     const { presentation, user } = req

--- a/src/server/routes/presentation.js
+++ b/src/server/routes/presentation.js
@@ -24,6 +24,20 @@ const storage = multer.memoryStorage()
 const upload = multer({ storage })
 
 const generateFileId = () => crypto.randomBytes(8).toString("hex")
+const hasPositionConflict = (cues, index, screen, excludedCueId = null) => {
+  return cues.some((cue) => {
+    const samePosition = Number(cue.index) === Number(index) && Number(cue.screen) === Number(screen)
+    if (!samePosition) {
+      return false
+    }
+
+    if (!excludedCueId) {
+      return true
+    }
+
+    return cue._id.toString() !== excludedCueId.toString()
+  })
+}
 
 const deletObject = async (id, cueId, driveToken) => {
   const cue = await Presentation.findOne(
@@ -311,6 +325,10 @@ router.put("/:id", userExtractor, requirePresentationAccess, upload.single("imag
       }
     }
 
+    if (hasPositionConflict(presentation.cues, index, screen)) {
+      return res.status(400).json({ error: "A cue with the same index and screen already exists." })
+    }
+
     const fileObject = {
               id: fileId,
               name: file && file.originalname ? file.originalname : (image === "/blank-white.png" ? "blank-white.png" : image === "/blank-indigo.png" ? "blank-indigo.png" : image === "/blank-tropicalindigo.png" ? "blank-tropicalindigo.png" : "blank2.png"),
@@ -424,6 +442,108 @@ router.put("/:id/shiftIndexes", userExtractor, requirePresentationAccess, async 
     next(err)
   }
 })
+
+router.put("/:id/swap", userExtractor, requirePresentationAccess, async (req, res, next) => {
+  try {
+    const { id } = req.params
+    const { presentation, user } = req
+    const {
+      firstCueId,
+      secondCueId,
+      firstIndex,
+      firstScreen,
+      secondIndex,
+      secondScreen,
+    } = req.body
+
+    const parsedFirstIndex = Number(firstIndex)
+    const parsedFirstScreen = Number(firstScreen)
+    const parsedSecondIndex = Number(secondIndex)
+    const parsedSecondScreen = Number(secondScreen)
+
+    if (
+      !firstCueId ||
+      !secondCueId ||
+      isNaN(parsedFirstIndex) ||
+      isNaN(parsedFirstScreen) ||
+      isNaN(parsedSecondIndex) ||
+      isNaN(parsedSecondScreen)
+    ) {
+      return res.status(400).json({ error: "Missing required swap fields" })
+    }
+
+    if (
+      !Number.isInteger(parsedFirstIndex) ||
+      !Number.isInteger(parsedFirstScreen) ||
+      !Number.isInteger(parsedSecondIndex) ||
+      !Number.isInteger(parsedSecondScreen)
+    ) {
+      return res.status(400).json({ error: "Swap coordinates must be integers" })
+    }
+
+    if (firstCueId === secondCueId) {
+      return res.status(400).json({ error: "Cannot swap a cue with itself" })
+    }
+
+    const maxScreen = presentation.screenCount + 1
+    if (
+      parsedFirstIndex < 0 ||
+      parsedFirstIndex >= presentation.indexCount ||
+      parsedSecondIndex < 0 ||
+      parsedSecondIndex >= presentation.indexCount ||
+      parsedFirstScreen < 1 ||
+      parsedFirstScreen > maxScreen ||
+      parsedSecondScreen < 1 ||
+      parsedSecondScreen > maxScreen
+    ) {
+      return res.status(400).json({ error: "Invalid swap target position" })
+    }
+
+    const firstCue = presentation.cues.id(firstCueId)
+    const secondCue = presentation.cues.id(secondCueId)
+
+    if (!firstCue || !secondCue) {
+      return res.status(404).json({ error: "Cue not found" })
+    }
+
+    const hasThirdCueConflict = presentation.cues.some((cue) => {
+      const cueId = cue._id.toString()
+      if (cueId === firstCueId.toString() || cueId === secondCueId.toString()) {
+        return false
+      }
+
+      return (
+        (Number(cue.index) === parsedFirstIndex && Number(cue.screen) === parsedFirstScreen) ||
+        (Number(cue.index) === parsedSecondIndex && Number(cue.screen) === parsedSecondScreen)
+      )
+    })
+
+    if (hasThirdCueConflict) {
+      return res.status(400).json({ error: "Swap target position is already occupied by another cue." })
+    }
+
+    firstCue.index = parsedFirstIndex
+    firstCue.screen = parsedFirstScreen
+    secondCue.index = parsedSecondIndex
+    secondCue.screen = parsedSecondScreen
+
+    await presentation.save({ validateModifiedOnly: true })
+
+    if (user.driveToken) {
+      const [updatedFirstCue, updatedSecondCue] = await processDriveCueFiles(
+        [firstCue, secondCue],
+        user.driveToken
+      )
+      return res.json({ firstCue: updatedFirstCue, secondCue: updatedSecondCue })
+    }
+
+    const [updatedFirstCue, updatedSecondCue] = await processS3Files([firstCue, secondCue], id)
+    return res.json({ firstCue: updatedFirstCue, secondCue: updatedSecondCue })
+  } catch (error) {
+    next(error)
+  }
+})
+
 router.put(
   "/:id/:cueId",
   userExtractor,
@@ -495,6 +615,11 @@ router.put(
       if (!cue) {
         return res.status(404).json({ error: "Cue not found" })
       }
+
+      if (hasPositionConflict(presentation.cues, index, screen, cueId)) {
+        return res.status(400).json({ error: "A cue with the same index and screen already exists." })
+      }
+
       // Update cue fields
       cue.index = index
       cue.screen = screen

--- a/src/server/tests/presentation_api.test.js
+++ b/src/server/tests/presentation_api.test.js
@@ -16,6 +16,7 @@ let authHeader
 let testPresentationId
 
 const mockImageBuffer = fs.readFileSync(path.join(__dirname, "mock_image.png"))
+const mockAudioBuffer = Buffer.from("mock-audio")
 
 describe("test presentation", () => {
   beforeEach(async () => {
@@ -59,6 +60,28 @@ describe("test presentation", () => {
       .put(url)
       .set("Authorization", authHeader)
       .attach("image", mockImageBuffer, "mock_image.png")
+      .field("index", index)
+      .field("cueName", cueName)
+      .field("screen", screen)
+      .field("fileName", "")
+
+    return response
+  }
+
+  const createAudioCue = async (index, cueName, screen) => {
+    if (!testPresentationId) {
+      throw new Error("Error in createAudioCue: testPresentationId is undefined")
+    }
+
+    const url = `/api/presentation/${testPresentationId}`
+
+    const response = await api
+      .put(url)
+      .set("Authorization", authHeader)
+      .attach("image", mockAudioBuffer, {
+        filename: "mock_audio.mp3",
+        contentType: "audio/mpeg",
+      })
       .field("index", index)
       .field("cueName", cueName)
       .field("screen", screen)
@@ -398,6 +421,42 @@ describe("test presentation", () => {
         .expect(400)
 
       expect(response.body.error).toBe("Swap target position is already occupied by another cue.")
+    })
+
+    test("rejects swap when cue types do not match target screens", async () => {
+      await Presentation.findByIdAndUpdate(
+        testPresentationId,
+        {
+          screenCount: 4,
+        },
+        { new: true }
+      )
+
+      const deleteResponse = await Presentation.findById(testPresentationId)
+      deleteResponse.cues = []
+      await deleteResponse.save()
+
+      await createCue(0, "Visual Cue", 1)
+      await createAudioCue(0, "Audio Cue", 5)
+
+      const presentation = await Presentation.findById(testPresentationId)
+      const visualCue = presentation.cues.find((cue) => cue.name === "Visual Cue")
+      const audioCue = presentation.cues.find((cue) => cue.name === "Audio Cue")
+
+      const response = await api
+        .put(`/api/presentation/${testPresentationId}/swapCues`)
+        .set("Authorization", authHeader)
+        .send({
+          firstCueId: visualCue._id.toString(),
+          secondCueId: audioCue._id.toString(),
+          firstIndex: 0,
+          firstScreen: 5,
+          secondIndex: 0,
+          secondScreen: 1,
+        })
+        .expect(400)
+
+      expect(response.body.error).toBe("Cue type does not match swap target screen")
     })
   })
 

--- a/src/server/tests/presentation_api.test.js
+++ b/src/server/tests/presentation_api.test.js
@@ -317,6 +317,90 @@ describe("test presentation", () => {
     })
   })
 
+  describe("PUT /api/presentation/:id/swapCues", () => {
+    let firstCueId
+    let secondCueId
+
+    beforeEach(async () => {
+      await createCue(0, "Swap Cue 1", 1)
+      await createCue(1, "Swap Cue 2", 1)
+
+      const presentation = await Presentation.findById(testPresentationId)
+      const firstCue = presentation.cues.find((cue) => cue.name === "Swap Cue 1")
+      const secondCue = presentation.cues.find((cue) => cue.name === "Swap Cue 2")
+
+      firstCueId = firstCue._id.toString()
+      secondCueId = secondCue._id.toString()
+    })
+
+    test("swaps cues successfully", async () => {
+      const response = await api
+        .put(`/api/presentation/${testPresentationId}/swapCues`)
+        .set("Authorization", authHeader)
+        .send({
+          firstCueId,
+          secondCueId,
+          firstIndex: 1,
+          firstScreen: 1,
+          secondIndex: 0,
+          secondScreen: 1,
+        })
+        .expect(200)
+
+      expect(response.body.firstCue).toBeDefined()
+      expect(response.body.secondCue).toBeDefined()
+      expect(response.body.firstCue.index).toBe(1)
+      expect(response.body.firstCue.screen).toBe(1)
+      expect(response.body.secondCue.index).toBe(0)
+      expect(response.body.secondCue.screen).toBe(1)
+
+      const updatedPresentation = await Presentation.findById(testPresentationId)
+      const updatedFirstCue = updatedPresentation.cues.id(firstCueId)
+      const updatedSecondCue = updatedPresentation.cues.id(secondCueId)
+
+      expect(updatedFirstCue.index).toBe(1)
+      expect(updatedFirstCue.screen).toBe(1)
+      expect(updatedSecondCue.index).toBe(0)
+      expect(updatedSecondCue.screen).toBe(1)
+    })
+
+    test("rejects decimal swap coordinates", async () => {
+      const response = await api
+        .put(`/api/presentation/${testPresentationId}/swapCues`)
+        .set("Authorization", authHeader)
+        .send({
+          firstCueId,
+          secondCueId,
+          firstIndex: 1.5,
+          firstScreen: 1,
+          secondIndex: 0,
+          secondScreen: 1,
+        })
+        .expect(400)
+
+      expect(response.body.error).toBe("Swap coordinates must be integers")
+    })
+
+    test("rejects swap when target position has third cue conflict", async () => {
+      await createCue(2, "Third Cue", 1)
+
+      const response = await api
+        .put(`/api/presentation/${testPresentationId}/swapCues`)
+        .set("Authorization", authHeader)
+        .send({
+          firstCueId,
+          secondCueId,
+          firstIndex: 2,
+          firstScreen: 1,
+          secondIndex: 0,
+          secondScreen: 1,
+        })
+        .expect(400)
+
+      expect(response.body.error).toBe("Swap target position is already occupied by another cue.")
+    })
+  })
+
   describe("PUT /api/presentation/:id/indexCount", () => {
     const validCases = [1, 5, 10, 100]
 


### PR DESCRIPTION
This pull request refactors and improves the cue swapping functionality in the presentation editor. The main change is to consolidate the logic for swapping cues into a dedicated `swapCues` action and service API, replacing the previous pattern of updating two cues individually. The update also includes new and updated unit tests for both the reducer and UI components to ensure correct drag-and-drop and swap behavior. These changes make cue swapping more reliable and maintainable.

**Cue Swapping Refactor and API Changes**
- Replaces the `updatePresentationSwappedCues` action with a new `swapCues` action, which calls a new `swapCues` API endpoint on the backend. This streamlines cue swapping by handling both cues in a single server call and simplifies the Redux and service logic.

**Frontend UI and Logic Updates**
- Updates the drag-and-drop logic in `GridLayoutComponent` to detect cue collisions and trigger the new swap action, preventing direct move updates when a swap is appropriate. Also adds a `data-testid` to the grid container for easier testing.

**Conflict Detection Enhancements (Backend)**
- Adds new helper functions (`hasPositionConflict` and `hasSwapTargetConflict`) on the backend to robustly detect and prevent cue position conflicts during swaps or moves, improving data integrity.

**Testing Improvements**
- Adds comprehensive unit tests for the new swap action, reducer, and UI drag-and-drop scenarios, ensuring correct swap and move behavior for both visual and audio cues and verifying that invalid moves are prevented. 

