### PR TITLE
Move gh actions db to local container

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -18,10 +18,6 @@ jobs:
 
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.12.1
-        with:
-          mongodb-username: "testing"
-          mongodb-password: "testing"
-          mongodb-db: "test"
 
       - name: Install dependencies
         run: npm ci
@@ -33,7 +29,7 @@ jobs:
         run: |
           npm run test-all
         env:
-          TEST_MONGODB_URI: "mongodb://testing:testing@localhost/test"
+          TEST_MONGODB_URI: "mongodb://localhost/test"
           PUBLIC_S3_ENDPOINT: ${{ secrets.UPCLOUD_ENDPOINT }}
           BUCKET_NAME: ${{ secrets.UPCLOUD_BUCKET }}
           BUCKET_REGION: ${{ secrets.UPCLOUD_REGION }}


### PR DESCRIPTION
Removes depency of external db from github actions and speeds up backend tests by 4x. Also allows multiple instances of tests to be run concurrently.