### PR TITLE
Bugfix: Fixed race condition bug

### DIFF
--- a/src/client/redux/presentationReducer.js
+++ b/src/client/redux/presentationReducer.js
@@ -35,10 +35,11 @@ const presentationSlice = createSlice({
       state.cues = updatedCues
     },
     removePresentation(state) {
-      state.cues = null
-      state.name = ""
-      state.screenCount = null
-      state.indexCount = null
+      state.cues = initialState.cues
+      state.name = initialState.name
+      state.screenCount = initialState.screenCount
+      state.indexCount = initialState.indexCount
+      state.saving = initialState.saving
     },
     incrementIndexCount(state) {
       state.indexCount += 1
@@ -52,46 +53,48 @@ const presentationSlice = createSlice({
       state.screenCount += 1
     },
     decrementScreenCount(state) {
-       if (state.screenCount > 1) {
-         state.screenCount -= 1
-       }
+      if (state.screenCount > 1) {
+        state.screenCount -= 1
+      }
     },
     updateNameOnly(state, action) {
       state.name = action.payload
     },
   },
-  extraReducers: builder => {
+  extraReducers: (builder) => {
     builder
-      .addCase(saveIndexCount.pending, state => {
+      .addCase(saveIndexCount.pending, (state) => {
         state.saving = true
       })
       .addCase(saveIndexCount.fulfilled, (state, action) => {
         state.saving = false
         const newIndexCount = action.payload.indexCount
         state.indexCount = newIndexCount
-        state.cues = state.cues.filter(cue => cue.index < newIndexCount)
+        state.cues = state.cues.filter((cue) => cue.index < newIndexCount)
       })
-      .addCase(saveIndexCount.rejected, state => {
+      .addCase(saveIndexCount.rejected, (state) => {
         state.saving = false
       })
-      .addCase(saveScreenCount.pending, state => {
+      .addCase(saveScreenCount.pending, (state) => {
         state.saving = true
       })
       .addCase(saveScreenCount.fulfilled, (state, action) => {
         state.saving = false
-        
+
         if (action.payload.screenCount !== undefined) {
           const newScreenCount = action.payload.screenCount
           const removedCuesCount = action.payload.removedCuesCount
-          
+
           state.screenCount = newScreenCount
-          
+
           if (removedCuesCount > 0) {
-            state.cues = state.cues.filter(cue => cue.screen <= newScreenCount)
+            state.cues = state.cues.filter(
+              (cue) => cue.screen <= newScreenCount
+            )
           }
         }
       })
-      .addCase(saveScreenCount.rejected, state => {
+      .addCase(saveScreenCount.rejected, (state) => {
         state.saving = false
       })
   },
@@ -212,25 +215,34 @@ export const swapCues =
     }
   }
 
-export const shiftPresentationIndexes = (presentationId, startIndex, direction) => async (dispatch) => {
-  try {
-    const result = await presentationService.shiftIndexes(presentationId, startIndex, direction)
-    await dispatch(fetchPresentationInfo(presentationId))
-    return result
-  } catch (error) {
-    const errorMessage = error.response?.data?.error || "An error occurred"
-    console.error(errorMessage)
-    throw new Error(errorMessage)
+export const shiftPresentationIndexes =
+  (presentationId, startIndex, direction) => async (dispatch) => {
+    try {
+      const result = await presentationService.shiftIndexes(
+        presentationId,
+        startIndex,
+        direction
+      )
+      await dispatch(fetchPresentationInfo(presentationId))
+      return result
+    } catch (error) {
+      const errorMessage = error.response?.data?.error || "An error occurred"
+      console.error(errorMessage)
+      throw new Error(errorMessage)
+    }
   }
-}
 
-export const updatePresentationName = (presentationId, newName) => async (dispatch, getState) => {
-  try {
-    const updated = await presentationService.updatePresentationName(presentationId, newName)
-    dispatch(updateNameOnly(updated.name))
-  } catch (error) {
-    const errorMessage = error.response?.data?.error || "An error occurred"
-    console.error(errorMessage)
-    throw new Error(errorMessage)
+export const updatePresentationName =
+  (presentationId, newName) => async (dispatch, getState) => {
+    try {
+      const updated = await presentationService.updatePresentationName(
+        presentationId,
+        newName
+      )
+      dispatch(updateNameOnly(updated.name))
+    } catch (error) {
+      const errorMessage = error.response?.data?.error || "An error occurred"
+      console.error(errorMessage)
+      throw new Error(errorMessage)
+    }
   }
-}

--- a/src/client/tests/unit/presentationReducer.test.js
+++ b/src/client/tests/unit/presentationReducer.test.js
@@ -18,7 +18,10 @@ import reducer, {
   shiftPresentationIndexes,
   updatePresentationName,
 } from "../../redux/presentationReducer.js"
-import { saveIndexCount, saveScreenCount } from "../../redux/presentationThunks.js"
+import {
+  saveIndexCount,
+  saveScreenCount,
+} from "../../redux/presentationThunks.js"
 import presentationService from "../../services/presentation.js"
 import { configureStore } from "@reduxjs/toolkit"
 import { createFormData } from "../../components/utils/formDataUtils.js"
@@ -126,13 +129,15 @@ describe("presentationReducer actions", () => {
     expect(decrementScreenCount()).toEqual(expectedAction)
   })
 
-  it("should create an action to update presentation name only", () => { 
+  it("should create an action to update presentation name only", () => {
     const newName = "Updated Presentation Name"
     const expectedAction = {
       type: "presentation/updateNameOnly",
       payload: newName,
     }
-    expect({ type: "presentation/updateNameOnly", payload: newName  }).toEqual(expectedAction)
+    expect({ type: "presentation/updateNameOnly", payload: newName }).toEqual(
+      expectedAction
+    )
   })
 })
 
@@ -151,8 +156,17 @@ describe("presentationReducer reducer", () => {
     const name = "My Presentation"
     const screenCount = 3
     const indexCount = 5
-    const action = { type: setPresentationInfo.type, payload: { cues, name, screenCount, indexCount } }
-    const expectedState = { ...initialState, cues, name, screenCount, indexCount }
+    const action = {
+      type: setPresentationInfo.type,
+      payload: { cues, name, screenCount, indexCount },
+    }
+    const expectedState = {
+      ...initialState,
+      cues,
+      name,
+      screenCount,
+      indexCount,
+    }
 
     expect(reducer(initialState, action)).toEqual(expectedState)
   })
@@ -161,7 +175,7 @@ describe("presentationReducer reducer", () => {
     const initialStateWithCues = {
       ...initialState,
       cues: [{ _id: 1, name: "Test Cue" }],
-      name: "My Presentation"
+      name: "My Presentation",
     }
     const addedCue = { _id: 2, name: "Another Cue" }
     const action = { type: addCue.type, payload: addedCue }
@@ -183,7 +197,7 @@ describe("presentationReducer reducer", () => {
         { _id: 1, name: "Test Cue" },
         { _id: 2, name: "Another Cue" },
       ],
-      name: "My Presentation"
+      name: "My Presentation",
     }
     const action = { type: deleteCue.type, payload: 1 }
     const expectedState = {
@@ -196,7 +210,13 @@ describe("presentationReducer reducer", () => {
 
   it("should handle removePresentation when state is already null", () => {
     const action = { type: removePresentation.type }
-    const expectedState = { ...initialState, cues: null, name: "", screenCount: null, indexCount: null }
+    const expectedState = {
+      ...initialState,
+      cues: [],
+      name: "",
+      screenCount: null,
+      indexCount: 5,
+    }
 
     expect(reducer(initialState, action)).toEqual(expectedState)
   })
@@ -209,10 +229,15 @@ describe("presentationReducer reducer", () => {
         { _id: 2, name: "Another Cue" },
       ],
       name: "My Presentation",
-      screenCount: 3
+      screenCount: 3,
     }
     const action = { type: removePresentation.type }
-    const expectedState = { ...initialState, cues: null, screenCount: null, indexCount: null}
+    const expectedState = {
+      ...initialState,
+      cues: [],
+      screenCount: null,
+      indexCount: 5,
+    }
 
     expect(reducer(initialStateWithCues, action)).toEqual(expectedState)
   })
@@ -269,7 +294,7 @@ describe("presentationReducer reducer", () => {
       indexCount: 1,
     }
     const action = { type: decrementIndexCount.type }
-    
+
     const result = reducer(initialStateWithMinIndexCount, action)
     // Verify IndexCount doesn't go below 1
     expect(result.indexCount).toBeGreaterThanOrEqual(1)
@@ -309,7 +334,7 @@ describe("presentationReducer reducer", () => {
       screenCount: 1,
     }
     const action = { type: decrementScreenCount.type }
-    
+
     const result = reducer(initialStateWithMinScreenCount, action)
     // Verify screenCount doesn't go below 1
     expect(result.screenCount).toBeGreaterThanOrEqual(1)
@@ -317,7 +342,7 @@ describe("presentationReducer reducer", () => {
 
   it("should handle multiple cue additions", () => {
     let state = initialState
-    
+
     const cue1 = { _id: 1, name: "Cue 1" }
     const cue2 = { _id: 2, name: "Cue 2" }
     const cue3 = { _id: 3, name: "Cue 3" }
@@ -342,9 +367,9 @@ describe("presentationReducer reducer", () => {
       ],
     }
     const action = { type: deleteCue.type, payload: 2 }
-    
+
     const result = reducer(initialStateWithCues, action)
-    
+
     expect(result.cues).toHaveLength(2)
     expect(result.cues).not.toContainEqual({ _id: 2, name: "Cue 2" })
     expect(result.cues).toContainEqual({ _id: 1, name: "Cue 1" })
@@ -362,9 +387,9 @@ describe("presentationReducer reducer", () => {
     }
     const updatedCue = { _id: 2, name: "Updated Cue 2" }
     const action = { type: editCue.type, payload: updatedCue }
-    
+
     const result = reducer(initialStateWithCues, action)
-    
+
     expect(result.cues[1]).toEqual(updatedCue)
     expect(result.cues[0]).toEqual({ _id: 1, name: "Cue 1" })
     expect(result.cues[2]).toEqual({ _id: 3, name: "Cue 3" })
@@ -380,9 +405,9 @@ describe("presentationReducer reducer", () => {
     }
     const newCue = { _id: 2, name: "New Cue" }
     const action = { type: addCue.type, payload: newCue }
-    
+
     const result = reducer(initialStateWithData, action)
-    
+
     expect(result.name).toBe("My Presentation")
     expect(result.screenCount).toBe(5)
     expect(result.indexCount).toBe(10)
@@ -401,13 +426,13 @@ describe("presentationReducer reducer", () => {
       saving: false,
     }
     const action = { type: removePresentation.type }
-    
+
     const result = reducer(initialStateWithData, action)
-    
-    expect(result.cues).toBeNull()
+
+    expect(result.cues).toStrictEqual([])
     expect(result.name).toBe("")
     expect(result.screenCount).toBeNull()
-    expect(result.indexCount).toBeNull()
+    expect(result.indexCount).toBe(5)
   })
 
   it("should set all presentation properties on setPresentationInfo", () => {
@@ -418,9 +443,9 @@ describe("presentationReducer reducer", () => {
       indexCount: 20,
     }
     const action = { type: setPresentationInfo.type, payload: presentationData }
-    
+
     const result = reducer(initialState, action)
-    
+
     expect(result.cues).toEqual(presentationData.cues)
     expect(result.name).toBe("Full Presentation")
     expect(result.screenCount).toBe(5)
@@ -436,9 +461,9 @@ describe("presentationReducer reducer", () => {
       ],
     }
     const action = { type: deleteCue.type, payload: 1 }
-    
+
     const result = reducer(originalState, action)
-    
+
     // Original should remain unchanged
     expect(originalState.cues).toHaveLength(2)
     // Result should have 1 less
@@ -473,11 +498,11 @@ describe("presentationReducer asynchronous actions", () => {
   it("should remove cue", async () => {
     const store = makeStore()
     const initialState = {
-    cues: [
+      cues: [
         { _id: 1, name: "Cue 1" },
         { _id: 2, name: "Cue 2" },
       ],
-      name: "My Presentation"
+      name: "My Presentation",
     }
     store.dispatch(setPresentationInfo(initialState))
 
@@ -545,7 +570,7 @@ describe("presentationReducer asynchronous actions", () => {
     await store.dispatch(deletePresentation("123"))
 
     expect(presentationService.remove).toHaveBeenCalled()
-    expect(store.getState().presentation.cues).toBeNull()
+    expect(store.getState().presentation.cues).toStrictEqual([])
   })
 
   it("should handle error in delete presentation", async () => {
@@ -567,7 +592,7 @@ describe("presentationReducer asynchronous actions", () => {
         { _id: 1, name: "Cue 1", index: 1, screen: 1 },
         { _id: 2, name: "Cue 2", index: 2, screen: 2 },
       ],
-      name: "My Presentation"
+      name: "My Presentation",
     }
 
     store.dispatch(setPresentationInfo(initialState))
@@ -593,16 +618,31 @@ describe("presentationReducer asynchronous actions", () => {
     })
   })
 
-
   it("should copy cue with file over cue without file", async () => {
     const store = makeStore()
-    const sourceFile = new File(["image-binary"], "source.png", { type: "image/png" })
+    const sourceFile = new File(["image-binary"], "source.png", {
+      type: "image/png",
+    })
     const sourceCueColor = "#000000"
 
     const initialState = {
       cues: [
-        { _id: 1, name: "Cue 1", index: 1, screen: 1, file: { name: "orig.png", type: "image/png" }, color: sourceCueColor },
-        { _id: 2, name: "Cue 2", index: 2, screen: 1, file: null, color: "#FFFFFF" },
+        {
+          _id: 1,
+          name: "Cue 1",
+          index: 1,
+          screen: 1,
+          file: { name: "orig.png", type: "image/png" },
+          color: sourceCueColor,
+        },
+        {
+          _id: 2,
+          name: "Cue 2",
+          index: 2,
+          screen: 1,
+          file: null,
+          color: "#FFFFFF",
+        },
       ],
       audioCues: [],
       name: "My Presentation",
@@ -634,13 +674,19 @@ describe("presentationReducer asynchronous actions", () => {
     const uploadedImage = sentFormData.get("image")
     const sentColor = sentFormData.get("color")
 
-    expect(presentationService.updateCue).toHaveBeenCalledWith("123", 2, expect.any(FormData))
+    expect(presentationService.updateCue).toHaveBeenCalledWith(
+      "123",
+      2,
+      expect.any(FormData)
+    )
 
     expect(uploadedImage).toBeInstanceOf(File)
     expect(uploadedImage.name).toBe("source.png")
     expect(sentColor).toBe(sourceCueColor)
 
-    const updatedCue = store.getState().presentation.cues.find((cue) => cue._id === 2)
+    const updatedCue = store
+      .getState()
+      .presentation.cues.find((cue) => cue._id === 2)
     expect(updatedCue).toEqual(
       expect.objectContaining({
         _id: 2,
@@ -664,8 +710,22 @@ describe("presentationReducer asynchronous actions", () => {
 
     const initialState = {
       cues: [
-        { _id: 1, name: "Cue 1", index: 1, screen: 1, file: null, color: sourceCueColor },
-        { _id: 2, name: "Cue 2", index: 2, screen: 1, file: { name: "target.png", type: "image/png" }, color: "#222222" },
+        {
+          _id: 1,
+          name: "Cue 1",
+          index: 1,
+          screen: 1,
+          file: null,
+          color: sourceCueColor,
+        },
+        {
+          _id: 2,
+          name: "Cue 2",
+          index: 2,
+          screen: 1,
+          file: { name: "target.png", type: "image/png" },
+          color: "#222222",
+        },
       ],
       audioCues: [],
       name: "My Presentation",
@@ -694,10 +754,16 @@ describe("presentationReducer asynchronous actions", () => {
     await store.dispatch(updatePresentation("123", copiedCueData, 2))
 
     const sentFormData = presentationService.updateCue.mock.calls.at(-1)[2]
-    expect(presentationService.updateCue).toHaveBeenCalledWith("123", 2, expect.any(FormData))
+    expect(presentationService.updateCue).toHaveBeenCalledWith(
+      "123",
+      2,
+      expect.any(FormData)
+    )
     expect(sentFormData.get("image")).toBe("null")
 
-    const updatedCue = store.getState().presentation.cues.find((cue) => cue._id === 2)
+    const updatedCue = store
+      .getState()
+      .presentation.cues.find((cue) => cue._id === 2)
     expect(updatedCue).toEqual(
       expect.objectContaining({
         _id: 2,
@@ -715,8 +781,22 @@ describe("presentationReducer asynchronous actions", () => {
 
     const initialState = {
       cues: [
-        { _id: 1, name: "Cue 1", index: 1, screen: 1, file: null, color: "#AA11CC" },
-        { _id: 2, name: "Cue 2", index: 2, screen: 1, file: null, color: "#33BB44" },
+        {
+          _id: 1,
+          name: "Cue 1",
+          index: 1,
+          screen: 1,
+          file: null,
+          color: "#AA11CC",
+        },
+        {
+          _id: 2,
+          name: "Cue 2",
+          index: 2,
+          screen: 1,
+          file: null,
+          color: "#33BB44",
+        },
       ],
       audioCues: [],
       name: "My Presentation",
@@ -745,10 +825,16 @@ describe("presentationReducer asynchronous actions", () => {
     await store.dispatch(updatePresentation("123", copiedCueData, 2))
 
     const sentFormData = presentationService.updateCue.mock.calls.at(-1)[2]
-    expect(presentationService.updateCue).toHaveBeenCalledWith("123", 2, expect.any(FormData))
+    expect(presentationService.updateCue).toHaveBeenCalledWith(
+      "123",
+      2,
+      expect.any(FormData)
+    )
     expect(sentFormData.get("color")).toBe("#AA11CC")
 
-    const updatedCue = store.getState().presentation.cues.find((cue) => cue._id === 2)
+    const updatedCue = store
+      .getState()
+      .presentation.cues.find((cue) => cue._id === 2)
     expect(updatedCue).toEqual(
       expect.objectContaining({
         _id: 2,
@@ -762,12 +848,21 @@ describe("presentationReducer asynchronous actions", () => {
 
   it("should create a new cue with copied values when pasting to empty grid position", async () => {
     const store = makeStore()
-    const sourceFile = new File(["image-binary"], "source.png", { type: "image/png" })
+    const sourceFile = new File(["image-binary"], "source.png", {
+      type: "image/png",
+    })
     const sourceCueColor = "#2B6CB0"
 
     const initialState = {
       cues: [
-        { _id: 1, name: "Cue 1", index: 1, screen: 1, file: { name: "source.png", type: "image/png" }, color: sourceCueColor },
+        {
+          _id: 1,
+          name: "Cue 1",
+          index: 1,
+          screen: 1,
+          file: { name: "source.png", type: "image/png" },
+          color: sourceCueColor,
+        },
       ],
       audioCues: [],
       name: "My Presentation",
@@ -845,7 +940,7 @@ describe("presentationReducer asynchronous actions", () => {
         { _id: 1, name: "Cue 1", index: 1, screen: 1 },
         { _id: 2, name: "Cue 2", index: 2, screen: 2 },
       ],
-      name: "My Presentation"
+      name: "My Presentation",
     }
 
     store.dispatch(setPresentationInfo(initialState))
@@ -868,9 +963,7 @@ describe("presentationReducer asynchronous actions", () => {
       secondCue: secondUpdatedCue,
     })
 
-    await store.dispatch(
-      swapCues("123", firstUpdatedCue, secondUpdatedCue)
-    )
+    await store.dispatch(swapCues("123", firstUpdatedCue, secondUpdatedCue))
 
     expect(presentationService.swapCues).toHaveBeenCalledWith("123", {
       firstCueId: firstUpdatedCue._id,
@@ -887,14 +980,14 @@ describe("presentationReducer asynchronous actions", () => {
 
   it("should shift presentation indices right", async () => {
     const store = makeStore()
-    
+
     const initialState = {
       cues: [
         { _id: 1, name: "Cue 1", index: 0 },
         { _id: 2, name: "Cue 2", index: 2 },
-        { _id: 3, name: "Cue 3", index: 4 }
+        { _id: 3, name: "Cue 3", index: 4 },
       ],
-      name: "My Presentation"
+      name: "My Presentation",
     }
 
     store.dispatch(setPresentationInfo(initialState))
@@ -902,37 +995,41 @@ describe("presentationReducer asynchronous actions", () => {
     const shiftedCues = [
       { _id: 1, name: "Cue 1", index: 0 },
       { _id: 2, name: "Cue 2", index: 3 },
-      { _id: 3, name: "Cue 3", index: 5 }
+      { _id: 3, name: "Cue 3", index: 5 },
     ]
 
     presentationService.shiftIndexes.mockResolvedValue({
       cues: shiftedCues,
       name: "My Presentation",
-      id: "123"
+      id: "123",
     })
-   
-     presentationService.get.mockResolvedValue({
-       cues: shiftedCues,
-       name: "My Presentation",
-       id: "123"
-     })
+
+    presentationService.get.mockResolvedValue({
+      cues: shiftedCues,
+      name: "My Presentation",
+      id: "123",
+    })
 
     await store.dispatch(shiftPresentationIndexes("123", 0, "right"))
 
-    expect(presentationService.shiftIndexes).toHaveBeenCalledWith("123", 0, "right")
+    expect(presentationService.shiftIndexes).toHaveBeenCalledWith(
+      "123",
+      0,
+      "right"
+    )
     expect(store.getState().presentation.cues).toEqual(shiftedCues)
   })
 
   it("should shift presentation indices left", async () => {
     const store = makeStore()
-    
+
     const initialState = {
       cues: [
         { _id: 1, name: "Cue 1", index: 0 },
         { _id: 2, name: "Cue 2", index: 2 },
-        { _id: 3, name: "Cue 3", index: 4 }
+        { _id: 3, name: "Cue 3", index: 4 },
       ],
-      name: "My Presentation"
+      name: "My Presentation",
     }
 
     store.dispatch(setPresentationInfo(initialState))
@@ -940,37 +1037,41 @@ describe("presentationReducer asynchronous actions", () => {
     const shiftedCues = [
       { _id: 1, name: "Cue 1", index: 0 },
       { _id: 2, name: "Cue 2", index: 1 },
-      { _id: 3, name: "Cue 3", index: 3 }
+      { _id: 3, name: "Cue 3", index: 3 },
     ]
 
     presentationService.shiftIndexes.mockResolvedValue({
       cues: shiftedCues,
       name: "My Presentation",
-      id: "123"
+      id: "123",
     })
-   
-     presentationService.get.mockResolvedValue({
-       cues: shiftedCues,
-       name: "My Presentation",
-       id: "123"
-     })
+
+    presentationService.get.mockResolvedValue({
+      cues: shiftedCues,
+      name: "My Presentation",
+      id: "123",
+    })
 
     await store.dispatch(shiftPresentationIndexes("123", 1, "left"))
 
-    expect(presentationService.shiftIndexes).toHaveBeenCalledWith("123", 1, "left")
+    expect(presentationService.shiftIndexes).toHaveBeenCalledWith(
+      "123",
+      1,
+      "left"
+    )
     expect(store.getState().presentation.cues).toEqual(shiftedCues)
   })
 
   it("should update only cues after startIndex when shifting right", async () => {
     const store = makeStore()
-    
+
     const initialState = {
       cues: [
         { _id: 1, name: "Cue 1", index: 0 },
         { _id: 2, name: "Cue 2", index: 1 },
-        { _id: 3, name: "Cue 3", index: 2 }
+        { _id: 3, name: "Cue 3", index: 2 },
       ],
-      name: "My Presentation"
+      name: "My Presentation",
     }
 
     store.dispatch(setPresentationInfo(initialState))
@@ -978,20 +1079,20 @@ describe("presentationReducer asynchronous actions", () => {
     const shiftedCues = [
       { _id: 1, name: "Cue 1", index: 0 },
       { _id: 2, name: "Cue 2", index: 2 },
-      { _id: 3, name: "Cue 3", index: 3 }
+      { _id: 3, name: "Cue 3", index: 3 },
     ]
 
     presentationService.shiftIndexes.mockResolvedValue({
       cues: shiftedCues,
       name: "My Presentation",
-      id: "123"
+      id: "123",
     })
-   
-     presentationService.get.mockResolvedValue({
-       cues: shiftedCues,
-       name: "My Presentation",
-       id: "123"
-     })
+
+    presentationService.get.mockResolvedValue({
+      cues: shiftedCues,
+      name: "My Presentation",
+      id: "123",
+    })
 
     await store.dispatch(shiftPresentationIndexes("123", 1, "right"))
 
@@ -1024,7 +1125,9 @@ describe("presentationReducer asynchronous actions", () => {
     store.dispatch({ type: saveIndexCount.fulfilled.type, payload })
     expect(store.getState().presentation.saving).toBe(false)
     expect(store.getState().presentation.indexCount).toBe(2)
-    expect(store.getState().presentation.cues.every(c => c.index < 2)).toBe(true)
+    expect(store.getState().presentation.cues.every((c) => c.index < 2)).toBe(
+      true
+    )
 
     // rejected should also ensure saving is false
     store.dispatch({ type: saveIndexCount.pending.type })
@@ -1057,7 +1160,9 @@ describe("presentationReducer asynchronous actions", () => {
     store.dispatch({ type: saveScreenCount.fulfilled.type, payload })
     expect(store.getState().presentation.saving).toBe(false)
     expect(store.getState().presentation.screenCount).toBe(2)
-    expect(store.getState().presentation.cues.every(c => c.screen <= 2)).toBe(true)
+    expect(store.getState().presentation.cues.every((c) => c.screen <= 2)).toBe(
+      true
+    )
 
     // rejected should also ensure saving is false
     store.dispatch({ type: saveScreenCount.pending.type })
@@ -1087,24 +1192,24 @@ describe("presentationReducer asynchronous actions", () => {
     })
 
     await expect(
-      store.dispatch(
-        swapCues("123", firstUpdatedCue, secondUpdatedCue)
-      )
+      store.dispatch(swapCues("123", firstUpdatedCue, secondUpdatedCue))
     ).rejects.toThrow("Not found")
   })
 
   it("should update presentation name only", async () => {
     const store = makeStore()
 
-    store.dispatch(setPresentationInfo({
-      cues: [],
-      name: "Old Presentation Name",
-      screenCount: 3,
-      indexCount: 5,
-    }))
+    store.dispatch(
+      setPresentationInfo({
+        cues: [],
+        name: "Old Presentation Name",
+        screenCount: 3,
+        indexCount: 5,
+      })
+    )
 
     presentationService.updatePresentationName.mockResolvedValue({
-      name: "New Name"
+      name: "New Name",
     })
 
     await store.dispatch(updatePresentationName("123", "New Name"))
@@ -1115,15 +1220,17 @@ describe("presentationReducer asynchronous actions", () => {
   it("throws error when updatePresentationName fails", async () => {
     const store = makeStore()
 
-    store.dispatch(setPresentationInfo({
-      cues: [],
-      name: "Old Name",
-      screenCount: 3,
-      indexCount: 5,
-    }))
+    store.dispatch(
+      setPresentationInfo({
+        cues: [],
+        name: "Old Name",
+        screenCount: 3,
+        indexCount: 5,
+      })
+    )
 
     presentationService.updatePresentationName.mockRejectedValue({
-      response: { data: { error: "Name invalid" } }
+      response: { data: { error: "Name invalid" } },
     })
 
     await expect(


### PR DESCRIPTION
This PR fixes a race condition bug in presentation editor caused by first deleting a presentation and creating a new one directly after.

This was caused by Redux setting `presentation.cues` to null instead of expected initial state which is an empty list.