### PR TITLE
Add cue transition settings to new editor UI, improve transition effects and new UI bugfixes

### DIFF
--- a/src/client/components/presentation/EditModeContainer.jsx
+++ b/src/client/components/presentation/EditModeContainer.jsx
@@ -5,11 +5,18 @@
  * The component uses react-grid-layout for responsive layout and Chakra UI for styling.
  */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { Box, Button, useColorModeValue } from "@chakra-ui/react"
+import {
+  Box,
+  Button,
+  FormLabel,
+  Select,
+  useColorModeValue,
+} from "@chakra-ui/react"
 import "react-grid-layout/css/styles.css"
 import { useDispatch, useSelector } from "react-redux"
 import { fetchPresentationInfo } from "../../redux/presentationReducer"
 import settingsIcon from "../../public/icons/Presentationsettings.svg"
+import ClickablePopover from "../utils/ClickablePopover"
 import EditMode from "./EditMode"
 import CuesForm from "./CuesForm"
 import PresentationPlaybackControls from "./PresentationPlaybackControls"
@@ -41,6 +48,8 @@ function EditorLayout(props) {
     cueData,
     updateCue = () => {},
     isAudioMode = false,
+    transitionType,
+    onTransitionChange = () => {},
     screens = {},
     toggleScreenVisibility = () => {},
     toggleAllScreens = () => {},
@@ -99,15 +108,38 @@ function EditorLayout(props) {
         position="relative"
         key="header"
       >
-        {/* TODO: 
-            The presentation settings button is not yet functional. Consider adding for example the 
-            cue transition animation selection into the settings */}
-        {/* <Button
-          aria-label="Presentation Settings"
-          className="edit-mode-btn edit-mode-btn-settings"
+        <ClickablePopover
+          label={
+            <Box>
+              <FormLabel
+                htmlFor="transition-type-select"
+                mb={2}
+                fontWeight={700}
+              >
+                Transition Type:
+              </FormLabel>
+              <Select
+                id="transition-type-select"
+                data-testid="transition-type-select"
+                value={transitionType}
+                onChange={(e) => onTransitionChange(e.target.value)}
+              >
+                <option value="fade">Fade</option>
+                <option value="slide-left">Slide From Left</option>
+                <option value="slide-right">Slide From Right</option>
+                <option value="zoom">Zoom</option>
+                <option value="none">None</option>
+              </Select>
+            </Box>
+          }
         >
-          <img src={settingsIcon} alt="" width="24" height="24" />
-        </Button> */}
+          <Button
+            aria-label="Presentation Settings"
+            className="edit-mode-btn edit-mode-btn-settings"
+          >
+            <img src={settingsIcon} alt="" width="24" height="24" />
+          </Button>
+        </ClickablePopover>
 
         <Box position="absolute" left="50%" transform="translateX(-50%)">
           <PresentationTitle id={id} presentationName={presentationName} />
@@ -238,6 +270,7 @@ const EditModeContainer = ({
   isToolboxOpen,
   setIsToolboxOpen,
   transitionType,
+  onTransitionChange,
   cueIndex,
   setCueIndex,
   isAudioMuted,
@@ -488,6 +521,8 @@ const EditModeContainer = ({
         cueData={cueData}
         updateCue={updateCue}
         isAudioMode={isAudioMode}
+        transitionType={transitionType}
+        onTransitionChange={onTransitionChange}
         screens={screens}
         toggleScreenVisibility={toggleScreenVisibility}
         toggleAllScreens={toggleAllScreens}

--- a/src/client/components/presentation/EditModeContainer.jsx
+++ b/src/client/components/presentation/EditModeContainer.jsx
@@ -57,6 +57,7 @@ function EditorLayout(props) {
     toggleAutoplay = () => {},
     isAutoplaying = false,
     audioSourceURL = "",
+    audioLoop = false,
     toggleAutoplayInterval = () => {},
     onOpenTutorial = () => {},
     editModeBackground,
@@ -193,6 +194,7 @@ function EditorLayout(props) {
           isAutoplaying={isAutoplaying}
           toggleAutoplayInterval={toggleAutoplayInterval}
           audioSourceURL={audioSourceURL}
+          audioLoop={audioLoop}
         />
       </div>
 
@@ -384,6 +386,7 @@ const EditModeContainer = ({
   const isCurrentCueAudio = Boolean(
     currentAudioCue && isType.audio(currentAudioFile)
   )
+  const currentAudioLoop = Boolean(currentAudioCue?.loop)
 
   const handleScreenClose = useCallback((screenNumber) => {
     setScreens((prev) => ({
@@ -535,6 +538,7 @@ const EditModeContainer = ({
         toggleAutoplayInterval={toggleAutoplayInterval}
         onOpenTutorial={handleOpenTutorial}
         audioSourceURL={currentAudioSrc}
+        audioLoop={currentAudioLoop}
         editModeBackground={editModeBackground}
         panelBackground={panelBackground}
         outlineColor={outlineColor}

--- a/src/client/components/presentation/EditModeContainer.jsx
+++ b/src/client/components/presentation/EditModeContainer.jsx
@@ -330,7 +330,10 @@ const EditModeContainer = ({
     screenNumbers.forEach((screenNumber) => {
       visibility[screenNumber] = false
     })
-    setScreens(visibility)
+    // Only add defaults for screen numbers we haven't seen yet - keep
+    // existing screens' open/closed state untouched so that editing a cue
+    // doesn't close every currently open presentation window
+    setScreens((prev) => ({ ...visibility, ...prev }))
     setMirroring({})
   }, [cues, screenCount])
 

--- a/src/client/components/presentation/PresentationPlaybackControls.jsx
+++ b/src/client/components/presentation/PresentationPlaybackControls.jsx
@@ -142,6 +142,7 @@ const PresentationPlaybackControls = ({
   isAutoplaying,
   toggleAutoplayInterval,
   audioSourceURL,
+  audioLoop = false,
 }) => (
   <Box
     bg=""
@@ -187,7 +188,7 @@ const PresentationPlaybackControls = ({
       toggleAutoplayInterval={toggleAutoplayInterval}
     />
     {audioSourceURL ? (
-      <audio autoPlay loop controls src={audioSourceURL}></audio>
+      <audio autoPlay loop={audioLoop} controls src={audioSourceURL}></audio>
     ) : null}
   </Box>
 )

--- a/src/client/components/presentation/Screen.jsx
+++ b/src/client/components/presentation/Screen.jsx
@@ -133,7 +133,8 @@ const ScreenContent = ({
       {/* Animates out previous cue media, if any */}
       {previousScreenData && (
         <Box
-          key={`${previousScreenData._id}-${previousScreenData.index}-${previousScreenData.screen}-${transitionType}`}
+          key={`${previousScreenData._id}-${previousScreenData.index}-${previousScreenData.screen}`}
+          data-testid="outgoing-cue-layer"
           flex="1"
           display="flex"
           justifyContent="center"
@@ -143,35 +144,18 @@ const ScreenContent = ({
           zIndex={1}
           animation={animStyle(exitAnim)}
         >
-          {(previousScreenData.file?.url || previousScreenData.file?.name) &&
-            (isType.image(previousScreenData.file) ? (
-              <Image
-                src={
-                  previousScreenData.file.url ||
-                  `/${previousScreenData.file.name}`
-                }
-                alt={previousScreenData.name}
-                width="100%"
-                height="100vh"
-                objectFit="contain"
-              />
-            ) : (
-              <video
-                src={previousScreenData.file.url}
-                width="100%"
-                height="100%"
-                autoPlay
-                loop
-                muted
-                style={{ objectFit: "contain" }}
-              />
-            ))}
+          {renderMedia(
+            previousScreenData.file,
+            previousScreenData.name,
+            previousScreenData.color
+          )}
         </Box>
       )}
 
       {/* Animates in current cue media */}
       <Box
-        key={`${currentScreenData?._id}-${currentScreenData?.index}-${currentScreenData?.screen}-${transitionType}`}
+        key={`${currentScreenData?._id}-${currentScreenData?.index}-${currentScreenData?.screen}`}
+        data-testid="incoming-cue-layer"
         flex="1"
         display="flex"
         justifyContent="center"

--- a/src/client/components/presentation/index.jsx
+++ b/src/client/components/presentation/index.jsx
@@ -1,8 +1,8 @@
 /*
-* Main component for rendering the presentation page, which includes both edit mode and show mode functionality.
-* The component manages state for the current cue index, presentation size, show mode toggle, and various UI states such as toolbox and transition menu visibility.
-* It also handles user authentication and presentation deletion through custom hooks and utility functions. 
-* The component fetches presentation information from the Redux store and passes necessary props down to the EditModeContainer component for rendering the appropriate UI based on the current mode. 
+ * Main component for rendering the presentation page, which includes both edit mode and show mode functionality.
+ * The component manages state for the current cue index, presentation size, show mode toggle, and various UI states such as toolbox and transition menu visibility.
+ * It also handles user authentication and presentation deletion through custom hooks and utility functions.
+ * The component fetches presentation information from the Redux store and passes necessary props down to the EditModeContainer component for rendering the appropriate UI based on the current mode.
  */
 import { useEffect, useState } from "react"
 import { useParams, useNavigate } from "react-router-dom"
@@ -25,17 +25,33 @@ const PresentationPage = ({ user }) => {
     handleCancelDelete,
   } = useDeletePresentation()
 
-
   useEffect(() => {
     dispatch(fetchPresentationInfo(id))
   }, [id, navigate, dispatch])
-
 
   const [presentationSize, setPresentationSize] = useState(0)
   const [isToolboxOpen, setIsToolboxOpen] = useState(false)
   const [isAudioMuted, setIsAudioMuted] = useState(false)
   const [isTransitionMenuOpen, setIsTransitionMenuOpen] = useState(false)
   const [transitionType, setTransitionType] = useState("fade")
+
+  useEffect(() => {
+    const savedTransitionType = localStorage.getItem(
+      `presentation-${id}-transition`
+    )
+    if (savedTransitionType) {
+      setTransitionType(savedTransitionType)
+    }
+  }, [id])
+
+  const handleTransitionChange = (value) => {
+    setTransitionType(value)
+    try {
+      localStorage.setItem(`presentation-${id}-transition`, value)
+    } catch (err) {
+      console.warn("Could not persist transition preference:", err)
+    }
+  }
 
   const presentationInfo = useSelector((state) => state.presentation.cues)
   const presentationName = useSelector((state) => state.presentation.name)
@@ -53,23 +69,25 @@ const PresentationPage = ({ user }) => {
     }
   }
 
-  return <EditModeContainer
-    className="presentation-page"
-    id={id}
-    cues={presentationInfo}
-    isToolboxOpen={isToolboxOpen}
-    setIsToolboxOpen={setIsToolboxOpen}
-    isTransitionMenuOpen={isTransitionMenuOpen}
-    setIsTransitionMenuOpen={setIsTransitionMenuOpen}
-    transitionType={transitionType}
-    setTransitionType={setTransitionType}
-    cueIndex={cueIndex}
-    setCueIndex={setCueIndex}
-    updateCue={updateCue}
-    isAudioMuted={isAudioMuted}
-    toggleAudioMute={toggleAudioMute}
-    indexCount={indexCount}
-  />
+  return (
+    <EditModeContainer
+      className="presentation-page"
+      id={id}
+      cues={presentationInfo}
+      isToolboxOpen={isToolboxOpen}
+      setIsToolboxOpen={setIsToolboxOpen}
+      isTransitionMenuOpen={isTransitionMenuOpen}
+      setIsTransitionMenuOpen={setIsTransitionMenuOpen}
+      transitionType={transitionType}
+      onTransitionChange={handleTransitionChange}
+      cueIndex={cueIndex}
+      setCueIndex={setCueIndex}
+      updateCue={updateCue}
+      isAudioMuted={isAudioMuted}
+      toggleAudioMute={toggleAudioMute}
+      indexCount={indexCount}
+    />
+  )
 }
 
 export default PresentationPage

--- a/src/client/tests/unit/EditModeContainerAudio.test.jsx
+++ b/src/client/tests/unit/EditModeContainerAudio.test.jsx
@@ -1,0 +1,150 @@
+/**
+ * Regression test verifying that the audio cue's `loop` field actually reaches
+ * the in-page audio player. EditModeContainer computes the current audio cue
+ * (on the dedicated audio row) but previously only passed its source URL
+ * down to PresentationPlaybackControls, never the loop flag - so the audio
+ * element always looped regardless of what the cue's loop setting was.
+ */
+
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import EditModeContainer from "../../components/presentation/EditModeContainer"
+import { useDispatch, useSelector } from "react-redux"
+
+jest.mock("react-redux", () => ({
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+}))
+
+jest.mock("../../redux/presentationReducer", () => ({
+  fetchPresentationInfo: jest.fn(() => ({
+    type: "MOCK_FETCH_PRESENTATION_INFO",
+  })),
+}))
+
+jest.mock("../../components/presentation/EditMode", () => {
+  return function MockEditMode() {
+    return <div data-testid="mock-edit-mode" />
+  }
+})
+
+jest.mock("../../components/presentation/CuesForm", () => {
+  return function MockCuesForm() {
+    return <div data-testid="mock-cues-form" />
+  }
+})
+
+jest.mock("../../components/presentation/PresentationTitle", () => {
+  return function MockPresentationTitle() {
+    return <div data-testid="mock-presentation-title" />
+  }
+})
+
+jest.mock("../../components/presentation/ScreensDisplay", () => ({
+  ScreensDisplay: function MockScreensDisplay() {
+    return <div data-testid="mock-screens-display" />
+  },
+}))
+
+jest.mock("../../components/presentation/Screen", () => {
+  return function MockScreen() {
+    return <div data-testid="mock-screen" />
+  }
+})
+
+jest.mock("../../components/tutorial/TutorialGuide", () => {
+  return function MockTutorialGuide() {
+    return <div data-testid="mock-tutorial-guide" />
+  }
+})
+
+jest.mock("../../components/utils/keyboardHandler", () => {
+  return function MockKeyboardHandler() {
+    return <div data-testid="mock-keyboard-handler" />
+  }
+})
+
+jest.mock("../../components/presentation/PresentationPlaybackControls", () => {
+  return function MockPresentationPlaybackControls(props) {
+    return (
+      <div
+        data-testid="mock-playback-controls"
+        data-audio-src={props.audioSourceURL}
+        data-audio-loop={String(props.audioLoop)}
+      />
+    )
+  }
+})
+
+jest.mock("../../components/utils/ResizeElement", () => jest.fn())
+
+describe("EditModeContainer audio loop wiring", () => {
+  const dispatchMock = jest.fn()
+
+  // Audio row is screenCount + 1, so with screenCount 2 the audio row is 3.
+  const makeCues = (loop) => [
+    {
+      _id: "cue-audio",
+      index: 0,
+      screen: 3,
+      name: "Background music",
+      cueType: "audio",
+      file: { type: "audio/mpeg", url: "https://example.com/track.mp3" },
+      loop,
+    },
+  ]
+
+  const baseProps = {
+    id: "presentation-1",
+    isToolboxOpen: false,
+    setIsToolboxOpen: jest.fn(),
+    transitionType: "none",
+    cueIndex: 0,
+    setCueIndex: jest.fn(),
+    isAudioMuted: false,
+    toggleAudioMute: jest.fn(),
+    indexCount: 10,
+    addCue: jest.fn(),
+    onClose: jest.fn(),
+    position: null,
+    cueData: null,
+    updateCue: jest.fn(),
+    isAudioMode: false,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    useDispatch.mockReturnValue(dispatchMock)
+    useSelector.mockImplementation((selector) =>
+      selector({
+        presentation: {
+          name: "Test presentation",
+          screenCount: 2,
+        },
+      })
+    )
+  })
+
+  test("passes audioLoop=true through to the playback controls when the cue loops", () => {
+    render(<EditModeContainer {...baseProps} cues={makeCues(true)} />)
+
+    const controls = screen.getByTestId("mock-playback-controls")
+    expect(controls).toHaveAttribute(
+      "data-audio-src",
+      "https://example.com/track.mp3"
+    )
+    expect(controls).toHaveAttribute("data-audio-loop", "true")
+  })
+
+  test("passes audioLoop=false through to the playback controls when the cue does not loop", () => {
+    render(<EditModeContainer {...baseProps} cues={makeCues(false)} />)
+
+    const controls = screen.getByTestId("mock-playback-controls")
+    expect(controls).toHaveAttribute(
+      "data-audio-src",
+      "https://example.com/track.mp3"
+    )
+    expect(controls).toHaveAttribute("data-audio-loop", "false")
+  })
+})

--- a/src/client/tests/unit/EditModeContainerScreens.test.jsx
+++ b/src/client/tests/unit/EditModeContainerScreens.test.jsx
@@ -1,0 +1,258 @@
+/**
+ * Regression tests for a bug where editing any cue - renaming it, dragging it
+ * to another frame, or dragging it to another screen - closed every currently
+ * open presentation screen window, even when the edited cue had nothing to do
+ * with what was on display.
+ *
+ * Root cause: EditModeContainer rebuilt its `screens` visibility state from
+ * scratch on every `cues` change, defaulting every screen back to hidden.
+ */
+
+import React from "react"
+import { render, screen, fireEvent, act } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import EditModeContainer from "../../components/presentation/EditModeContainer"
+import { useDispatch, useSelector } from "react-redux"
+
+jest.mock("react-redux", () => ({
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+}))
+
+jest.mock("../../redux/presentationReducer", () => ({
+  fetchPresentationInfo: jest.fn(() => ({
+    type: "MOCK_FETCH_PRESENTATION_INFO",
+  })),
+}))
+
+jest.mock("../../components/presentation/EditMode", () => {
+  return function MockEditMode() {
+    return <div data-testid="mock-edit-mode" />
+  }
+})
+
+jest.mock("../../components/presentation/CuesForm", () => {
+  return function MockCuesForm() {
+    return <div data-testid="mock-cues-form" />
+  }
+})
+
+jest.mock("../../components/presentation/PresentationTitle", () => {
+  return function MockPresentationTitle() {
+    return <div data-testid="mock-presentation-title" />
+  }
+})
+
+jest.mock("../../components/presentation/ScreensDisplay", () => ({
+  ScreensDisplay: function MockScreensDisplay() {
+    return <div data-testid="mock-screens-display" />
+  },
+}))
+
+jest.mock("../../components/presentation/Screen", () => {
+  return function MockScreen({ screenNumber, isVisible }) {
+    return (
+      <div
+        data-testid={`mock-screen-${screenNumber}`}
+        data-visible={isVisible}
+      />
+    )
+  }
+})
+
+jest.mock("../../components/tutorial/TutorialGuide", () => {
+  return function MockTutorialGuide() {
+    return <div data-testid="mock-tutorial-guide" />
+  }
+})
+
+jest.mock("../../components/utils/keyboardHandler", () => {
+  return function MockKeyboardHandler() {
+    return <div data-testid="mock-keyboard-handler" />
+  }
+})
+
+jest.mock("../../components/presentation/PresentationPlaybackControls", () => {
+  return function MockPresentationPlaybackControls(props) {
+    return (
+      <div data-testid="mock-playback-controls">
+        <button type="button" onClick={props.toggleAllScreens}>
+          Toggle all screens
+        </button>
+      </div>
+    )
+  }
+})
+
+jest.mock("../../components/utils/ResizeElement", () => jest.fn())
+
+describe("EditModeContainer screen visibility across cue edits", () => {
+  const dispatchMock = jest.fn()
+
+  const makeCues = (screen2Name) => [
+    {
+      _id: "cue-1",
+      index: 0,
+      screen: 1,
+      name: "Cue 1",
+      cueType: "visual",
+      file: { type: "image/png", url: "https://example.com/cue-1.png" },
+      loop: false,
+    },
+    {
+      _id: "cue-2",
+      index: 9,
+      screen: 2,
+      name: screen2Name,
+      cueType: "visual",
+      file: { type: "image/png", url: "https://example.com/cue-2.png" },
+      loop: false,
+    },
+  ]
+
+  const baseProps = {
+    id: "presentation-1",
+    isToolboxOpen: false,
+    setIsToolboxOpen: jest.fn(),
+    transitionType: "none",
+    cueIndex: 0,
+    setCueIndex: jest.fn(),
+    isAudioMuted: false,
+    toggleAudioMute: jest.fn(),
+    indexCount: 10,
+    addCue: jest.fn(),
+    onClose: jest.fn(),
+    position: null,
+    cueData: null,
+    updateCue: jest.fn(),
+    isAudioMode: false,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    useDispatch.mockReturnValue(dispatchMock)
+    useSelector.mockImplementation((selector) =>
+      selector({
+        presentation: {
+          name: "Test presentation",
+          // 3 visual screens + 1 audio row, so screen 3 used by the
+          // "move to another screen" test below is a normal visual screen.
+          screenCount: 3,
+        },
+      })
+    )
+  })
+
+  // Renders EditModeContainer with mutable `cues` state, opens every screen
+  // via the "Open all screens" control, then applies `applyEdit` to simulate
+  // a cue mutation (rename, drag to another frame, drag to another screen...)
+  // and hands back helpers to inspect the resulting screen visibility.
+  const renderWithCueEdit = (initialCues, applyEdit) => {
+    let setCuesRef
+    function Harness() {
+      const [cues, setCues] = React.useState(initialCues)
+      setCuesRef = setCues
+
+      return <EditModeContainer {...baseProps} cues={cues} />
+    }
+
+    render(<Harness />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle all screens" }))
+
+    const editCue = () => {
+      act(() => {
+        setCuesRef((prevCues) => applyEdit(prevCues))
+      })
+    }
+
+    return { editCue }
+  }
+
+  test("editing an unrelated cue does not close already-open screens", () => {
+    const { editCue } = renderWithCueEdit(makeCues("Cue 2"), () =>
+      makeCues("Cue 2 renamed")
+    )
+
+    expect(screen.getByTestId("mock-screen-1")).toHaveAttribute(
+      "data-visible",
+      "true"
+    )
+    expect(screen.getByTestId("mock-screen-2")).toHaveAttribute(
+      "data-visible",
+      "true"
+    )
+
+    editCue()
+
+    expect(screen.getByTestId("mock-screen-1")).toHaveAttribute(
+      "data-visible",
+      "true"
+    )
+    expect(screen.getByTestId("mock-screen-2")).toHaveAttribute(
+      "data-visible",
+      "true"
+    )
+  })
+
+  test("moving a cue to another frame does not close already-open screens", () => {
+    const { editCue } = renderWithCueEdit(makeCues("Cue 2"), (prevCues) =>
+      // Drag cue-1 from frame 0 to frame 5 on the same screen.
+      prevCues.map((cue) => (cue._id === "cue-1" ? { ...cue, index: 5 } : cue))
+    )
+
+    expect(screen.getByTestId("mock-screen-1")).toHaveAttribute(
+      "data-visible",
+      "true"
+    )
+    expect(screen.getByTestId("mock-screen-2")).toHaveAttribute(
+      "data-visible",
+      "true"
+    )
+
+    editCue()
+
+    expect(screen.getByTestId("mock-screen-1")).toHaveAttribute(
+      "data-visible",
+      "true"
+    )
+    expect(screen.getByTestId("mock-screen-2")).toHaveAttribute(
+      "data-visible",
+      "true"
+    )
+  })
+
+  test("moving a cue to another screen does not close already-open screens", () => {
+    const { editCue } = renderWithCueEdit(makeCues("Cue 2"), (prevCues) =>
+      // Drag cue-2 from screen 2 to a brand new screen 3.
+      prevCues.map((cue) => (cue._id === "cue-2" ? { ...cue, screen: 3 } : cue))
+    )
+
+    expect(screen.getByTestId("mock-screen-1")).toHaveAttribute(
+      "data-visible",
+      "true"
+    )
+    expect(screen.getByTestId("mock-screen-2")).toHaveAttribute(
+      "data-visible",
+      "true"
+    )
+
+    editCue()
+
+    // Screens that were already open (1 and 2) stay open even though screen 2
+    // no longer has any cue assigned to it - only newly-seen screen numbers
+    // default to closed.
+    expect(screen.getByTestId("mock-screen-1")).toHaveAttribute(
+      "data-visible",
+      "true"
+    )
+    expect(screen.getByTestId("mock-screen-2")).toHaveAttribute(
+      "data-visible",
+      "true"
+    )
+    expect(screen.getByTestId("mock-screen-3")).toHaveAttribute(
+      "data-visible",
+      "false"
+    )
+  })
+})

--- a/src/client/tests/unit/EditModeContainerSettings.test.jsx
+++ b/src/client/tests/unit/EditModeContainerSettings.test.jsx
@@ -1,0 +1,194 @@
+/**
+ * This test suite covers the presentation "Settings" button in EditModeContainer,
+ * which opens a popover for choosing how cues transition between frames on the
+ * pop-up screen windows.
+ */
+
+import React from "react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import EditModeContainer from "../../components/presentation/EditModeContainer"
+import { useDispatch, useSelector } from "react-redux"
+import { fetchPresentationInfo } from "../../redux/presentationReducer"
+
+jest.mock("react-redux", () => ({
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+}))
+
+jest.mock("../../redux/presentationReducer", () => ({
+  fetchPresentationInfo: jest.fn(() => ({
+    type: "MOCK_FETCH_PRESENTATION_INFO",
+  })),
+}))
+
+jest.mock("../../components/presentation/EditMode", () => {
+  return function MockEditMode() {
+    return <div data-testid="mock-edit-mode" />
+  }
+})
+
+jest.mock("../../components/presentation/CuesForm", () => {
+  return function MockCuesForm() {
+    return <div data-testid="mock-cues-form" />
+  }
+})
+
+jest.mock("../../components/presentation/PresentationTitle", () => {
+  return function MockPresentationTitle() {
+    return <div data-testid="mock-presentation-title" />
+  }
+})
+
+jest.mock("../../components/presentation/ScreensDisplay", () => ({
+  ScreensDisplay: function MockScreensDisplay() {
+    return <div data-testid="mock-screens-display" />
+  },
+}))
+
+jest.mock("../../components/presentation/Screen", () => {
+  return function MockScreen() {
+    return <div data-testid="mock-screen" />
+  }
+})
+
+jest.mock("../../components/tutorial/TutorialGuide", () => {
+  return function MockTutorialGuide() {
+    return <div data-testid="mock-tutorial-guide" />
+  }
+})
+
+jest.mock("../../components/utils/keyboardHandler", () => {
+  return function MockKeyboardHandler() {
+    return <div data-testid="mock-keyboard-handler" />
+  }
+})
+
+jest.mock("../../components/presentation/PresentationPlaybackControls", () => {
+  return function MockPresentationPlaybackControls() {
+    return <div data-testid="mock-playback-controls" />
+  }
+})
+
+jest.mock("../../components/utils/ResizeElement", () => jest.fn())
+
+describe("EditModeContainer transition settings", () => {
+  const baseCues = [
+    {
+      _id: "cue-1",
+      index: 0,
+      screen: 1,
+      name: "Cue 1",
+      cueType: "visual",
+      file: { type: "image/png", url: "https://example.com/cue-1.png" },
+      loop: false,
+    },
+  ]
+
+  const baseProps = {
+    id: "presentation-1",
+    cues: baseCues,
+    isToolboxOpen: false,
+    setIsToolboxOpen: jest.fn(),
+    transitionType: "fade",
+    onTransitionChange: jest.fn(),
+    cueIndex: 0,
+    setCueIndex: jest.fn(),
+    isAudioMuted: false,
+    toggleAudioMute: jest.fn(),
+    indexCount: 10,
+    addCue: jest.fn(),
+    onClose: jest.fn(),
+    position: null,
+    cueData: null,
+    updateCue: jest.fn(),
+    isAudioMode: false,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    useDispatch.mockReturnValue(jest.fn())
+    useSelector.mockImplementation((selector) =>
+      selector({
+        presentation: {
+          name: "Test presentation",
+          screenCount: 2,
+        },
+      })
+    )
+  })
+
+  test("renders a Presentation Settings button", () => {
+    render(<EditModeContainer {...baseProps} />)
+
+    expect(screen.getByLabelText("Presentation Settings")).toBeInTheDocument()
+  })
+
+  test("opens a popover with the transition type select when clicked", async () => {
+    render(<EditModeContainer {...baseProps} />)
+
+    fireEvent.click(screen.getByLabelText("Presentation Settings"))
+
+    await waitFor(() => {
+      expect(screen.getByText("Transition Type:")).toBeVisible()
+      expect(screen.getByTestId("transition-type-select")).toBeVisible()
+    })
+  })
+
+  test("select lists all supported transition options", async () => {
+    render(<EditModeContainer {...baseProps} />)
+
+    fireEvent.click(screen.getByLabelText("Presentation Settings"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("transition-type-select")).toBeVisible()
+    })
+
+    const select = screen.getByTestId("transition-type-select")
+    const optionValues = Array.from(select.options).map(
+      (option) => option.value
+    )
+
+    expect(optionValues).toEqual([
+      "fade",
+      "slide-left",
+      "slide-right",
+      "zoom",
+      "none",
+    ])
+  })
+
+  test("select reflects the current transitionType prop", async () => {
+    render(<EditModeContainer {...baseProps} transitionType="zoom" />)
+
+    fireEvent.click(screen.getByLabelText("Presentation Settings"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("transition-type-select")).toBeVisible()
+    })
+
+    expect(screen.getByTestId("transition-type-select").value).toBe("zoom")
+  })
+
+  test("changing the select calls onTransitionChange with the new value", async () => {
+    const onTransitionChange = jest.fn()
+    render(
+      <EditModeContainer
+        {...baseProps}
+        onTransitionChange={onTransitionChange}
+      />
+    )
+
+    fireEvent.click(screen.getByLabelText("Presentation Settings"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("transition-type-select")).toBeVisible()
+    })
+
+    fireEvent.change(screen.getByTestId("transition-type-select"), {
+      target: { value: "slide-left" },
+    })
+
+    expect(onTransitionChange).toHaveBeenCalledWith("slide-left")
+  })
+})

--- a/src/client/tests/unit/PresentationPage.test.jsx
+++ b/src/client/tests/unit/PresentationPage.test.jsx
@@ -1,0 +1,102 @@
+/**
+ * Tests for PresentationPage (src/client/components/presentation/index.jsx),
+ * focused on loading and persisting the per-presentation cue transition-type
+ * preference via localStorage.
+ */
+
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import PresentationPage from "../../components/presentation/index"
+import { useDispatch, useSelector } from "react-redux"
+import { useParams, useNavigate } from "react-router-dom"
+
+jest.mock("react-redux", () => ({
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+}))
+
+jest.mock("react-router-dom", () => ({
+  useParams: jest.fn(),
+  useNavigate: jest.fn(),
+}))
+
+jest.mock("../../redux/presentationReducer", () => ({
+  fetchPresentationInfo: jest.fn(() => ({
+    type: "MOCK_FETCH_PRESENTATION_INFO",
+  })),
+}))
+
+jest.mock("../../components/utils/useDeletePresentation", () => {
+  return function useDeletePresentation() {
+    return {
+      isDialogOpen: false,
+      handleDeletePresentation: jest.fn(),
+      handleConfirmDelete: jest.fn(),
+      handleCancelDelete: jest.fn(),
+    }
+  }
+})
+
+jest.mock("../../components/presentation/EditModeContainer", () => {
+  return function MockEditModeContainer(props) {
+    return (
+      <div>
+        <span data-testid="transition-type">{props.transitionType}</span>
+        <button
+          type="button"
+          onClick={() => props.onTransitionChange("slide-left")}
+        >
+          change-transition
+        </button>
+      </div>
+    )
+  }
+})
+
+describe("PresentationPage transition preference", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    window.localStorage.clear()
+    useParams.mockReturnValue({ id: "presentation-1" })
+    useNavigate.mockReturnValue(jest.fn())
+    useDispatch.mockReturnValue(jest.fn())
+    useSelector.mockImplementation((selector) =>
+      selector({
+        presentation: {
+          cues: [],
+          name: "Test presentation",
+          indexCount: 0,
+        },
+      })
+    )
+  })
+
+  test("defaults to fade when nothing is stored", () => {
+    render(<PresentationPage user={{}} />)
+
+    expect(screen.getByTestId("transition-type").textContent).toBe("fade")
+  })
+
+  test("restores a previously saved transition preference from localStorage", () => {
+    window.localStorage.setItem(
+      "presentation-presentation-1-transition",
+      "zoom"
+    )
+
+    render(<PresentationPage user={{}} />)
+
+    expect(screen.getByTestId("transition-type").textContent).toBe("zoom")
+  })
+
+  test("persists the new transition choice to localStorage when changed", () => {
+    render(<PresentationPage user={{}} />)
+
+    fireEvent.click(screen.getByText("change-transition"))
+
+    expect(
+      window.localStorage.getItem("presentation-presentation-1-transition")
+    ).toBe("slide-left")
+    expect(screen.getByTestId("transition-type").textContent).toBe("slide-left")
+  })
+})

--- a/src/client/tests/unit/PresentationPlaybackControls.test.jsx
+++ b/src/client/tests/unit/PresentationPlaybackControls.test.jsx
@@ -65,13 +65,17 @@ describe("PresentationPlaybackControls", () => {
   test("renders Open all screens when all screens are closed", () => {
     renderControls({ screens: { 1: false, 2: false } })
 
-    expect(screen.getByRole("button", { name: "Open all screens" })).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Open all screens" })
+    ).toBeInTheDocument()
   })
 
   test("renders Close all screens when at least one screen is open", () => {
     renderControls({ screens: { 1: true, 2: false } })
 
-    expect(screen.getByRole("button", { name: "Close all screens" })).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Close all screens" })
+    ).toBeInTheDocument()
   })
 
   test("calls toggleAllScreens when the all screens button is clicked", () => {
@@ -95,7 +99,9 @@ describe("PresentationPlaybackControls", () => {
   test("shows Stop Autoplay when autoplay is active", () => {
     renderControls({ isAutoplaying: true })
 
-    expect(screen.getByRole("button", { name: "Stop Autoplay" })).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Stop Autoplay" })
+    ).toBeInTheDocument()
   })
 
   test("calls toggleAutoplayInterval on interval input changes", () => {
@@ -103,8 +109,28 @@ describe("PresentationPlaybackControls", () => {
     const toggleAutoplayInterval = jest.fn()
     renderControls({ toggleAutoplayInterval, autoplayInterval: 5 })
 
-    fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "0.5" } })
+    fireEvent.change(screen.getByRole("spinbutton"), {
+      target: { value: "0.5" },
+    })
 
     expect(toggleAutoplayInterval).toHaveBeenCalled()
+  })
+
+  test("audio element loops when audioLoop is true", () => {
+    const { container } = renderControls({
+      audioSourceURL: "https://example.com/cue.mp3",
+      audioLoop: true,
+    })
+
+    expect(container.querySelector("audio")).toHaveAttribute("loop")
+  })
+
+  test("audio element does not loop when audioLoop is false", () => {
+    const { container } = renderControls({
+      audioSourceURL: "https://example.com/cue.mp3",
+      audioLoop: false,
+    })
+
+    expect(container.querySelector("audio")).not.toHaveAttribute("loop")
   })
 })

--- a/src/client/tests/unit/Screen.test.jsx
+++ b/src/client/tests/unit/Screen.test.jsx
@@ -408,6 +408,132 @@ describe("Screen", () => {
     })
   })
 
+  // Regression test that ensures that the outgoing cue is still rendered as a background when it is a color cue,
+  // instead of being dropped and displaying a blank or black background during the transition to the next cue.
+  test("keeps rendering the outgoing cue's color as a background instead of leaving it blank", async () => {
+    const colorCue = {
+      file: null,
+      color: "red",
+      index: 1,
+      name: "color-cue",
+      screen: 1,
+      _id: "id-color",
+      loop: false,
+    }
+
+    const imageCue = {
+      file: {
+        url: "http://example.com/next.jpg",
+        type: "image/jpg",
+        name: "next.jpg",
+      },
+      index: 2,
+      name: "image-cue",
+      screen: 1,
+      _id: "id-image",
+      loop: false,
+    }
+
+    const { rerender } = render(
+      <Screen
+        screenNumber={1}
+        screenData={colorCue}
+        isVisible={true}
+        onClose={() => {}}
+      />
+    )
+
+    await waitFor(() => {
+      const popup = window.open.mock.results.at(-1).value
+      expect(popup.document.title).toBe("Screen 1 • Frame 1")
+    })
+
+    await act(async () => {
+      rerender(
+        <Screen
+          screenNumber={1}
+          screenData={imageCue}
+          isVisible={true}
+          onClose={() => {}}
+        />
+      )
+    })
+
+    // Once the color cue becomes the outgoing (previous) layer, it should
+    // still be rendered as a colored background.
+    const popup = window.open.mock.results.at(-1).value
+    const outgoingLayer = popup.document.body.querySelector(
+      '[data-testid="outgoing-cue-layer"]'
+    )
+    expect(outgoingLayer).toBeTruthy()
+    expect(outgoingLayer.children.length).toBeGreaterThan(0)
+  })
+
+  test("renders the outgoing image cue with the same styling as the incoming cue", async () => {
+    const firstImageCue = {
+      file: {
+        url: "http://example.com/outgoing.jpg",
+        type: "image/jpg",
+        name: "outgoing.jpg",
+      },
+      index: 1,
+      name: "outgoing-cue",
+      screen: 1,
+      _id: "id-outgoing",
+      loop: false,
+    }
+
+    const secondImageCue = {
+      file: {
+        url: "http://example.com/incoming.jpg",
+        type: "image/jpg",
+        name: "incoming.jpg",
+      },
+      index: 2,
+      name: "incoming-cue",
+      screen: 1,
+      _id: "id-incoming",
+      loop: false,
+    }
+
+    const { rerender } = render(
+      <Screen
+        screenNumber={1}
+        screenData={firstImageCue}
+        isVisible={true}
+        onClose={() => {}}
+      />
+    )
+
+    await waitFor(() => {
+      const popup = window.open.mock.results.at(-1).value
+      expect(popup.document.title).toBe("Screen 1 • Frame 1")
+    })
+
+    await act(async () => {
+      rerender(
+        <Screen
+          screenNumber={1}
+          screenData={secondImageCue}
+          isVisible={true}
+          onClose={() => {}}
+        />
+      )
+    })
+
+    const popup = window.open.mock.results.at(-1).value
+    const outgoingImg = popup.document.body.querySelector(
+      '[data-testid="outgoing-cue-layer"] img'
+    )
+    const incomingImg = popup.document.body.querySelector(
+      '[data-testid="incoming-cue-layer"] img'
+    )
+    expect(outgoingImg).toBeTruthy()
+    expect(incomingImg).toBeTruthy()
+    // Chakra classNames are generated based on the style props, so if the classNames match, then the cue image styling matches
+    expect(outgoingImg.className).toBe(incomingImg.className)
+  })
+
   test("shows and hides cue metadata with the Shift key", async () => {
     const screenData = {
       file: {


### PR DESCRIPTION
**Changes**
- Cue transition effects can once again be changed through a new settings button in the new presentation editor UI
- Improved transition effects:
  - Transition effects now work properly for cues that only have a background color
  - Image file cues no longer snap to a different size when transitioning to another cue
- Open screens no longer automatically close when editing the presentation
- Fixed a bug that caused audio cues to loop by default and changing the loop setting had no effect



Closes #838
Closes #839 
Closes #624