### PR TITLE
Improve expired user session handling

### DIFF
--- a/src/client/components/homepage/index.jsx
+++ b/src/client/components/homepage/index.jsx
@@ -1,7 +1,7 @@
 /*
-* Home page component for displaying user's presentations (Presentations) and providing navigation options.
-* It includes features for creating, editing, and deleting all of users'presentations, as well as linking Google Drive for storage.
-* The component also incorporates a tutorial guide for new users and admin controls for users with admin privileges.
+ * Home page component for displaying user's presentations (Presentations) and providing navigation options.
+ * It includes features for creating, editing, and deleting all of users'presentations, as well as linking Google Drive for storage.
+ * The component also incorporates a tutorial guide for new users and admin controls for users with admin privileges.
  */
 import {
   Button,
@@ -48,13 +48,11 @@ const HomePage = ({ user, setUser }) => {
         const updatedPresentations = await presentationService.getAll()
         setPresentations(updatedPresentations)
       } catch (error) {
-        if (error.response && error.response.status === 401) {
-          navigate("/")
-        }
+        console.error("Error fetching presentations: ", error)
       }
     }
     getPresentationData()
-  }, [navigate])
+  }, [])
 
   useEffect(() => {
     const hasSeen = localStorage.getItem("hasSeenHelp_homepage")
@@ -66,12 +64,21 @@ const HomePage = ({ user, setUser }) => {
 
   const createPresentation = async (presentationObject) => {
     try {
-      const createdPresentation = await presentationService.create(presentationObject)
+      const createdPresentation =
+        await presentationService.create(presentationObject)
       const updatedPresentations = await presentationService.getAll()
       setPresentations(updatedPresentations)
-      localStorage.setItem(`presentation-${createdPresentation.id}-startingColor`, presentationObject.startingFrameColor)
-      
-      await addInitialElements(createdPresentation.id, presentationObject.screenCount, showToast, presentationObject.startingFrameColor)
+      localStorage.setItem(
+        `presentation-${createdPresentation.id}-startingColor`,
+        presentationObject.startingFrameColor
+      )
+
+      await addInitialElements(
+        createdPresentation.id,
+        presentationObject.screenCount,
+        showToast,
+        presentationObject.startingFrameColor
+      )
       navigate(`/presentation/${createdPresentation.id}`)
     } catch (error) {
       console.error("Error creating presentation: ", error)
@@ -82,7 +89,10 @@ const HomePage = ({ user, setUser }) => {
     navigate(`/presentation/${presentationId}`)
   }
 
-  const handleEditPresentation = async (presentationId, updatedPresentation) => {
+  const handleEditPresentation = async (
+    presentationId,
+    updatedPresentation
+  ) => {
     try {
       await presentationService.update(presentationId, updatedPresentation)
       const updatedPresentations = await presentationService.getAll()

--- a/src/client/components/navbar/index.jsx
+++ b/src/client/components/navbar/index.jsx
@@ -5,7 +5,7 @@
  */
 
 import { Link, useNavigate, useLocation } from "react-router-dom"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import {
   Container,
   Box,
@@ -33,7 +33,10 @@ import getToken from "../../auth"
 import { isTokenExpired } from "../../auth"
 import UserManualModal from "./UserManualModal"
 import { useCustomToast } from "../utils/toastUtils"
-import { SESSION_EXPIRED_MESSAGE } from "../../utils/axiosAuthInterceptor"
+import {
+  SESSION_EXPIRED_MESSAGE,
+  SESSION_EXPIRED_EVENT,
+} from "../../utils/axiosAuthInterceptor"
 
 const NavBar = ({ user, setUser }) => {
   const navigate = useNavigate()
@@ -41,6 +44,7 @@ const NavBar = ({ user, setUser }) => {
   const showToast = useCustomToast()
   const [isManualOpen, setIsManualOpen] = useState(false)
   const [highlight, setHighlight] = useState(false)
+  const sessionExpiredHandledRef = useRef(false)
 
   const isFrontpage = location.pathname === "/"
   const isHomepage = location.pathname === "/home"
@@ -87,6 +91,10 @@ const NavBar = ({ user, setUser }) => {
   }
 
   const handleSessionExpired = () => {
+    // Guards against concurrent session-expired events being handled multiple times in quick succession
+    if (sessionExpiredHandledRef.current) return
+    sessionExpiredHandledRef.current = true
+
     handleLogout(navigate, setUser)
     showToast({
       title: "Session expired",
@@ -95,11 +103,13 @@ const NavBar = ({ user, setUser }) => {
     })
   }
   const onLogin = (user) => {
+    sessionExpiredHandledRef.current = false
     setUser(user)
     navigate("/home")
   }
 
   const onSignup = (user) => {
+    sessionExpiredHandledRef.current = false
     setUser(user)
     navigate("/home")
   }
@@ -123,10 +133,10 @@ const NavBar = ({ user, setUser }) => {
 
   // React to an expired/invalid session detected mid-session by the axios interceptor
   useEffect(() => {
-    window.addEventListener("session-expired", handleSessionExpired)
+    window.addEventListener(SESSION_EXPIRED_EVENT, handleSessionExpired)
     // Cleanup the event listener on component unmount (navbar should always be mounted, but just in case)
     return () =>
-      window.removeEventListener("session-expired", handleSessionExpired)
+      window.removeEventListener(SESSION_EXPIRED_EVENT, handleSessionExpired)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [navigate, setUser])
 

--- a/src/client/components/navbar/index.jsx
+++ b/src/client/components/navbar/index.jsx
@@ -32,10 +32,13 @@ import bHyLogo from "../../public/b_hy_logo.svg"
 import getToken from "../../auth"
 import { isTokenExpired } from "../../auth"
 import UserManualModal from "./UserManualModal"
+import { useCustomToast } from "../utils/toastUtils"
+import { SESSION_EXPIRED_MESSAGE } from "../../utils/axiosAuthInterceptor"
 
 const NavBar = ({ user, setUser }) => {
   const navigate = useNavigate()
   const location = useLocation()
+  const showToast = useCustomToast()
   const [isManualOpen, setIsManualOpen] = useState(false)
   const [highlight, setHighlight] = useState(false)
 
@@ -54,25 +57,25 @@ const NavBar = ({ user, setUser }) => {
       ? "rgba(255, 255, 255, 0.4)"
       : "rgba(23, 25, 35, 0.3)"
 
-  const navBorderBottom = colorMode === "light"
-    ? "1px solid rgba(0, 0, 0, 0.08)"
-    : "1px solid rgba(255, 255, 255, 0.08)"
+  const navBorderBottom =
+    colorMode === "light"
+      ? "1px solid rgba(0, 0, 0, 0.08)"
+      : "1px solid rgba(255, 255, 255, 0.08)"
 
-  const pulse = colorMode === "dark"
-  ? keyframes`
+  const pulse =
+    colorMode === "dark"
+      ? keyframes`
     0% { box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.5); }
     70% { box-shadow: 0 0 0 10px rgba(255, 255, 255, 0); }
     100% { box-shadow: 0 0 0 0 rgba(255, 255, 255, 0); }
   `
-  : keyframes`
+      : keyframes`
     0% { box-shadow: 0 0 0 0 rgba(128, 90, 213, 0.5); }
     70% { box-shadow: 0 0 0 10px rgba(128, 90, 213, 0); }
     100% { box-shadow: 0 0 0 0 rgba(128, 90, 213, 0); }
   `
 
-  const animation = prefersReducedMotion
-    ? undefined
-    : `${pulse} 2s infinite`
+  const animation = prefersReducedMotion ? undefined : `${pulse} 2s infinite`
 
   const navbarLogo = colorMode === "dark" ? hyLogo : bHyLogo
 
@@ -81,6 +84,15 @@ const NavBar = ({ user, setUser }) => {
     window.localStorage.removeItem("driveAccessToken")
     setUser(null)
     navigate("/")
+  }
+
+  const handleSessionExpired = () => {
+    handleLogout(navigate, setUser)
+    showToast({
+      title: "Session expired",
+      description: SESSION_EXPIRED_MESSAGE,
+      status: "warning",
+    })
   }
   const onLogin = (user) => {
     setUser(user)
@@ -93,9 +105,7 @@ const NavBar = ({ user, setUser }) => {
   }
 
   const handleOpenManual = () => {
-    const key = isHomepage
-      ? "hasSeenHelp_homepage"
-      : "hasSeenHelp_presentation"
+    const key = isHomepage ? "hasSeenHelp_homepage" : "hasSeenHelp_presentation"
 
     localStorage.setItem(key, "true")
     setHighlight(false)
@@ -108,15 +118,22 @@ const NavBar = ({ user, setUser }) => {
     if (isTokenExpired(token)) {
       handleLogout(navigate, setUser)
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []) //run only once
+
+  // React to an expired/invalid session detected mid-session by the axios interceptor
+  useEffect(() => {
+    window.addEventListener("session-expired", handleSessionExpired)
+    // Cleanup the event listener on component unmount (navbar should always be mounted, but just in case)
+    return () =>
+      window.removeEventListener("session-expired", handleSessionExpired)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [navigate, setUser])
 
   // Check if user has seen the help tooltip for the current page
   useEffect(() => {
     // Unique key depending on the page
-    const key = isHomepage
-      ? "hasSeenHelp_homepage"
-      : "hasSeenHelp_presentation"
+    const key = isHomepage ? "hasSeenHelp_homepage" : "hasSeenHelp_presentation"
 
     const hasSeen = localStorage.getItem(key)
 
@@ -124,7 +141,7 @@ const NavBar = ({ user, setUser }) => {
       setHighlight(true) // show highlight on first visit
     }
   }, [isHomepage, isPresentationPage])
-  
+
   return (
     <>
       <Box
@@ -146,36 +163,54 @@ const NavBar = ({ user, setUser }) => {
           justify="space-between"
           background={navBackground}
         >
-
-            <Flex as={motion.div} whileHover={{ scale: 1.05 }}onHoverStart={(e) => {}} onHoverEnd={(e) => {}}align="center" mr={7} gap={6}>
-              <Tooltip label="to Frontpage" aria-label="A tooltip">
-                <Heading
-                  as="h3"
-                  size="lg"
-                  letterSpacing={"tighter"}
-                  fontWeight={600}
-                  fontFamily={"'Poppins', sans-serif"}
-                  style={{ WebkitFontSmoothing: "antialiased", MozOsxFontSmoothing: "grayscale" }}
-                >
-                  <Link to={"/"} style={{ position: "relative" }}>
-                    <Text as="span" color="inherit">
-                      MuViCo
-                    </Text>
-                    <Text
-                      as="span"
-                      position="absolute"
-                      bottom="-2px"
-                      left="0"
-                      w="100%"
-                      h="1px"
-                      bg="purple.200"
-                    />
-                  </Link>
-                </Heading>
-              </Tooltip>
-            </Flex>
-            <Flex as={motion.div} whileHover={{ scale: 1.05 }}onHoverStart={(e) => {}} onHoverEnd={(e) => {}}align="center" mr={7} gap={6}>
-              { user && (
+          <Flex
+            as={motion.div}
+            whileHover={{ scale: 1.05 }}
+            onHoverStart={(e) => {}}
+            onHoverEnd={(e) => {}}
+            align="center"
+            mr={7}
+            gap={6}
+          >
+            <Tooltip label="to Frontpage" aria-label="A tooltip">
+              <Heading
+                as="h3"
+                size="lg"
+                letterSpacing={"tighter"}
+                fontWeight={600}
+                fontFamily={"'Poppins', sans-serif"}
+                style={{
+                  WebkitFontSmoothing: "antialiased",
+                  MozOsxFontSmoothing: "grayscale",
+                }}
+              >
+                <Link to={"/"} style={{ position: "relative" }}>
+                  <Text as="span" color="inherit">
+                    MuViCo
+                  </Text>
+                  <Text
+                    as="span"
+                    position="absolute"
+                    bottom="-2px"
+                    left="0"
+                    w="100%"
+                    h="1px"
+                    bg="purple.200"
+                  />
+                </Link>
+              </Heading>
+            </Tooltip>
+          </Flex>
+          <Flex
+            as={motion.div}
+            whileHover={{ scale: 1.05 }}
+            onHoverStart={(e) => {}}
+            onHoverEnd={(e) => {}}
+            align="center"
+            mr={7}
+            gap={6}
+          >
+            {user && (
               <Tooltip label="to Homepage" aria-label="A tooltip">
                 <Heading
                   as="h3"
@@ -183,9 +218,16 @@ const NavBar = ({ user, setUser }) => {
                   letterSpacing={"tighter"}
                   fontWeight={600}
                   fontFamily={"'Poppins', sans-serif"}
-                  style={{ WebkitFontSmoothing: "antialiased", MozOsxFontSmoothing: "grayscale" }}
+                  style={{
+                    WebkitFontSmoothing: "antialiased",
+                    MozOsxFontSmoothing: "grayscale",
+                  }}
                 >
-                  <Link to={"/home"} id="navbar-presentations-link" style={{ position: "relative" }}>
+                  <Link
+                    to={"/home"}
+                    id="navbar-presentations-link"
+                    style={{ position: "relative" }}
+                  >
                     <Text as="span" color="inherit">
                       Presentations
                     </Text>
@@ -202,7 +244,7 @@ const NavBar = ({ user, setUser }) => {
                 </Heading>
               </Tooltip>
             )}
-            </Flex>
+          </Flex>
           <Box flex={3} align="right">
             <ThemeToggleButton />
             {user && (
@@ -213,7 +255,10 @@ const NavBar = ({ user, setUser }) => {
                     variant="ghost"
                     fontWeight={600}
                     fontFamily={"'Poppins', sans-serif"}
-                    style={{ WebkitFontSmoothing: "antialiased", MozOsxFontSmoothing: "grayscale" }}
+                    style={{
+                      WebkitFontSmoothing: "antialiased",
+                      MozOsxFontSmoothing: "grayscale",
+                    }}
                     onClick={() => {
                       setTimeout(() => handleLogout(navigate, setUser), 0) // Trigger logout after current render cycle
                     }}
@@ -279,7 +324,12 @@ const NavBar = ({ user, setUser }) => {
                 </Box>
               </>
             )}
-            <Box ml={4} display="inline-flex" alignItems="center" verticalAlign="middle">
+            <Box
+              ml={4}
+              display="inline-flex"
+              alignItems="center"
+              verticalAlign="middle"
+            >
               <img
                 src={navbarLogo}
                 alt="HY logo"

--- a/src/client/components/presentation/CuesForm.jsx
+++ b/src/client/components/presentation/CuesForm.jsx
@@ -1,6 +1,6 @@
 /**
  * CuesForm component for adding and editing cues in the presentation
- * 
+ *
  * This component is used in the presentation editor to allow users to add new cues or edit existing cues.
  * It supports both visual cues (images and videos) and audio cues, with validation for file types and required fields.
  * The form includes inputs for cue name, index, screen number, file upload, and color selection.
@@ -15,8 +15,6 @@ import {
   Heading,
   Divider,
   Tooltip,
-  ChakraProvider,
-  extendTheme,
   Box,
   VStack,
   HStack,
@@ -29,9 +27,7 @@ import { InfoOutlineIcon, DeleteIcon } from "@chakra-ui/icons"
 import { SpeakerIcon } from "../../lib/icons"
 import { useState, useEffect, useRef } from "react"
 import Error from "../utils/Error"
-import {
-  getNextAvailableIndex,
-} from "../utils/numberInputUtils"
+import { getNextAvailableIndex } from "../utils/numberInputUtils"
 import { ColorPickerWithPresets } from "./ColorPicker"
 import {
   isAudioMimeType,
@@ -40,8 +36,6 @@ import {
   getAllowedMimeTypesForScreen,
 } from "../utils/fileTypeUtils"
 import mediaStore from "./mediaFileStore"
-
-const theme = extendTheme({})
 
 // Create a transparent 1x1 pixel image to suppress the default browser drag ghost image
 const transparentDragImage = (() => {
@@ -64,7 +58,6 @@ const suppressNativeDragGhost = (dataTransfer) => {
   dataTransfer.setDragImage(transparentDragImage, 0, 0)
 }
 
-
 /**
  * CuesForm component - a form for adding and editing presentation cues
  * Props:
@@ -78,20 +71,46 @@ const suppressNativeDragGhost = (dataTransfer) => {
  * - isAudioMode: Boolean indicating if in audio mode
  * - indexCount: Count of indices
  */
-const CuesForm = ({ addCue, onClose, position, cues, cueData, updateCue, screenCount, isAudioMode = false, indexCount }) => {
+const CuesForm = ({
+  addCue,
+  onClose,
+  position,
+  cues,
+  cueData,
+  updateCue,
+  screenCount,
+  isAudioMode = false,
+  indexCount,
+}) => {
   const [file, setFile] = useState("")
   const [actualFile, setActualFile] = useState(null)
   const [fileName, setFileName] = useState("")
   const [index, setIndex] = useState(position?.index || 0)
   const [cueName, setCueName] = useState("")
-  const [screen, setScreen] = useState(isAudioMode ? 0 : (position?.screen || 1))
+  const [screen, setScreen] = useState(isAudioMode ? 0 : position?.screen || 1)
   const [cueId, setCueId] = useState("")
   const [loop, setLoop] = useState(false)
   const [error, setError] = useState(null)
   const [color, setColor] = useState()
   const [selectedColor, setSelectedColor] = useState("#9244ff")
-  const presetColors = ["#000000","#787878", "#c0c0c0", "#ffffff","#ff0000","#ff8000","#ffff00", "#80ff00", "#00ff00", "#00ff80", "#00ffff", "#0080ff", "#0000ff", "#7f00ff", "#ff00ff", "#ff007f",
-      ]
+  const presetColors = [
+    "#000000",
+    "#787878",
+    "#c0c0c0",
+    "#ffffff",
+    "#ff0000",
+    "#ff8000",
+    "#ffff00",
+    "#80ff00",
+    "#00ff00",
+    "#00ff80",
+    "#00ffff",
+    "#0080ff",
+    "#0000ff",
+    "#7f00ff",
+    "#ff00ff",
+    "#ff007f",
+  ]
 
   // Media pool management state - for uploading and displaying media/audio files before adding to cue
   const [mediaFiles, setMediaFiles] = useState([])
@@ -169,7 +188,8 @@ const CuesForm = ({ addCue, onClose, position, cues, cueData, updateCue, screenC
       setCueId(cueData._id)
       setColor(cueData.color)
 
-      const cueFile = cueData.file && typeof cueData.file === "object" ? cueData.file : null
+      const cueFile =
+        cueData.file && typeof cueData.file === "object" ? cueData.file : null
       setFile("")
       setActualFile(cueFile)
       setFileName(cueFile?.name || "")
@@ -184,7 +204,17 @@ const CuesForm = ({ addCue, onClose, position, cues, cueData, updateCue, screenC
         setScreen(position?.screen || 1)
       }
     }
-  }, [cueData, setCueName, setIndex, setScreen, setCueId, setFile, setColor, isAudioMode, position?.screen])
+  }, [
+    cueData,
+    setCueName,
+    setIndex,
+    setScreen,
+    setCueId,
+    setFile,
+    setColor,
+    isAudioMode,
+    position?.screen,
+  ])
 
   const checkFileType = (file) => {
     if (!file || !file.type) {
@@ -192,7 +222,10 @@ const CuesForm = ({ addCue, onClose, position, cues, cueData, updateCue, screenC
     }
 
     const targetScreen = isAudioMimeType(file.type) ? audioRow : screen
-    const allowedMimeTypes = getAllowedMimeTypesForScreen(targetScreen, screenCount)
+    const allowedMimeTypes = getAllowedMimeTypesForScreen(
+      targetScreen,
+      screenCount
+    )
 
     if (!allowedMimeTypes.includes(file.type)) {
       const errorMsg = isAudioRow(targetScreen, screenCount)
@@ -206,7 +239,6 @@ const CuesForm = ({ addCue, onClose, position, cues, cueData, updateCue, screenC
     return true
   }
 
-  
   // Handle adding a new cue - validates and calls addCue callback
   const onAddCue = (event) => {
     event.preventDefault()
@@ -292,55 +324,54 @@ const CuesForm = ({ addCue, onClose, position, cues, cueData, updateCue, screenC
     setError(null)
   }
 
-
   // Handle uploading images/videos to media pool - creates preview URLs for drag-and-drop
   const handleMediaUpload = (event) => {
     const files = Array.from(event.target.files)
-    const validMediaFiles = files.filter(file => {
+    const validMediaFiles = files.filter((file) => {
       const isImage = file.type.startsWith("image/")
       const isVideo = file.type.startsWith("video/")
       return isImage || isVideo
     })
-    
+
     // Create media objects with preview URLs
     const newMediaFiles = validMediaFiles.map((file, idx) => ({
       id: `media-${Date.now()}-${idx}`,
       file,
       name: file.name,
       type: file.type,
-      preview: URL.createObjectURL(file)
+      preview: URL.createObjectURL(file),
     }))
-    
-    setMediaFiles(prev => [...prev, ...newMediaFiles])
+
+    setMediaFiles((prev) => [...prev, ...newMediaFiles])
   }
 
   const handleSoundUpload = (event) => {
     const files = Array.from(event.target.files)
-    const validAudioFiles = files.filter(file => isAudioMimeType(file.type))
-    
+    const validAudioFiles = files.filter((file) => isAudioMimeType(file.type))
+
     // Create sound objects
     const newSoundFiles = validAudioFiles.map((file, idx) => ({
       id: `sound-${Date.now()}-${idx}`,
       file,
       name: file.name,
-      type: file.type
+      type: file.type,
     }))
-    
-    setSoundFiles(prev => [...prev, ...newSoundFiles])
+
+    setSoundFiles((prev) => [...prev, ...newSoundFiles])
   }
 
   const removeMediaFile = (id) => {
-    setMediaFiles(prev => {
-      const file = prev.find(f => f.id === id)
+    setMediaFiles((prev) => {
+      const file = prev.find((f) => f.id === id)
       if (file?.preview) {
         URL.revokeObjectURL(file.preview)
       }
-      return prev.filter(f => f.id !== id)
+      return prev.filter((f) => f.id !== id)
     })
   }
 
   const removeSoundFile = (id) => {
-    setSoundFiles(prev => prev.filter(f => f.id !== id))
+    setSoundFiles((prev) => prev.filter((f) => f.id !== id))
   }
 
   // Calculate contrasting text color (black or white) based on background color brightness
@@ -366,12 +397,11 @@ const CuesForm = ({ addCue, onClose, position, cues, cueData, updateCue, screenC
     return brightness >= 186 ? "black" : "white"
   }
 
-
   const tabStyles = {
     button: (isActive) => ({
       padding: "8px 16px",
       border: "none",
-      backgroundColor: isActive ?  "#D6BCFA" : "#9244ff",
+      backgroundColor: isActive ? "#D6BCFA" : "#9244ff",
       color: !isActive ? "white" : "black",
       cursor: "pointer",
       fontWeight: isActive ? "bold" : "normal",
@@ -389,22 +419,23 @@ const CuesForm = ({ addCue, onClose, position, cues, cueData, updateCue, screenC
       overflowY: "auto",
     },
   }
-  
+
   // Render the form with three tabs: Colors, Media, and Audio
   // The colors tab allows creating colored elements by dragging them to the grid
   // The media tab allows uploading and dragging images/videos to the grid
   // The audio tab allows uploading and dragging audio files to the grid
   return (
     <div className="cue-editor-form">
-
-    <ChakraProvider theme={theme} >
-
       <form onSubmit={cueData ? handleUpdateSubmit : onAddCue}>
         <FormControl as="fieldset">
           {cueData ? (
-            <Heading size="md" mb={4}>Edit Element</Heading>
+            <Heading size="md" mb={4}>
+              Edit Element
+            </Heading>
           ) : (
-            <Heading size="md" mb={4} color="white">Add element</Heading>
+            <Heading size="md" mb={4} color="white">
+              Add element
+            </Heading>
           )}
 
           <Box>
@@ -445,19 +476,21 @@ const CuesForm = ({ addCue, onClose, position, cues, cueData, updateCue, screenC
                     onChange={setSelectedColor}
                     presetColors={presetColors}
                   />
-                  <FormHelperText mb={2} color="black">Element name</FormHelperText>
-                    <Input
-                      data-testid="cue-name"
-                      id="cue-name"
-                      value={cueName}
-                      placeholder="Color Element"
-                      mb={2}
-                      color="black"
-                      sx={{ color: "black !important", caretColor: "black" }}
-                      _placeholder={{ color: "#acacac" }}
-                      onChange={(e) => setCueName(e.target.value)}
-                      required
-                    />
+                  <FormHelperText mb={2} color="black">
+                    Element name
+                  </FormHelperText>
+                  <Input
+                    data-testid="cue-name"
+                    id="cue-name"
+                    value={cueName}
+                    placeholder="Color Element"
+                    mb={2}
+                    color="black"
+                    sx={{ color: "black !important", caretColor: "black" }}
+                    _placeholder={{ color: "#acacac" }}
+                    onChange={(e) => setCueName(e.target.value)}
+                    required
+                  />
 
                   <Box
                     className="droppable-color-element"
@@ -474,8 +507,14 @@ const CuesForm = ({ addCue, onClose, position, cues, cueData, updateCue, screenC
 
                       mediaStore.setActiveDragData(dragData)
 
-                      e.dataTransfer.setData("application/json", JSON.stringify(dragData))
-                      e.dataTransfer.setData("text/plain", JSON.stringify(dragData))
+                      e.dataTransfer.setData(
+                        "application/json",
+                        JSON.stringify(dragData)
+                      )
+                      e.dataTransfer.setData(
+                        "text/plain",
+                        JSON.stringify(dragData)
+                      )
                     }}
                     onDragEnd={() => mediaStore.clearActiveDragData()}
                     p={6}
@@ -488,7 +527,10 @@ const CuesForm = ({ addCue, onClose, position, cues, cueData, updateCue, screenC
                     _active={{ cursor: "grabbing" }}
                     _hover={{ opacity: 0.8 }}
                   >
-                    <Text color={getContrastTextColor(selectedColor)} fontWeight="bold">
+                    <Text
+                      color={getContrastTextColor(selectedColor)}
+                      fontWeight="bold"
+                    >
                       Drag color to grid
                     </Text>
                   </Box>
@@ -497,14 +539,15 @@ const CuesForm = ({ addCue, onClose, position, cues, cueData, updateCue, screenC
 
               {/* MEDIA TAB - Upload and manage images/videos */}
               {activeTab === "media" && (
-                <VStack spacing={4} align="stretch" >
+                <VStack spacing={4} align="stretch">
                   <FormHelperText color="black">
                     Upload images or videos and drag them to the grid
                     <Tooltip
                       label={
                         <>
-                          <strong>Valid image types: </strong>.apng, .avif, .bmp, .cur,
-                          .gif, .ico, .jfif, .jpe, .jpeg, .jpg, .png, .svg and .webp
+                          <strong>Valid image types: </strong>.apng, .avif,
+                          .bmp, .cur, .gif, .ico, .jfif, .jpe, .jpeg, .jpg,
+                          .png, .svg and .webp
                           <br />
                           <strong>Valid video types: </strong> .mp4 and .3gp
                         </>
@@ -513,7 +556,12 @@ const CuesForm = ({ addCue, onClose, position, cues, cueData, updateCue, screenC
                       p={2}
                       fontSize="sm"
                     >
-                      <Button variant="ghost" size="xs" marginLeft={2} color="black">
+                      <Button
+                        variant="ghost"
+                        size="xs"
+                        marginLeft={2}
+                        color="black"
+                      >
                         <InfoOutlineIcon />
                       </Button>
                     </Tooltip>
@@ -542,7 +590,9 @@ const CuesForm = ({ addCue, onClose, position, cues, cueData, updateCue, screenC
                   {mediaFiles.length > 0 && (
                     <>
                       <Divider />
-                      <Text fontWeight="bold">Media Pool ({mediaFiles.length})</Text>
+                      <Text fontWeight="bold">
+                        Media Pool ({mediaFiles.length})
+                      </Text>
                       <SimpleGrid columns={2} spacing={3}>
                         {mediaFiles.map((media) => (
                           <Box
@@ -561,9 +611,15 @@ const CuesForm = ({ addCue, onClose, position, cues, cueData, updateCue, screenC
                                 previewUrl: media.preview,
                               }
                               mediaStore.setActiveDragData(dragData)
-                              
-                              e.dataTransfer.setData("application/json", JSON.stringify(dragData))
-                              e.dataTransfer.setData("text/plain", JSON.stringify(dragData))
+
+                              e.dataTransfer.setData(
+                                "application/json",
+                                JSON.stringify(dragData)
+                              )
+                              e.dataTransfer.setData(
+                                "text/plain",
+                                JSON.stringify(dragData)
+                              )
                             }}
                             onDragEnd={() => mediaStore.clearActiveDragData()}
                             position="relative"
@@ -573,7 +629,10 @@ const CuesForm = ({ addCue, onClose, position, cues, cueData, updateCue, screenC
                             p={2}
                             cursor="grab"
                             _active={{ cursor: "grabbing" }}
-                            _hover={{ borderColor: "purple.500", bg: "purple.50" }}
+                            _hover={{
+                              borderColor: "purple.500",
+                              bg: "purple.50",
+                            }}
                           >
                             <IconButton
                               icon={<DeleteIcon />}
@@ -616,12 +675,21 @@ const CuesForm = ({ addCue, onClose, position, cues, cueData, updateCue, screenC
                   <FormHelperText color="black">
                     Upload audio files and drag them to the grid
                     <Tooltip
-                      label={<><strong>Valid audio types: </strong> .mp3 and .wav</>}
+                      label={
+                        <>
+                          <strong>Valid audio types: </strong> .mp3 and .wav
+                        </>
+                      }
                       placement="right-end"
                       p={2}
                       fontSize="sm"
                     >
-                      <Button variant="ghost" size="xs" marginLeft={2} color="black">
+                      <Button
+                        variant="ghost"
+                        size="xs"
+                        marginLeft={2}
+                        color="black"
+                      >
                         <InfoOutlineIcon />
                       </Button>
                     </Tooltip>
@@ -649,7 +717,9 @@ const CuesForm = ({ addCue, onClose, position, cues, cueData, updateCue, screenC
                   {soundFiles.length > 0 && (
                     <>
                       <Divider />
-                      <Text fontWeight="bold" color="black">Sound Pool ({soundFiles.length})</Text>
+                      <Text fontWeight="bold" color="black">
+                        Sound Pool ({soundFiles.length})
+                      </Text>
                       <VStack spacing={2} align="stretch">
                         {soundFiles.map((sound) => (
                           <Box
@@ -667,9 +737,15 @@ const CuesForm = ({ addCue, onClose, position, cues, cueData, updateCue, screenC
                                 mimeType: sound.type,
                               }
                               mediaStore.setActiveDragData(dragData)
-                              
-                              e.dataTransfer.setData("application/json", JSON.stringify(dragData))
-                              e.dataTransfer.setData("text/plain", JSON.stringify(dragData))
+
+                              e.dataTransfer.setData(
+                                "application/json",
+                                JSON.stringify(dragData)
+                              )
+                              e.dataTransfer.setData(
+                                "text/plain",
+                                JSON.stringify(dragData)
+                              )
                             }}
                             onDragEnd={() => mediaStore.clearActiveDragData()}
                             display="flex"
@@ -681,9 +757,17 @@ const CuesForm = ({ addCue, onClose, position, cues, cueData, updateCue, screenC
                             p={3}
                             cursor="grab"
                             _active={{ cursor: "grabbing" }}
-                            _hover={{ borderColor: "purple.500", bg: "purple.50" }}
+                            _hover={{
+                              borderColor: "purple.500",
+                              bg: "purple.50",
+                            }}
                           >
-                            <Box display="flex" alignItems="center" flex={1} color="black">
+                            <Box
+                              display="flex"
+                              alignItems="center"
+                              flex={1}
+                              color="black"
+                            >
                               <SpeakerIcon boxSize="20px" mr={2} />
                               <Text fontSize="sm" noOfLines={1}>
                                 {sound.name}
@@ -705,13 +789,10 @@ const CuesForm = ({ addCue, onClose, position, cues, cueData, updateCue, screenC
             </Box>
           </Box>
 
-
           {error && <Error error={error} />}
         </FormControl>
       </form>
-    </ChakraProvider>
     </div>
-
   )
 }
 

--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -12,14 +12,7 @@
 - indexCount: number of indexes (frames) in the presentation
  */
 import React, { useState, useRef, useEffect, useMemo } from "react"
-import {
-  Box,
-  Text,
-  ChakraProvider,
-  extendTheme,
-  useOutsideClick,
-  useColorModeValue,
-} from "@chakra-ui/react"
+import { Box, Text, useOutsideClick, useColorModeValue } from "@chakra-ui/react"
 import "react-grid-layout/css/styles.css"
 import { useDispatch, useSelector } from "react-redux"
 import {
@@ -64,8 +57,6 @@ import {
   isImageOrVideoMimeType,
 } from "../utils/fileTypeUtils"
 import mediaStore from "./mediaFileStore"
-
-const theme = extendTheme({})
 
 /**
  * EditMode Component - Main editing interface for presentations
@@ -1582,7 +1573,7 @@ const EditMode = ({
   }
   // Render the grid layout with headers and cues, and handle drag-and-drop interactions
   return (
-    <ChakraProvider theme={theme}>
+    <>
       <CustomAlert showAlert={showAlert} alertData={alertData} />
       <div
         onDrop={handleDrop}
@@ -1996,7 +1987,7 @@ const EditMode = ({
           message={confirmMessage}
         />
       </div>
-    </ChakraProvider>
+    </>
   )
 }
 export default EditMode

--- a/src/client/components/profilepage/profile.jsx
+++ b/src/client/components/profilepage/profile.jsx
@@ -1,18 +1,19 @@
-/* 
-* Profile page component for displaying user information and allowing password changes.
-* Includes form validation using Yup and error handling for both validation and API errors.
-* Features:
-* - Displays username (and email if available) in a read-only format.
-* - Provides a form for changing the password with fields for current password, new password, and confirm password.
-* - Validates form inputs with specific rules for password complexity and matching.
-* - Shows error messages for validation errors and API errors using Chakra UI's toast notifications.
+/*
+ * Profile page component for displaying user information and allowing password changes.
+ * Includes form validation using Yup and error handling for both validation and API errors.
+ * Features:
+ * - Displays username (and email if available) in a read-only format.
+ * - Provides a form for changing the password with fields for current password, new password, and confirm password.
+ * - Validates form inputs with specific rules for password complexity and matching.
+ * - Shows error messages for validation errors and API errors using Chakra UI's toast notifications.
  */
 import { useState, useRef } from "react"
 import { useNavigate } from "react-router-dom"
 import * as yup from "yup"
-import { ViewIcon, ViewOffIcon} from "@chakra-ui/icons"
+import { ViewIcon, ViewOffIcon } from "@chakra-ui/icons"
 import authService from "../../services/auth"
-import Error from "../utils/Error" 
+import Error from "../utils/Error"
+import { useCustomToast } from "../utils/toastUtils"
 
 import {
   minPwLength,
@@ -31,10 +32,9 @@ import {
   Button,
   Card,
   CardBody,
-  useToast,
   InputGroup,
   InputRightElement,
-  IconButton
+  IconButton,
 } from "@chakra-ui/react"
 
 const validationSchema = yup.object().shape({
@@ -42,7 +42,10 @@ const validationSchema = yup.object().shape({
   newPassword: yup
     .string()
     .required("New password is required")
-    .min(minPwLength, `Password must be at least ${minPwLength} characters long`)
+    .min(
+      minPwLength,
+      `Password must be at least ${minPwLength} characters long`
+    )
     .max(maxPwLength, `Password must be at most ${maxPwLength} characters`)
     .test(
       "password-not-whitespace-only",
@@ -80,7 +83,7 @@ const Profile = ({ user }) => {
     confirmPassword: false,
   })
   const [formErrors, setFormErrors] = useState({})
-  const toast = useToast()
+  const showToast = useCustomToast()
 
   const handlePasswordChange = (e) => {
     const { name, value } = e.target
@@ -113,12 +116,10 @@ const Profile = ({ user }) => {
 
       await authService.changepassword(payload)
 
-      toast({
+      showToast({
         title: "Success",
         description: "Password changed successfully",
         status: "success",
-        duration: 3000,
-        isClosable: true,
       })
 
       setPasswords({
@@ -138,12 +139,10 @@ const Profile = ({ user }) => {
         return
       }
 
-      toast({
+      showToast({
         title: "Error",
         description: err?.response?.data?.error || "Failed to change password",
         status: "error",
-        duration: 5000,
-        isClosable: true,
       })
     }
   }
@@ -163,7 +162,12 @@ const Profile = ({ user }) => {
                 Account Information
               </Heading>
               <VStack align="start" spacing={3}>
-                <FormLabel fontWeight="bold">Username:&nbsp;&nbsp;&nbsp;&nbsp;<span style={{fontWeight: "normal"}}>{user.username || "N/A"}</span></FormLabel>
+                <FormLabel fontWeight="bold">
+                  Username:&nbsp;&nbsp;&nbsp;&nbsp;
+                  <span style={{ fontWeight: "normal" }}>
+                    {user.username || "N/A"}
+                  </span>
+                </FormLabel>
               </VStack>
             </CardBody>
           </Card>
@@ -182,7 +186,9 @@ const Profile = ({ user }) => {
                       <Input
                         id="current-password"
                         data-testid="current-password-input"
-                        type={showPasswords.currentPassword ? "text" : "password"}
+                        type={
+                          showPasswords.currentPassword ? "text" : "password"
+                        }
                         name="currentPassword"
                         value={passwords.currentPassword}
                         onChange={handlePasswordChange}
@@ -190,16 +196,33 @@ const Profile = ({ user }) => {
                       />
                       <InputRightElement>
                         <IconButton
-                          aria-label={showPasswords.currentPassword ? "Hide password" : "Show password"}
-                          icon={showPasswords.currentPassword ? <ViewOffIcon /> : <ViewIcon />}
-                          onClick={() => setShowPasswords({...showPasswords, currentPassword: !showPasswords.currentPassword})}
+                          aria-label={
+                            showPasswords.currentPassword
+                              ? "Hide password"
+                              : "Show password"
+                          }
+                          icon={
+                            showPasswords.currentPassword ? (
+                              <ViewOffIcon />
+                            ) : (
+                              <ViewIcon />
+                            )
+                          }
+                          onClick={() =>
+                            setShowPasswords({
+                              ...showPasswords,
+                              currentPassword: !showPasswords.currentPassword,
+                            })
+                          }
                           variant="ghost"
                           size="sm"
                           tabIndex={-1}
                         />
                       </InputRightElement>
                     </InputGroup>
-                    {formErrors.currentPassword && <Error error={formErrors.currentPassword} />}
+                    {formErrors.currentPassword && (
+                      <Error error={formErrors.currentPassword} />
+                    )}
                   </FormControl>
 
                   <FormControl isRequired>
@@ -216,18 +239,34 @@ const Profile = ({ user }) => {
                       />
                       <InputRightElement>
                         <IconButton
-                          aria-label={showPasswords.newPassword ? "Hide password" : "Show password"}
-                          icon={showPasswords.newPassword ? <ViewOffIcon /> : <ViewIcon />}
-                          onClick={() => setShowPasswords({...showPasswords, newPassword: !showPasswords.newPassword})}
+                          aria-label={
+                            showPasswords.newPassword
+                              ? "Hide password"
+                              : "Show password"
+                          }
+                          icon={
+                            showPasswords.newPassword ? (
+                              <ViewOffIcon />
+                            ) : (
+                              <ViewIcon />
+                            )
+                          }
+                          onClick={() =>
+                            setShowPasswords({
+                              ...showPasswords,
+                              newPassword: !showPasswords.newPassword,
+                            })
+                          }
                           variant="ghost"
                           size="sm"
                           tabIndex={-1}
                         />
                       </InputRightElement>
                     </InputGroup>
-                    {formErrors.newPassword && <Error error={formErrors.newPassword} />}
+                    {formErrors.newPassword && (
+                      <Error error={formErrors.newPassword} />
+                    )}
                   </FormControl>
-                  
 
                   <FormControl isRequired>
                     <FormLabel>Confirm Password</FormLabel>
@@ -235,7 +274,9 @@ const Profile = ({ user }) => {
                       <Input
                         id="confirm-password"
                         data-testid="confirm-password-input"
-                        type={showPasswords.confirmPassword ? "text" : "password"}
+                        type={
+                          showPasswords.confirmPassword ? "text" : "password"
+                        }
                         name="confirmPassword"
                         value={passwords.confirmPassword}
                         onChange={handlePasswordChange}
@@ -243,26 +284,40 @@ const Profile = ({ user }) => {
                       />
                       <InputRightElement>
                         <IconButton
-                          aria-label={showPasswords.confirmPassword ? "Hide password" : "Show password"}
-                          icon={showPasswords.confirmPassword ? <ViewOffIcon /> : <ViewIcon />}
-                          onClick={() => setShowPasswords({...showPasswords, confirmPassword: !showPasswords.confirmPassword})}
+                          aria-label={
+                            showPasswords.confirmPassword
+                              ? "Hide password"
+                              : "Show password"
+                          }
+                          icon={
+                            showPasswords.confirmPassword ? (
+                              <ViewOffIcon />
+                            ) : (
+                              <ViewIcon />
+                            )
+                          }
+                          onClick={() =>
+                            setShowPasswords({
+                              ...showPasswords,
+                              confirmPassword: !showPasswords.confirmPassword,
+                            })
+                          }
                           variant="ghost"
                           size="sm"
                           tabIndex={-1}
                         />
                       </InputRightElement>
                     </InputGroup>
-                    {formErrors.confirmPassword && <Error error={formErrors.confirmPassword} />}
+                    {formErrors.confirmPassword && (
+                      <Error error={formErrors.confirmPassword} />
+                    )}
                   </FormControl>
 
                   <HStack spacing={3} pt={4}>
                     <Button type="submit" colorScheme="purple">
                       Confirm changes
                     </Button>
-                    <Button
-                      variant="outline"
-                      onClick={() => navigate("/")}
-                    >
+                    <Button variant="outline" onClick={() => navigate("/")}>
                       Return to Frontpage
                     </Button>
                   </HStack>

--- a/src/client/components/utils/toastUtils.js
+++ b/src/client/components/utils/toastUtils.js
@@ -3,12 +3,42 @@
  * Provides a custom hook, useCustomToast, that returns a showToast function for easy toast display.
  */
 
+import { useEffect, useRef } from "react"
 import { useToast } from "@chakra-ui/react"
+
+// How long to hold off on "error" toasts after a session-expiry is detected.
+// NavBar already shows a clear message and redirects when this fires, so the
+// many call sites across the app that independently toast on a failed API
+// call would otherwise show a second, confusing message for the same event.
+const SESSION_EXPIRED_SUPPRESSION_WINDOW_MS = 5000
 
 export const useCustomToast = () => {
   const toast = useToast()
+  const sessionExpiredRef = useRef(false)
+
+  useEffect(() => {
+    let resetTimer
+    const markSessionExpired = () => {
+      sessionExpiredRef.current = true
+      clearTimeout(resetTimer)
+      resetTimer = setTimeout(() => {
+        sessionExpiredRef.current = false
+      }, SESSION_EXPIRED_SUPPRESSION_WINDOW_MS)
+    }
+
+    window.addEventListener("session-expired", markSessionExpired)
+    return () => {
+      // Cleanup the event listener when components using this hook unmount
+      window.removeEventListener("session-expired", markSessionExpired)
+      clearTimeout(resetTimer)
+    }
+  }, [])
 
   const showToast = ({ title, description, status }) => {
+    if (status === "error" && sessionExpiredRef.current) {
+      return
+    }
+
     toast({
       title,
       description,

--- a/src/client/components/utils/toastUtils.js
+++ b/src/client/components/utils/toastUtils.js
@@ -5,6 +5,7 @@
 
 import { useEffect, useRef } from "react"
 import { useToast } from "@chakra-ui/react"
+import { SESSION_EXPIRED_EVENT } from "../../utils/axiosAuthInterceptor"
 
 // How long to hold off on "error" toasts after a session-expiry is detected.
 // NavBar already shows a clear message and redirects when this fires, so the
@@ -26,10 +27,10 @@ export const useCustomToast = () => {
       }, SESSION_EXPIRED_SUPPRESSION_WINDOW_MS)
     }
 
-    window.addEventListener("session-expired", markSessionExpired)
+    window.addEventListener(SESSION_EXPIRED_EVENT, markSessionExpired)
     return () => {
       // Cleanup the event listener when components using this hook unmount
-      window.removeEventListener("session-expired", markSessionExpired)
+      window.removeEventListener(SESSION_EXPIRED_EVENT, markSessionExpired)
       clearTimeout(resetTimer)
     }
   }, [])

--- a/src/client/main.jsx
+++ b/src/client/main.jsx
@@ -5,6 +5,9 @@ import store from "./redux/store"
 import "../../styles.css"
 
 import App from "./App"
+import { setupAxiosAuthInterceptor } from "./utils/axiosAuthInterceptor"
+
+setupAxiosAuthInterceptor()
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <Provider store={store}>

--- a/src/client/tests/unit/autologout.test.js
+++ b/src/client/tests/unit/autologout.test.js
@@ -1,42 +1,88 @@
 /*
- * Auto-logout unit test.
- * Verifies that an expired token clears the user state and redirects to home.
+ * Auto-logout unit tests.
+ * Verifies that an expired token clears the user state and redirects to home,
+ * both at initial mount (a token that was already dead before the app loaded)
+ * and reactively mid-session (the axios interceptor detecting a token that
+ * died while the user was already using the app).
  */
-import { render, waitFor } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
-import '@testing-library/jest-dom'
-import NavBar from '../../components/navbar/index'
-import { isTokenExpired } from '../../auth'
+import { act } from "react"
+import { render, waitFor } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import "@testing-library/jest-dom"
+import { useToast } from "@chakra-ui/react"
+import NavBar from "../../components/navbar/index"
+import { isTokenExpired } from "../../auth"
 
-jest.mock('../../auth')
-jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    useNavigate: jest.fn(),
-  }))
-jest.mock('../../components/utils/firebase', () => ({
-  apikey: 'testkey'
-  }))
+jest.mock("../../auth")
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: jest.fn(),
+}))
+jest.mock("../../components/utils/firebase", () => ({
+  apikey: "testkey",
+}))
+jest.mock("@chakra-ui/react", () => {
+  const originalModule = jest.requireActual("@chakra-ui/react")
+  return {
+    ...originalModule,
+    useToast: jest.fn(),
+  }
+})
 
-describe('autologout', () => {
-  test('user is logged out when token expires', async () => {
+describe("autologout", () => {
+  test("user is logged out when token expires", async () => {
     const setUser = jest.fn()
     const navigate = jest.fn()
 
     isTokenExpired.mockReturnValue(true)
-    require('react-router-dom').useNavigate.mockReturnValue(navigate)
+    require("react-router-dom").useNavigate.mockReturnValue(navigate)
 
     render(
       <MemoryRouter>
-        <NavBar user={{ username: 'testuser' }} 
-        setUser={setUser} 
-        navigate={navigate} 
+        <NavBar
+          user={{ username: "testuser" }}
+          setUser={setUser}
+          navigate={navigate}
         />
       </MemoryRouter>
     )
 
     await waitFor(() => {
       expect(setUser).toHaveBeenCalledWith(null)
-      expect(navigate).toHaveBeenCalledWith('/')
+      expect(navigate).toHaveBeenCalledWith("/")
+    })
+  })
+})
+
+describe("session-expired event", () => {
+  test("clears user, redirects home, and shows a toast when session-expired fires", async () => {
+    const setUser = jest.fn()
+    const navigate = jest.fn()
+    const toastMock = jest.fn()
+
+    isTokenExpired.mockReturnValue(false)
+    require("react-router-dom").useNavigate.mockReturnValue(navigate)
+    useToast.mockReturnValue(toastMock)
+
+    render(
+      <MemoryRouter>
+        <NavBar user={{ username: "testuser" }} setUser={setUser} />
+      </MemoryRouter>
+    )
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("session-expired"))
+    })
+
+    await waitFor(() => {
+      expect(setUser).toHaveBeenCalledWith(null)
+      expect(navigate).toHaveBeenCalledWith("/")
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: "warning",
+          description: expect.stringMatching(/session has expired/i),
+        })
+      )
     })
   })
 })

--- a/src/client/tests/unit/autologout.test.js
+++ b/src/client/tests/unit/autologout.test.js
@@ -6,12 +6,13 @@
  * died while the user was already using the app).
  */
 import { act } from "react"
-import { render, waitFor } from "@testing-library/react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
 import { MemoryRouter } from "react-router-dom"
 import "@testing-library/jest-dom"
 import { useToast } from "@chakra-ui/react"
 import NavBar from "../../components/navbar/index"
 import { isTokenExpired } from "../../auth"
+import { SESSION_EXPIRED_EVENT } from "../../utils/axiosAuthInterceptor"
 
 jest.mock("../../auth")
 jest.mock("react-router-dom", () => ({
@@ -26,6 +27,20 @@ jest.mock("@chakra-ui/react", () => {
   return {
     ...originalModule,
     useToast: jest.fn(),
+  }
+})
+jest.mock("../../components/navbar/Login", () => {
+  const React = require("react")
+  return function MockLogin({ onLogin }) {
+    return (
+      <button
+        type="button"
+        data-testid="mock-login-trigger"
+        onClick={() => onLogin({ id: 1, username: "login-user" })}
+      >
+        Trigger Login
+      </button>
+    )
   }
 })
 
@@ -71,7 +86,7 @@ describe("session-expired event", () => {
     )
 
     act(() => {
-      window.dispatchEvent(new CustomEvent("session-expired"))
+      window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT))
     })
 
     await waitFor(() => {
@@ -84,5 +99,66 @@ describe("session-expired event", () => {
         })
       )
     })
+  })
+
+  test("only reacts once to a burst of session-expired events fired back-to-back", async () => {
+    // Simulates e.g. EditMode's Promise.all batch of updateCue calls: if the
+    // token dies mid-batch, every parallel request 401s and independently
+    // dispatches session-expired. That shouldn't stack multiple toasts/redirects.
+    const setUser = jest.fn()
+    const navigate = jest.fn()
+    const toastMock = jest.fn()
+
+    isTokenExpired.mockReturnValue(false)
+    require("react-router-dom").useNavigate.mockReturnValue(navigate)
+    useToast.mockReturnValue(toastMock)
+
+    render(
+      <MemoryRouter>
+        <NavBar user={{ username: "testuser" }} setUser={setUser} />
+      </MemoryRouter>
+    )
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT))
+      window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT))
+      window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT))
+    })
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledTimes(1)
+    })
+    expect(setUser).toHaveBeenCalledTimes(1)
+    expect(navigate).toHaveBeenCalledTimes(1)
+  })
+
+  test("reacts again to a new session-expired event after logging back in", async () => {
+    const setUser = jest.fn()
+    const navigate = jest.fn()
+    const toastMock = jest.fn()
+
+    isTokenExpired.mockReturnValue(false)
+    require("react-router-dom").useNavigate.mockReturnValue(navigate)
+    useToast.mockReturnValue(toastMock)
+
+    render(
+      <MemoryRouter>
+        <NavBar user={null} setUser={setUser} />
+      </MemoryRouter>
+    )
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT))
+    })
+    await waitFor(() => expect(toastMock).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByRole("button", { name: "Login" }))
+    fireEvent.click(screen.getByTestId("mock-login-trigger"))
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT))
+    })
+
+    await waitFor(() => expect(toastMock).toHaveBeenCalledTimes(2))
   })
 })

--- a/src/client/tests/unit/axiosAuthInterceptor.test.js
+++ b/src/client/tests/unit/axiosAuthInterceptor.test.js
@@ -4,12 +4,15 @@
  * backend's own signal that the app's JWT itself failed verification)
  * dispatches "session-expired".
  */
-import { handleResponseError } from "../../utils/axiosAuthInterceptor"
+import {
+  handleResponseError,
+  SESSION_EXPIRED_EVENT,
+} from "../../utils/axiosAuthInterceptor"
 
 describe("axiosAuthInterceptor", () => {
   test("dispatches session-expired when the response body includes code SESSION_EXPIRED", async () => {
     const listener = jest.fn()
-    window.addEventListener("session-expired", listener)
+    window.addEventListener(SESSION_EXPIRED_EVENT, listener)
 
     const error = {
       response: {
@@ -21,12 +24,12 @@ describe("axiosAuthInterceptor", () => {
     await expect(handleResponseError(error)).rejects.toBe(error)
     expect(listener).toHaveBeenCalledTimes(1)
 
-    window.removeEventListener("session-expired", listener)
+    window.removeEventListener(SESSION_EXPIRED_EVENT, listener)
   })
 
   test("does not dispatch session-expired for a 401 without the code (e.g. wrong login credentials)", async () => {
     const listener = jest.fn()
-    window.addEventListener("session-expired", listener)
+    window.addEventListener(SESSION_EXPIRED_EVENT, listener)
 
     const error = {
       response: {
@@ -38,12 +41,12 @@ describe("axiosAuthInterceptor", () => {
     await expect(handleResponseError(error)).rejects.toBe(error)
     expect(listener).not.toHaveBeenCalled()
 
-    window.removeEventListener("session-expired", listener)
+    window.removeEventListener(SESSION_EXPIRED_EVENT, listener)
   })
 
   test("does not dispatch session-expired for a 401 on Firebase sign-in verification failure", async () => {
     const listener = jest.fn()
-    window.addEventListener("session-expired", listener)
+    window.addEventListener(SESSION_EXPIRED_EVENT, listener)
 
     const error = {
       response: {
@@ -55,18 +58,18 @@ describe("axiosAuthInterceptor", () => {
     await expect(handleResponseError(error)).rejects.toBe(error)
     expect(listener).not.toHaveBeenCalled()
 
-    window.removeEventListener("session-expired", listener)
+    window.removeEventListener(SESSION_EXPIRED_EVENT, listener)
   })
 
   test("does not throw and does not dispatch for a network error with no response at all", async () => {
     const listener = jest.fn()
-    window.addEventListener("session-expired", listener)
+    window.addEventListener(SESSION_EXPIRED_EVENT, listener)
 
     const error = new Error("Network Error")
 
     await expect(handleResponseError(error)).rejects.toBe(error)
     expect(listener).not.toHaveBeenCalled()
 
-    window.removeEventListener("session-expired", listener)
+    window.removeEventListener(SESSION_EXPIRED_EVENT, listener)
   })
 })

--- a/src/client/tests/unit/axiosAuthInterceptor.test.js
+++ b/src/client/tests/unit/axiosAuthInterceptor.test.js
@@ -1,20 +1,21 @@
 /*
  * Axios auth-error interceptor unit tests.
- * Verifies a 401 from an authenticated request is treated as an expired
- * session (dispatches "session-expired"), while a 401 from an unauthenticated
- * request (e.g. a wrong-password login attempt, which has no Authorization
- * header) is left alone.
+ * Verifies a 401 whose response body includes code: "SESSION_EXPIRED" (the
+ * backend's own signal that the app's JWT itself failed verification)
+ * dispatches "session-expired".
  */
 import { handleResponseError } from "../../utils/axiosAuthInterceptor"
 
 describe("axiosAuthInterceptor", () => {
-  test("dispatches session-expired when a request with an Authorization header gets a 401", async () => {
+  test("dispatches session-expired when the response body includes code SESSION_EXPIRED", async () => {
     const listener = jest.fn()
     window.addEventListener("session-expired", listener)
 
     const error = {
-      response: { status: 401 },
-      config: { headers: { Authorization: "Bearer sometoken" } },
+      response: {
+        status: 401,
+        data: { error: "token expired", code: "SESSION_EXPIRED" },
+      },
     }
 
     await expect(handleResponseError(error)).rejects.toBe(error)
@@ -23,14 +24,45 @@ describe("axiosAuthInterceptor", () => {
     window.removeEventListener("session-expired", listener)
   })
 
-  test("does not dispatch session-expired for a 401 with no Authorization header (e.g. failed login)", async () => {
+  test("does not dispatch session-expired for a 401 without the code (e.g. wrong login credentials)", async () => {
     const listener = jest.fn()
     window.addEventListener("session-expired", listener)
 
     const error = {
-      response: { status: 401 },
-      config: { headers: {} },
+      response: {
+        status: 401,
+        data: { error: "invalid username or password" },
+      },
     }
+
+    await expect(handleResponseError(error)).rejects.toBe(error)
+    expect(listener).not.toHaveBeenCalled()
+
+    window.removeEventListener("session-expired", listener)
+  })
+
+  test("does not dispatch session-expired for a 401 on Firebase sign-in verification failure", async () => {
+    const listener = jest.fn()
+    window.addEventListener("session-expired", listener)
+
+    const error = {
+      response: {
+        status: 401,
+        data: { error: "Token verification failed" },
+      },
+    }
+
+    await expect(handleResponseError(error)).rejects.toBe(error)
+    expect(listener).not.toHaveBeenCalled()
+
+    window.removeEventListener("session-expired", listener)
+  })
+
+  test("does not throw and does not dispatch for a network error with no response at all", async () => {
+    const listener = jest.fn()
+    window.addEventListener("session-expired", listener)
+
+    const error = new Error("Network Error")
 
     await expect(handleResponseError(error)).rejects.toBe(error)
     expect(listener).not.toHaveBeenCalled()

--- a/src/client/tests/unit/axiosAuthInterceptor.test.js
+++ b/src/client/tests/unit/axiosAuthInterceptor.test.js
@@ -1,0 +1,40 @@
+/*
+ * Axios auth-error interceptor unit tests.
+ * Verifies a 401 from an authenticated request is treated as an expired
+ * session (dispatches "session-expired"), while a 401 from an unauthenticated
+ * request (e.g. a wrong-password login attempt, which has no Authorization
+ * header) is left alone.
+ */
+import { handleResponseError } from "../../utils/axiosAuthInterceptor"
+
+describe("axiosAuthInterceptor", () => {
+  test("dispatches session-expired when a request with an Authorization header gets a 401", async () => {
+    const listener = jest.fn()
+    window.addEventListener("session-expired", listener)
+
+    const error = {
+      response: { status: 401 },
+      config: { headers: { Authorization: "Bearer sometoken" } },
+    }
+
+    await expect(handleResponseError(error)).rejects.toBe(error)
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    window.removeEventListener("session-expired", listener)
+  })
+
+  test("does not dispatch session-expired for a 401 with no Authorization header (e.g. failed login)", async () => {
+    const listener = jest.fn()
+    window.addEventListener("session-expired", listener)
+
+    const error = {
+      response: { status: 401 },
+      config: { headers: {} },
+    }
+
+    await expect(handleResponseError(error)).rejects.toBe(error)
+    expect(listener).not.toHaveBeenCalled()
+
+    window.removeEventListener("session-expired", listener)
+  })
+})

--- a/src/client/tests/unit/homepage.test.js
+++ b/src/client/tests/unit/homepage.test.js
@@ -170,28 +170,6 @@ describe("HomePage", () => {
     })
   })
 
-  test("navigates to / on 401 Unauthorized error", async () => {
-    presentationService.getAll.mockRejectedValue({
-      response: { status: 401 },
-    })
-
-    render(<HomePage user={{ isAdmin: true }} />)
-
-    await waitFor(() => expect(presentationService.getAll).toHaveBeenCalled())
-
-    expect(navigate).toHaveBeenCalledWith("/")
-  })
-
-  test("does not navigate to / on non-401 error", async () => {
-    presentationService.getAll.mockRejectedValue(new Error("Random error"))
-
-    render(<HomePage user={{ isAdmin: true }} />)
-
-    await waitFor(() => expect(presentationService.getAll).toHaveBeenCalled())
-
-    expect(navigate).not.toHaveBeenCalledWith("/")
-  })
-
   test("handles error when presentationService.create fails", async () => {
     const errorMessage = "Creation failed"
     presentationService.create.mockRejectedValue(new Error(errorMessage))

--- a/src/client/tests/unit/toastUtils.test.js
+++ b/src/client/tests/unit/toastUtils.test.js
@@ -1,0 +1,107 @@
+/*
+ * useCustomToast unit tests.
+ * This shared hook is the one chokepoint every toast call site in the app
+ * already goes through. Verifies it suppresses a redundant "error" toast for
+ * a short window right after a session-expiry is detected (NavBar already
+ * told the user and is redirecting them away), without requiring any of the
+ * individual call sites to guard themselves.
+ */
+import { renderHook, act } from "@testing-library/react"
+import { useToast } from "@chakra-ui/react"
+import { useCustomToast } from "../../components/utils/toastUtils"
+
+jest.mock("@chakra-ui/react", () => {
+  const originalModule = jest.requireActual("@chakra-ui/react")
+  return {
+    ...originalModule,
+    useToast: jest.fn(),
+  }
+})
+
+describe("useCustomToast", () => {
+  let toastMock
+
+  beforeEach(() => {
+    toastMock = jest.fn()
+    useToast.mockReturnValue(toastMock)
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  test("shows a toast normally when no session-expired event has fired", () => {
+    const { result } = renderHook(() => useCustomToast())
+
+    act(() => {
+      result.current({ title: "Error", description: "Oops", status: "error" })
+    })
+
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Error",
+        description: "Oops",
+        status: "error",
+      })
+    )
+  })
+
+  test("suppresses an error toast requested right after a session-expired event", () => {
+    const { result } = renderHook(() => useCustomToast())
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("session-expired"))
+    })
+    act(() => {
+      result.current({
+        title: "Error",
+        description: "token expired",
+        status: "error",
+      })
+    })
+
+    expect(toastMock).not.toHaveBeenCalled()
+  })
+
+  test("does not suppress a non-error toast (e.g. NavBar's own session-expired notice)", () => {
+    const { result } = renderHook(() => useCustomToast())
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("session-expired"))
+    })
+    act(() => {
+      result.current({
+        title: "Session expired",
+        description: "...",
+        status: "warning",
+      })
+    })
+
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "warning" })
+    )
+  })
+
+  test("resumes showing error toasts once the suppression window elapses", () => {
+    jest.useFakeTimers()
+    const { result } = renderHook(() => useCustomToast())
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("session-expired"))
+    })
+    act(() => {
+      jest.advanceTimersByTime(5000)
+    })
+    act(() => {
+      result.current({
+        title: "Error",
+        description: "a later, unrelated error",
+        status: "error",
+      })
+    })
+
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "a later, unrelated error" })
+    )
+  })
+})

--- a/src/client/tests/unit/toastUtils.test.js
+++ b/src/client/tests/unit/toastUtils.test.js
@@ -9,6 +9,7 @@
 import { renderHook, act } from "@testing-library/react"
 import { useToast } from "@chakra-ui/react"
 import { useCustomToast } from "../../components/utils/toastUtils"
+import { SESSION_EXPIRED_EVENT } from "../../utils/axiosAuthInterceptor"
 
 jest.mock("@chakra-ui/react", () => {
   const originalModule = jest.requireActual("@chakra-ui/react")
@@ -50,7 +51,7 @@ describe("useCustomToast", () => {
     const { result } = renderHook(() => useCustomToast())
 
     act(() => {
-      window.dispatchEvent(new CustomEvent("session-expired"))
+      window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT))
     })
     act(() => {
       result.current({
@@ -67,7 +68,7 @@ describe("useCustomToast", () => {
     const { result } = renderHook(() => useCustomToast())
 
     act(() => {
-      window.dispatchEvent(new CustomEvent("session-expired"))
+      window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT))
     })
     act(() => {
       result.current({
@@ -87,7 +88,7 @@ describe("useCustomToast", () => {
     const { result } = renderHook(() => useCustomToast())
 
     act(() => {
-      window.dispatchEvent(new CustomEvent("session-expired"))
+      window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT))
     })
     act(() => {
       jest.advanceTimersByTime(5000)

--- a/src/client/utils/axiosAuthInterceptor.js
+++ b/src/client/utils/axiosAuthInterceptor.js
@@ -3,29 +3,16 @@
  * notifies the rest of the app via a "session-expired" window event,
  * without touching every individual service call site.
  *
- * Only requests that already carried an Authorization header are treated
- * this way - the login/signup endpoints also return 401 for bad
- * credentials, and those requests are unauthenticated, so they must be
- * left for the calling form to handle locally.
+ * The backend marks a 401 with code: "SESSION_EXPIRED" specifically when
+ * the app's own JWT failed verification (see src/server/utils/middleware.js).
  */
 import axios from "axios"
 
 export const SESSION_EXPIRED_MESSAGE =
   "Your session has expired. Please log in again."
 
-const hasAuthorizationHeader = (headers) => {
-  if (!headers) return false
-  if (typeof headers.get === "function") {
-    return Boolean(headers.get("Authorization"))
-  }
-  return Boolean(headers.Authorization || headers.authorization)
-}
-
 export const handleResponseError = (error) => {
-  const isAuthFailure = error.response?.status === 401
-  const wasAuthenticatedRequest = hasAuthorizationHeader(error.config?.headers)
-
-  if (isAuthFailure && wasAuthenticatedRequest) {
+  if (error.response?.data?.code === "SESSION_EXPIRED") {
     window.dispatchEvent(new CustomEvent("session-expired"))
   }
 

--- a/src/client/utils/axiosAuthInterceptor.js
+++ b/src/client/utils/axiosAuthInterceptor.js
@@ -11,9 +11,12 @@ import axios from "axios"
 export const SESSION_EXPIRED_MESSAGE =
   "Your session has expired. Please log in again."
 
+// Used to broadcast a detected session expiry to the rest of the app
+export const SESSION_EXPIRED_EVENT = "session-expired"
+
 export const handleResponseError = (error) => {
   if (error.response?.data?.code === "SESSION_EXPIRED") {
-    window.dispatchEvent(new CustomEvent("session-expired"))
+    window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT))
   }
 
   return Promise.reject(error)

--- a/src/client/utils/axiosAuthInterceptor.js
+++ b/src/client/utils/axiosAuthInterceptor.js
@@ -1,0 +1,37 @@
+/*
+ * Detects an expired/invalid app session from any axios response and
+ * notifies the rest of the app via a "session-expired" window event,
+ * without touching every individual service call site.
+ *
+ * Only requests that already carried an Authorization header are treated
+ * this way - the login/signup endpoints also return 401 for bad
+ * credentials, and those requests are unauthenticated, so they must be
+ * left for the calling form to handle locally.
+ */
+import axios from "axios"
+
+export const SESSION_EXPIRED_MESSAGE =
+  "Your session has expired. Please log in again."
+
+const hasAuthorizationHeader = (headers) => {
+  if (!headers) return false
+  if (typeof headers.get === "function") {
+    return Boolean(headers.get("Authorization"))
+  }
+  return Boolean(headers.Authorization || headers.authorization)
+}
+
+export const handleResponseError = (error) => {
+  const isAuthFailure = error.response?.status === 401
+  const wasAuthenticatedRequest = hasAuthorizationHeader(error.config?.headers)
+
+  if (isAuthFailure && wasAuthenticatedRequest) {
+    window.dispatchEvent(new CustomEvent("session-expired"))
+  }
+
+  return Promise.reject(error)
+}
+
+export const setupAxiosAuthInterceptor = () => {
+  axios.interceptors.response.use((response) => response, handleResponseError)
+}

--- a/src/server/routes/users.js
+++ b/src/server/routes/users.js
@@ -1,7 +1,7 @@
 /**
  * This module defines the routes for user-related operations, including linking and unlinking Google Drive accounts and changing user passwords.
- * It uses middleware to extract the user from the request and to ensure that the user is authenticated before performing any operations. 
- * The routes interact with the User model to perform database operations and return JSON responses. 
+ * It uses middleware to extract the user from the request and to ensure that the user is authenticated before performing any operations.
+ * The routes interact with the User model to perform database operations and return JSON responses.
  * Input validation is included to ensure that required fields are present and meet specified criteria, such as password strength requirements.
  */
 
@@ -110,7 +110,7 @@ router.post("/change-password", userExtractor, async (req, res) => {
   }
 
   if (!(await checkPassword(currentPassword, user.passwordHash))) {
-    return res.status(401).json({
+    return res.status(400).json({
       error: "Current password is not valid",
     })
   }

--- a/src/server/tests/middleware.test.js
+++ b/src/server/tests/middleware.test.js
@@ -149,7 +149,7 @@ describe("Middleware functions", () => {
       await userExtractor(mockRequest, mockResponse, mockNext)
       expect(mockResponse.status).not.toHaveBeenCalled()
       expect(mockNext).toHaveBeenCalledTimes(1)
-      
+
       const errorArg = mockNext.mock.calls[0][0]
       expect(errorArg).toBeInstanceOf(Error)
       expect(errorArg.name).toBe("JsonWebTokenError")
@@ -162,7 +162,10 @@ describe("Middleware functions", () => {
       await userExtractor(mockRequest, mockResponse, mockNext)
 
       expect(mockResponse.status).toHaveBeenCalledWith(401)
-      expect(mockResponse.json).toHaveBeenCalledWith({ error: "token invalid" })
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        error: "token invalid",
+        code: "SESSION_EXPIRED",
+      })
     })
 
     test("should call next() when no token provided", async () => {
@@ -184,7 +187,7 @@ describe("Middleware functions", () => {
 
       expect(mockResponse.status).not.toHaveBeenCalled()
       expect(mockNext).toHaveBeenCalledTimes(1)
-      
+
       const errorArg = mockNext.mock.calls[0][0]
       expect(errorArg).toBeInstanceOf(Error)
       expect(errorArg.name).toBe("TokenExpiredError")
@@ -313,7 +316,9 @@ describe("Middleware functions", () => {
       unknownEndpoint(mockRequest, mockResponse)
 
       expect(mockResponse.status).toHaveBeenCalledWith(404)
-      expect(mockResponse.send).toHaveBeenCalledWith({ error: "unknown endpoint" })
+      expect(mockResponse.send).toHaveBeenCalledWith({
+        error: "unknown endpoint",
+      })
     })
 
     test("should not call next()", () => {
@@ -339,7 +344,9 @@ describe("Middleware functions", () => {
       errorHandler(error, mockRequest, mockResponse, mockNext)
 
       expect(mockResponse.status).toHaveBeenCalledWith(400)
-      expect(mockResponse.send).toHaveBeenCalledWith({ error: "malformatted id" })
+      expect(mockResponse.send).toHaveBeenCalledWith({
+        error: "malformatted id",
+      })
     })
 
     test("should handle ValidationError", () => {
@@ -349,7 +356,9 @@ describe("Middleware functions", () => {
       errorHandler(error, mockRequest, mockResponse, mockNext)
 
       expect(mockResponse.status).toHaveBeenCalledWith(400)
-      expect(mockResponse.json).toHaveBeenCalledWith({ error: "Validation failed" })
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        error: "Validation failed",
+      })
     })
 
     test("should handle JsonWebTokenError", () => {
@@ -359,7 +368,10 @@ describe("Middleware functions", () => {
       errorHandler(error, mockRequest, mockResponse, mockNext)
 
       expect(mockResponse.status).toHaveBeenCalledWith(401)
-      expect(mockResponse.json).toHaveBeenCalledWith({ error: "invalid token" })
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        error: "invalid token",
+        code: "SESSION_EXPIRED",
+      })
     })
 
     test("should handle TokenExpiredError", () => {
@@ -369,7 +381,10 @@ describe("Middleware functions", () => {
       errorHandler(error, mockRequest, mockResponse, mockNext)
 
       expect(mockResponse.status).toHaveBeenCalledWith(401)
-      expect(mockResponse.json).toHaveBeenCalledWith({ error: "token expired" })
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        error: "token expired",
+        code: "SESSION_EXPIRED",
+      })
     })
 
     test("should handle MongoServerError duplicate key error", () => {
@@ -380,7 +395,9 @@ describe("Middleware functions", () => {
       errorHandler(error, mockRequest, mockResponse, mockNext)
 
       expect(mockResponse.status).toHaveBeenCalledWith(400)
-      expect(mockResponse.json).toHaveBeenCalledWith({ error: "duplicate key error" })
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        error: "duplicate key error",
+      })
     })
 
     test("should pass unknown errors to next middleware", () => {

--- a/src/server/tests/users_api.test.js
+++ b/src/server/tests/users_api.test.js
@@ -130,7 +130,7 @@ describe("POST /change-password", () => {
         currentPassword: "wrongpassword",
         newPassword: "newpassword123",
       })
-      .expect(401)
+      .expect(400)
       .expect("Content-Type", /application\/json/)
   })
 

--- a/src/server/utils/middleware.js
+++ b/src/server/utils/middleware.js
@@ -34,7 +34,9 @@ const userExtractor = async (request, response, next) => {
     if (token) {
       const decodedToken = jwt.verify(token, process.env.SECRET)
       if (!decodedToken.id) {
-        return response.status(401).json({ error: "token invalid" })
+        return response
+          .status(401)
+          .json({ error: "token invalid", code: "SESSION_EXPIRED" })
       }
 
       request.user = await User.findById(decodedToken.id)
@@ -93,10 +95,14 @@ const errorHandler = (error, request, response, next) => {
     return response.status(400).json({ error: error.message })
   }
   if (error.name === "JsonWebTokenError") {
-    return response.status(401).json({ error: "invalid token" })
+    return response
+      .status(401)
+      .json({ error: "invalid token", code: "SESSION_EXPIRED" })
   }
   if (error.name === "TokenExpiredError") {
-    return response.status(401).json({ error: "token expired" })
+    return response
+      .status(401)
+      .json({ error: "token expired", code: "SESSION_EXPIRED" })
   }
   if (error.name === "MongoServerError" && error.code === 11000) {
     return response.status(400).json({ error: "duplicate key error" })


### PR DESCRIPTION
**Changes**
- Making a backend request with an expired token now:
  1. Redirects the user to the frontpage
  2. Deletes the session / token from localstorage
  3. Notifies the user that their session has expired and that they should login again
- The backend now attaches a "SESSION_EXPIRED" code into the response to make it more explicit
- Changed response status from 401 to 400 when the user attempts to change their password while providing wrong current password
- Added a frontend guard against multiple expiration responses arriving at once
- Other error toasts are now suppressed when processing and displaying the expired session toast
- Fixed a bug where the expired session toast would not appear while editing the presentation
- The profile page now uses the same custom toast as the rest of the app

**Note:**
The token timeout is still set to 1 hour, since raising it may cause issues with google drive tokens expiring.

Closes #841 