### PR TITLE
Fix presentation frame edit race condition and re-enable the presentation save status badge

### DIFF
--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -104,7 +104,6 @@ const EditMode = ({
   const dispatch = useDispatch()
   const presentation = useSelector((state) => state.presentation)
   const containerRef = useRef(null)
-  const [status, setStatus] = useState("saved")
   const [selectedCue, setSelectedCue] = useState(null)
   const [isConfirmOpen, setIsConfirmOpen] = useState(false)
   const [confirmMessage, setConfirmMessage] = useState("")
@@ -388,7 +387,6 @@ const EditMode = ({
     const cuesAfter = cues.filter((cue) => Number(cue.index) > Number(index))
 
     if (originalIndexCount < 101) {
-      setStatus("loading")
       try {
         dispatch(incrementIndexCount())
         await dispatch(
@@ -399,7 +397,6 @@ const EditMode = ({
           await dispatch(shiftPresentationIndexes(id, index, "right"))
         }
 
-        setStatus("saved")
         if (cuesAfter.length > 0) {
           showToast({
             title: "Frame added in between",
@@ -411,7 +408,6 @@ const EditMode = ({
         console.error("Error shifting cues when adding index:", error)
         dispatch(decrementIndexCount())
         await dispatch(saveIndexCount({ id, indexCount: originalIndexCount }))
-        setStatus("saved")
         showToast({
           title: "Error",
           description: error.message || "Failed to add index",
@@ -455,10 +451,8 @@ const EditMode = ({
 
   const performRemoveIndex = async (newIndexCount) => {
     if (indexCount > 1) {
-      setStatus("loading")
       dispatch(decrementIndexCount())
       await dispatch(saveIndexCount({ id, indexCount: newIndexCount }))
-      setStatus("saved")
     }
   }
 
@@ -469,13 +463,11 @@ const EditMode = ({
   const shiftAndRemoveIndex = async (index) => {
     const cuesAfter = cues.filter((cue) => Number(cue.index) > Number(index))
 
-    setStatus("loading")
     try {
       if (cuesAfter.length > 0) {
         await dispatch(shiftPresentationIndexes(id, index, "left"))
       }
       await performRemoveIndex(indexCount - 1)
-      setStatus("saved")
       return cuesAfter.length
     } catch (error) {
       console.error("Error shifting cues when removing index:", error)
@@ -484,7 +476,6 @@ const EditMode = ({
         description: error.message || "Failed to remove index",
         status: "error",
       })
-      setStatus("saved")
       return null
     }
   }
@@ -1055,7 +1046,6 @@ const EditMode = ({
 
   // Add a new cue - checks for conflicts and saves to backend
   const addCue = async (cueData) => {
-    setStatus("loading")
     const { index, cueName, screen, file, loop, color } = cueData
 
     //Check if cue with same index and screen already exists
@@ -1082,7 +1072,6 @@ const EditMode = ({
       await dispatch(createCue(id, formData))
 
       setTimeout(() => {
-        setStatus("saved")
         showToast({
           title: "Element added",
           description: `Element ${cueName} added to screen ${screen}`,
@@ -1149,9 +1138,21 @@ const EditMode = ({
     )
 
     setConfirmAction(() => async () => {
-      const updatedCueData = await createUpdatedCueData(existingCue, updatedCue)
-      await dispatch(removeCue(id, previousCueId))
-      await dispatchUpdateCue(existingCue._id, updatedCueData)
+      try {
+        const updatedCueData = await createUpdatedCueData(
+          existingCue,
+          updatedCue
+        )
+        await dispatch(removeCue(id, previousCueId))
+        await dispatchUpdateCue(existingCue._id, updatedCueData)
+      } catch (error) {
+        console.error(error)
+        showToast({
+          title: "Error",
+          description: error.message || "Failed to update element",
+          status: "error",
+        })
+      }
       setIsConfirmOpen(false)
     })
     setIsConfirmOpen(true)
@@ -1220,11 +1221,9 @@ const EditMode = ({
   }
   // Dispatch cue update to backend - used for moving cues and updating from toolbox
   const dispatchUpdateCue = async (cueId, updatedCue) => {
-    setStatus("loading")
     try {
       await dispatch(updatePresentation(id, updatedCue, cueId))
       setTimeout(() => {
-        setStatus("saved")
         showToast({
           title: "Element updated",
           description: `Element ${updatedCue.cueName} updated on screen ${updatedCue.screen}`,
@@ -1253,13 +1252,10 @@ const EditMode = ({
 
   // Swap two cues positions - handles element reordering on grid
   const dispatchSwapCues = async (newTargetCue, newSelectedCue) => {
-    setStatus("loading")
     try {
       await dispatch(swapCues(id, newTargetCue, newSelectedCue))
-      setStatus("saved")
     } catch (error) {
       console.error(error)
-      setStatus("saved")
       showToast({
         title: "Error",
         description: error.message || "An error occurred",
@@ -1913,24 +1909,6 @@ const EditMode = ({
               setIsToolboxOpen(false)
             }}
           />
-        </Box>
-        <Box
-          position="fixed"
-          top="20%"
-          right="5%"
-          display="flex"
-          alignItems="center"
-          zIndex={1}
-        ></Box>
-        <Box
-          position="fixed"
-          top="11%"
-          right="5%"
-          display="flex"
-          alignItems="center"
-          zIndex={1}
-        >
-          {/* <StatusTooltip status={status}/> */}
         </Box>
         <Dialog
           isOpen={isConfirmOpen}

--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -370,29 +370,14 @@ const EditMode = ({
         }
       }
 
-      // Get all cues after this index, shift them to the left
-      const cuesAfter = cues.filter((c) => Number(c.index) > Number(index))
-      if (index !== indexCount - 1) {
-        try {
-          await dispatch(shiftPresentationIndexes(id, index, "left"))
-          showToast({
-            title: "Removed frame in between and its elements",
-            description: `Removed old Frame ${index} and all its elements.${cuesAfter.length > 0 ? ` Moved ${cuesAfter.length} element(s) backwards.` : ""}`,
-            status: "success",
-          })
-        } catch (err) {
-          console.error("Failed to shift cues after deleting index:", err)
-          showToast({
-            title: "Error",
-            description: err.message || "Failed to remove index",
-            status: "error",
-          })
-          return
-        }
-      }
+      const movedCount = await shiftAndRemoveIndex(index)
+      if (movedCount === null) return
 
-      // Remove last index
-      await performRemoveIndex(indexCount - 1)
+      showToast({
+        title: "Removed frame in between and its elements",
+        description: `Removed old Frame ${index} and all its elements.${movedCount > 0 ? ` Moved ${movedCount} element(s) backwards.` : ""}`,
+        status: "success",
+      })
     })
     setIsConfirmOpen(true)
   }
@@ -455,35 +440,16 @@ const EditMode = ({
       return
     }
 
-    // Get all cues after this index, shift them to the left
-    const cuesAfter = cues.filter((cue) => Number(cue.index) > Number(index))
+    const movedCount = await shiftAndRemoveIndex(index)
+    if (movedCount === null) return
 
-    if (cuesAfter.length === 0) {
-      // Just remove last index if no cues to move
-      await performRemoveIndex(indexCount - 1)
-      return
-    }
-
-    setStatus("loading")
-    try {
-      await dispatch(shiftPresentationIndexes(id, index, "left"))
-
-      await performRemoveIndex(indexCount - 1)
-      setStatus("saved")
-      // We never reach here if there were existing elements on the removed index, as handleIndexHasData handles that case (so different toast)
+    // We never reach here if there were existing elements on the removed index, as handleIndexHasData handles that case (so different toast)
+    if (movedCount > 0) {
       showToast({
         title: "Removed frame in between",
-        description: `Removed old Frame ${index}. Moved ${cuesAfter.length} element(s) backwards.`,
+        description: `Removed old Frame ${index}. Moved ${movedCount} element(s) backwards.`,
         status: "success",
       })
-    } catch (error) {
-      console.error("Error shifting cues when removing index:", error)
-      showToast({
-        title: "Error",
-        description: error.message || "Failed to remove index",
-        status: "error",
-      })
-      setStatus("saved")
     }
   }
 
@@ -493,6 +459,33 @@ const EditMode = ({
       dispatch(decrementIndexCount())
       await dispatch(saveIndexCount({ id, indexCount: newIndexCount }))
       setStatus("saved")
+    }
+  }
+
+  // Shared by handleRemoveIndex and handleIndexHasData: shifts cues after
+  // `index` left by one (only if any exist), then shrinks the index count.
+  // Returns null and shows an error toast if the shift fails, so callers can
+  // skip their own success toast; otherwise returns how many cues moved.
+  const shiftAndRemoveIndex = async (index) => {
+    const cuesAfter = cues.filter((cue) => Number(cue.index) > Number(index))
+
+    setStatus("loading")
+    try {
+      if (cuesAfter.length > 0) {
+        await dispatch(shiftPresentationIndexes(id, index, "left"))
+      }
+      await performRemoveIndex(indexCount - 1)
+      setStatus("saved")
+      return cuesAfter.length
+    } catch (error) {
+      console.error("Error shifting cues when removing index:", error)
+      showToast({
+        title: "Error",
+        description: error.message || "Failed to remove index",
+        status: "error",
+      })
+      setStatus("saved")
+      return null
     }
   }
 

--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -382,6 +382,12 @@ const EditMode = ({
           })
         } catch (err) {
           console.error("Failed to shift cues after deleting index:", err)
+          showToast({
+            title: "Error",
+            description: err.message || "Failed to remove index",
+            status: "error",
+          })
+          return
         }
       }
 

--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -371,13 +371,13 @@ const EditMode = ({
       }
 
       // Get all cues after this index, shift them to the left
-      const cuesToShift = cues.filter((c) => Number(c.index) > Number(index))
+      const cuesAfter = cues.filter((c) => Number(c.index) > Number(index))
       if (index !== indexCount - 1) {
         try {
           await dispatch(shiftPresentationIndexes(id, index, "left"))
           showToast({
             title: "Removed frame in between and its elements",
-            description: `Removed old Frame ${index} and all its elements.${cuesToShift.length > 0 ? ` Moved ${cuesToShift.length} element(s) backwards.` : ""}`,
+            description: `Removed old Frame ${index} and all its elements.${cuesAfter.length > 0 ? ` Moved ${cuesAfter.length} element(s) backwards.` : ""}`,
             status: "success",
           })
         } catch (err) {
@@ -447,10 +447,10 @@ const EditMode = ({
       return
     }
 
-    const cuesInIndex = cues.filter(
+    const cuesOnIndex = cues.filter(
       (cue) => Number(cue.index) === Number(index)
     )
-    if (cuesInIndex.length > 0) {
+    if (cuesOnIndex.length > 0) {
       handleIndexHasData(index)
       return
     }
@@ -487,11 +487,11 @@ const EditMode = ({
     }
   }
 
-  const performRemoveIndex = async (indexToRemove) => {
+  const performRemoveIndex = async (newIndexCount) => {
     if (indexCount > 1) {
       setStatus("loading")
       dispatch(decrementIndexCount())
-      await dispatch(saveIndexCount({ id, indexCount: indexToRemove }))
+      await dispatch(saveIndexCount({ id, indexCount: newIndexCount }))
       setStatus("saved")
     }
   }

--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -30,7 +30,6 @@ import {
 } from "../../redux/presentationReducer"
 import { saveIndexCount, saveScreenCount } from "../../redux/presentationThunks"
 import { createFormData } from "../utils/formDataUtils"
-import presentationService from "../../services/presentation"
 import ToolBox from "./ToolBox"
 import GridLayoutComponent from "./GridLayoutComponent"
 import useEditModeDragPreviewState from "./useEditModeDragPreviewState"
@@ -405,38 +404,15 @@ const EditMode = ({
           saveIndexCount({ id, indexCount: originalIndexCount + 1 })
         )
 
-        const cuesToShift = cuesAfter
-          .slice()
-          .sort((a, b) => Number(b.index) - Number(a.index))
-
-        // Create new data for the elements in the new positions
-        const updatePromises = cuesToShift.map((cue) => {
-          const formData = createFormData(
-            Number(cue.index) + 1,
-            cue.name,
-            cue.screen,
-            cue.file,
-            cue._id,
-            cue.color,
-            cue.loop
-          )
-
-          return presentationService.updateCue(id, cue._id, formData)
-        })
-
-        // We wait for all the promises to resolve
-        const updatedCues = await Promise.all(updatePromises)
-
-        // Then update cues
-        for (const updated of updatedCues) {
-          dispatch(editCue(updated))
+        if (cuesAfter.length > 0) {
+          await dispatch(shiftPresentationIndexes(id, index, "right"))
         }
 
         setStatus("saved")
-        if (cuesToShift.length > 0) {
+        if (cuesAfter.length > 0) {
           showToast({
             title: "Frame added in between",
-            description: `Added a new frame after ${index === 0 ? "Starting Frame" : `Frame ${index}`}. Moved ${cuesToShift.length} element(s) forward.`,
+            description: `Added a new frame after ${index === 0 ? "Starting Frame" : `Frame ${index}`}. Moved ${cuesAfter.length} element(s) forward.`,
             status: "success",
           })
         }
@@ -484,37 +460,14 @@ const EditMode = ({
 
     setStatus("loading")
     try {
-      const cuesToShift = cuesAfter
-        .slice()
-        .sort((a, b) => Number(a.index) - Number(b.index))
-
-      // Create new data for the elements in the new positions
-      const updatePromises = cuesToShift.map((cue) => {
-        const formData = createFormData(
-          Number(cue.index) - 1,
-          cue.name,
-          cue.screen,
-          cue.file,
-          cue._id,
-          cue.color,
-          cue.loop
-        )
-
-        return presentationService.updateCue(id, cue._id, formData)
-      })
-
-      const updatedCues = await Promise.all(updatePromises)
-
-      for (const updated of updatedCues) {
-        dispatch(editCue(updated))
-      }
+      await dispatch(shiftPresentationIndexes(id, index, "left"))
 
       await performRemoveIndex(indexCount - 1)
       setStatus("saved")
       // We never reach here if there were existing elements on the removed index, as handleIndexHasData handles that case (so different toast)
       showToast({
         title: "Removed frame in between",
-        description: `Removed old Frame ${index}. Moved ${cuesToShift.length} element(s) backwards.`,
+        description: `Removed old Frame ${index}. Moved ${cuesAfter.length} element(s) backwards.`,
         status: "success",
       })
     } catch (error) {

--- a/src/client/components/presentation/EditModeContainer.jsx
+++ b/src/client/components/presentation/EditModeContainer.jsx
@@ -21,6 +21,7 @@ import EditMode from "./EditMode"
 import CuesForm from "./CuesForm"
 import PresentationPlaybackControls from "./PresentationPlaybackControls"
 import PresentationTitle from "./PresentationTitle"
+import StatusTooltip from "./StatusToolTip"
 import Screen from "./Screen"
 import TutorialGuide from "../tutorial/TutorialGuide"
 import { presentationTutorialSteps } from "../data/tutorialSteps"
@@ -175,7 +176,13 @@ function EditorLayout(props) {
         <div id="screen_resize_handle" className="resize_handle"></div>
       </div>
       <div
-        style={{ backgroundColor: editModeBackground, borderRadius: "8px" }}
+        style={{
+          backgroundColor: editModeBackground,
+          borderRadius: "8px",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
         className="no-resize-handle"
         key="playbackControls"
       >
@@ -196,6 +203,9 @@ function EditorLayout(props) {
           audioSourceURL={audioSourceURL}
           audioLoop={audioLoop}
         />
+        <Box mr={4}>
+          <StatusTooltip />
+        </Box>
       </div>
 
       <div className="edit-workspace" key="editWorkspace">

--- a/src/client/components/presentation/StatusToolTip.jsx
+++ b/src/client/components/presentation/StatusToolTip.jsx
@@ -1,24 +1,60 @@
-import React from "react"
+import React, { useEffect, useRef, useState } from "react"
+import { useSelector } from "react-redux"
 import { Box, Tooltip, Spinner } from "@chakra-ui/react"
 import { CheckIcon } from "@chakra-ui/icons"
 
-const StatusTooltip = ({ status }) => (
-  <Tooltip
-    label={
-      status === "loading" ? "Saving in progress..." : "Your changes are saved!"
+// How long the "saved" checkmark stays visible before fading out, so it
+// doesn't linger as noise once nothing is happening.
+const SAVED_FADE_DELAY_MS = 2000
+
+const StatusTooltip = () => {
+  const pendingSaves = useSelector((state) => state.presentation.pendingSaves)
+  const status = pendingSaves > 0 ? "loading" : "saved"
+  // Starts hidden, not visible: on mount there's no save to report yet, so
+  // there's nothing to show until the first "loading" transition reveals it.
+  const [visible, setVisible] = useState(false)
+  const fadeTimerRef = useRef(null)
+
+  useEffect(() => {
+    clearTimeout(fadeTimerRef.current)
+
+    if (status === "loading") {
+      setVisible(true)
+      return
     }
-    aria-label="Status Tooltip"
-    placement="right"
-    zIndex="tooltip"
-  >
-    <Box>
-      {status === "loading" ? (
-        <Spinner size="md" color="purple.200" />
-      ) : (
-        <CheckIcon w={6} h={6} color="purple.200" />
-      )}
-    </Box>
-  </Tooltip>
-)
+
+    fadeTimerRef.current = setTimeout(() => {
+      setVisible(false)
+    }, SAVED_FADE_DELAY_MS)
+
+    return () => clearTimeout(fadeTimerRef.current)
+  }, [status])
+
+  return (
+    <Tooltip
+      label={
+        status === "loading"
+          ? "Saving in progress..."
+          : "Your changes are saved!"
+      }
+      aria-label="Status Tooltip"
+      placement="left"
+      zIndex="tooltip"
+    >
+      <Box
+        data-testid="status-tooltip-badge"
+        opacity={visible ? 1 : 0}
+        transition="opacity 400ms ease"
+        pointerEvents={visible ? "auto" : "none"}
+      >
+        {status === "loading" ? (
+          <Spinner size="md" color="purple.200" />
+        ) : (
+          <CheckIcon w={6} h={6} color="purple.200" />
+        )}
+      </Box>
+    </Tooltip>
+  )
+}
 
 export default StatusTooltip

--- a/src/client/redux/presentationReducer.js
+++ b/src/client/redux/presentationReducer.js
@@ -15,7 +15,7 @@ const initialState = {
   name: "",
   screenCount: null,
   indexCount: 5,
-  saving: false,
+  pendingSaves: 0,
 }
 /** * The presentationSlice manages the state of the presentation, including cues, name, screen count,
  * and index count. It defines reducers for setting presentation info, adding/editing/deleting cues,
@@ -49,7 +49,13 @@ const presentationSlice = createSlice({
       state.name = initialState.name
       state.screenCount = initialState.screenCount
       state.indexCount = initialState.indexCount
-      state.saving = initialState.saving
+      state.pendingSaves = initialState.pendingSaves
+    },
+    beginSave(state) {
+      state.pendingSaves += 1
+    },
+    endSave(state) {
+      state.pendingSaves = Math.max(0, state.pendingSaves - 1)
     },
     incrementIndexCount(state) {
       state.indexCount += 1
@@ -74,22 +80,22 @@ const presentationSlice = createSlice({
   extraReducers: (builder) => {
     builder
       .addCase(saveIndexCount.pending, (state) => {
-        state.saving = true
+        state.pendingSaves += 1
       })
       .addCase(saveIndexCount.fulfilled, (state, action) => {
-        state.saving = false
+        state.pendingSaves = Math.max(0, state.pendingSaves - 1)
         const newIndexCount = action.payload.indexCount
         state.indexCount = newIndexCount
         state.cues = state.cues.filter((cue) => cue.index < newIndexCount)
       })
       .addCase(saveIndexCount.rejected, (state) => {
-        state.saving = false
+        state.pendingSaves = Math.max(0, state.pendingSaves - 1)
       })
       .addCase(saveScreenCount.pending, (state) => {
-        state.saving = true
+        state.pendingSaves += 1
       })
       .addCase(saveScreenCount.fulfilled, (state, action) => {
-        state.saving = false
+        state.pendingSaves = Math.max(0, state.pendingSaves - 1)
 
         if (action.payload.screenCount !== undefined) {
           const newScreenCount = action.payload.screenCount
@@ -105,7 +111,7 @@ const presentationSlice = createSlice({
         }
       })
       .addCase(saveScreenCount.rejected, (state) => {
-        state.saving = false
+        state.pendingSaves = Math.max(0, state.pendingSaves - 1)
       })
   },
 })
@@ -121,6 +127,8 @@ export const {
   incrementScreenCount,
   decrementScreenCount,
   updateNameOnly,
+  beginSave,
+  endSave,
 } = presentationSlice.actions
 
 export default presentationSlice.reducer
@@ -137,6 +145,7 @@ export const fetchPresentationInfo = (id) => async (dispatch) => {
 }
 
 export const removeCue = (presentationId, cueId) => async (dispatch) => {
+  dispatch(beginSave())
   try {
     await presentationService.removeCue(presentationId, cueId)
     dispatch(deleteCue(cueId))
@@ -144,10 +153,13 @@ export const removeCue = (presentationId, cueId) => async (dispatch) => {
     const errorMessage = error.response?.data?.error || "An error occurred"
     console.error(errorMessage)
     throw new Error(errorMessage)
+  } finally {
+    dispatch(endSave())
   }
 }
 
 export const createCue = (id, formData) => async (dispatch) => {
+  dispatch(beginSave())
   try {
     const updatedPresentation = await presentationService.addCue(id, formData)
     const newCue = updatedPresentation.cues.find(
@@ -160,6 +172,8 @@ export const createCue = (id, formData) => async (dispatch) => {
     const errorMessage = error.response?.data?.error || "An error occurred"
     console.error(errorMessage)
     throw new Error(errorMessage)
+  } finally {
+    dispatch(endSave())
   }
 }
 
@@ -176,6 +190,7 @@ export const deletePresentation = (id) => async (dispatch) => {
 
 export const updatePresentation =
   (presentationId, updatedCueData, cueId) => async (dispatch) => {
+    dispatch(beginSave())
     try {
       const formData = createFormData(
         updatedCueData.index,
@@ -198,11 +213,14 @@ export const updatePresentation =
       const errorMessage = error.response?.data?.error || "An error occurred"
       console.error(errorMessage)
       throw new Error(errorMessage)
+    } finally {
+      dispatch(endSave())
     }
   }
 
 export const swapCues =
   (presentationId, firstUpdatedCue, secondUpdatedCue) => async (dispatch) => {
+    dispatch(beginSave())
     try {
       const swapPayload = {
         firstCueId: firstUpdatedCue._id,
@@ -222,11 +240,14 @@ export const swapCues =
       const errorMessage = error.response?.data?.error || "An error occurred"
       console.error(errorMessage)
       throw new Error(errorMessage)
+    } finally {
+      dispatch(endSave())
     }
   }
 
 export const shiftPresentationIndexes =
   (presentationId, startIndex, direction) => async (dispatch) => {
+    dispatch(beginSave())
     try {
       const result = await presentationService.shiftIndexes(
         presentationId,
@@ -239,11 +260,14 @@ export const shiftPresentationIndexes =
       const errorMessage = error.response?.data?.error || "An error occurred"
       console.error(errorMessage)
       throw new Error(errorMessage)
+    } finally {
+      dispatch(endSave())
     }
   }
 
 export const updatePresentationName =
   (presentationId, newName) => async (dispatch, getState) => {
+    dispatch(beginSave())
     try {
       const updated = await presentationService.updatePresentationName(
         presentationId,
@@ -254,5 +278,7 @@ export const updatePresentationName =
       const errorMessage = error.response?.data?.error || "An error occurred"
       console.error(errorMessage)
       throw new Error(errorMessage)
+    } finally {
+      dispatch(endSave())
     }
   }

--- a/src/client/tests/unit/EditMode.test.jsx
+++ b/src/client/tests/unit/EditMode.test.jsx
@@ -20,6 +20,7 @@ import {
   updatePresentation,
   incrementIndexCount,
   decrementIndexCount,
+  removeCue,
   shiftPresentationIndexes,
 } from "../../redux/presentationReducer"
 import { saveIndexCount } from "../../redux/presentationThunks"
@@ -1195,6 +1196,60 @@ describe("EditMode drag swapping", () => {
         screen.getByText(/Frame 1 has existing elements/)
       ).toBeInTheDocument()
       expect(shiftPresentationIndexes).not.toHaveBeenCalled()
+    })
+
+    it("removes the cue, shifts remaining cues, and shrinks the index count after confirming removal of a frame with a cue", async () => {
+      const cues = [buildCue({ id: "c1", index: 1 })]
+      renderWithFrames(cues, 3)
+
+      await act(async () => {
+        fireEvent.click(screen.getAllByLabelText("Remove Frame")[0])
+      })
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("confirm-dialog-confirm"))
+      })
+
+      expect(removeCue).toHaveBeenCalledWith("presentation-1", "c1")
+      expect(shiftPresentationIndexes).toHaveBeenCalledWith(
+        "presentation-1",
+        1,
+        "left"
+      )
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Removed frame in between and its elements",
+        })
+      )
+      expect(decrementIndexCount).toHaveBeenCalled()
+      expect(saveIndexCount).toHaveBeenCalledWith({
+        id: "presentation-1",
+        indexCount: 2,
+      })
+    })
+
+    it("skips shrinking the index count when the shift fails while removing a frame with a cue on it", async () => {
+      const cues = [buildCue({ id: "c1", index: 1 })]
+      renderWithFrames(cues, 3)
+      mockDispatch.mockImplementation((action) =>
+        action?.type === "MOCK_SHIFT_INDEXES"
+          ? Promise.reject(new Error("shift failed"))
+          : Promise.resolve({})
+      )
+
+      await act(async () => {
+        fireEvent.click(screen.getAllByLabelText("Remove Frame")[0])
+      })
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("confirm-dialog-confirm"))
+      })
+
+      await waitFor(() => {
+        expect(mockShowToast).toHaveBeenCalledWith(
+          expect.objectContaining({ title: "Error" })
+        )
+      })
+      expect(decrementIndexCount).not.toHaveBeenCalled()
+      expect(saveIndexCount).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/client/tests/unit/EditMode.test.jsx
+++ b/src/client/tests/unit/EditMode.test.jsx
@@ -1198,9 +1198,12 @@ describe("EditMode drag swapping", () => {
       expect(shiftPresentationIndexes).not.toHaveBeenCalled()
     })
 
-    it("removes the cue, shifts remaining cues, and shrinks the index count after confirming removal of a frame with a cue", async () => {
-      const cues = [buildCue({ id: "c1", index: 1 })]
-      renderWithFrames(cues, 3)
+    it("removes the cue, shifts remaining cues after it, and shrinks the index count after confirming removal of a frame with a cue", async () => {
+      const cues = [
+        buildCue({ id: "c1", index: 1 }),
+        buildCue({ id: "c2", index: 2 }),
+      ]
+      renderWithFrames(cues, 4)
 
       await act(async () => {
         fireEvent.click(screen.getAllByLabelText("Remove Frame")[0])
@@ -1218,6 +1221,32 @@ describe("EditMode drag swapping", () => {
       expect(mockShowToast).toHaveBeenCalledWith(
         expect.objectContaining({
           title: "Removed frame in between and its elements",
+          description: expect.stringContaining("Moved 1 element(s) backwards"),
+        })
+      )
+      expect(decrementIndexCount).toHaveBeenCalled()
+      expect(saveIndexCount).toHaveBeenCalledWith({
+        id: "presentation-1",
+        indexCount: 3,
+      })
+    })
+
+    it("removes the cue and shrinks the index count without shifting when there is nothing after the removed frame", async () => {
+      const cues = [buildCue({ id: "c1", index: 1 })]
+      renderWithFrames(cues, 3)
+
+      await act(async () => {
+        fireEvent.click(screen.getAllByLabelText("Remove Frame")[0])
+      })
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("confirm-dialog-confirm"))
+      })
+
+      expect(removeCue).toHaveBeenCalledWith("presentation-1", "c1")
+      expect(shiftPresentationIndexes).not.toHaveBeenCalled()
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Removed frame in between and its elements",
         })
       )
       expect(decrementIndexCount).toHaveBeenCalled()
@@ -1228,8 +1257,11 @@ describe("EditMode drag swapping", () => {
     })
 
     it("skips shrinking the index count when the shift fails while removing a frame with a cue on it", async () => {
-      const cues = [buildCue({ id: "c1", index: 1 })]
-      renderWithFrames(cues, 3)
+      const cues = [
+        buildCue({ id: "c1", index: 1 }),
+        buildCue({ id: "c2", index: 2 }),
+      ]
+      renderWithFrames(cues, 4)
       mockDispatch.mockImplementation((action) =>
         action?.type === "MOCK_SHIFT_INDEXES"
           ? Promise.reject(new Error("shift failed"))

--- a/src/client/tests/unit/EditMode.test.jsx
+++ b/src/client/tests/unit/EditMode.test.jsx
@@ -18,7 +18,11 @@ import {
   createCue,
   swapCues,
   updatePresentation,
+  incrementIndexCount,
+  decrementIndexCount,
+  shiftPresentationIndexes,
 } from "../../redux/presentationReducer"
+import { saveIndexCount } from "../../redux/presentationThunks"
 
 const mockDispatch = jest.fn(() => Promise.resolve({}))
 const mockShowToast = jest.fn()
@@ -945,5 +949,252 @@ describe("EditMode drag swapping", () => {
     )
 
     expect(defaultWasNotPrevented).toBe(false)
+  })
+
+  describe("frame index add/remove shifting", () => {
+    const buildCue = ({ id, index, screen = 1 }) => ({
+      _id: id,
+      index,
+      screen,
+      name: `Cue ${id}`,
+      color: "#ffffff",
+      cueType: "visual",
+      file: {
+        type: "image/png",
+        url: `https://example.com/${id}.png`,
+        name: `${id}.png`,
+      },
+    })
+
+    beforeEach(() => {
+      // jest.clearAllMocks() (outer beforeEach) clears call history but not a
+      // custom mockImplementation set by an error-path test — reset it here
+      // so each test starts from the default resolve-everything behavior.
+      mockDispatch.mockImplementation(() => Promise.resolve({}))
+    })
+
+    const renderWithFrames = (customCues, customIndexCount) => {
+      useSelector.mockImplementation((selector) =>
+        selector({
+          presentation: {
+            cues: customCues,
+            name: "Test presentation",
+            screenCount: 2,
+            indexCount: customIndexCount,
+          },
+        })
+      )
+      return render(
+        <EditMode
+          id="presentation-1"
+          cues={customCues}
+          isToolboxOpen={false}
+          setIsToolboxOpen={jest.fn()}
+          cueIndex={0}
+          isAudioMuted={false}
+          toggleAudioMute={jest.fn()}
+          indexCount={customIndexCount}
+        />
+      )
+    }
+
+    it("does not shift when adding a frame with no cues after it", async () => {
+      renderWithFrames([], 3)
+
+      await act(async () => {
+        fireEvent.click(screen.getAllByLabelText("Add Frame")[0])
+      })
+
+      await waitFor(() => {
+        expect(incrementIndexCount).toHaveBeenCalled()
+      })
+      expect(shiftPresentationIndexes).not.toHaveBeenCalled()
+      expect(mockShowToast).not.toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Frame added in between" })
+      )
+    })
+
+    it("shifts a single cue right in one request when adding a frame before it", async () => {
+      const cues = [buildCue({ id: "c1", index: 2 })]
+      renderWithFrames(cues, 4)
+
+      await act(async () => {
+        fireEvent.click(screen.getAllByLabelText("Add Frame")[0])
+      })
+
+      await waitFor(() => {
+        expect(shiftPresentationIndexes).toHaveBeenCalledWith(
+          "presentation-1",
+          0,
+          "right"
+        )
+      })
+      expect(shiftPresentationIndexes).toHaveBeenCalledTimes(1)
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Frame added in between",
+          description: expect.stringContaining("Moved 1 element(s) forward"),
+        })
+      )
+    })
+
+    it("shifts several consecutive same-screen cues in a single request when adding a frame (previously racy)", async () => {
+      const cues = [
+        buildCue({ id: "c1", index: 1 }),
+        buildCue({ id: "c2", index: 2 }),
+        buildCue({ id: "c3", index: 3 }),
+      ]
+      renderWithFrames(cues, 5)
+
+      await act(async () => {
+        fireEvent.click(screen.getAllByLabelText("Add Frame")[0])
+      })
+
+      await waitFor(() => {
+        expect(shiftPresentationIndexes).toHaveBeenCalledWith(
+          "presentation-1",
+          0,
+          "right"
+        )
+      })
+      expect(shiftPresentationIndexes).toHaveBeenCalledTimes(1)
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: expect.stringContaining("Moved 3 element(s) forward"),
+        })
+      )
+      expect(mockShowToast).not.toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Error" })
+      )
+    })
+
+    it("reverts the index-count increment when the shift request fails", async () => {
+      const cues = [buildCue({ id: "c1", index: 2 })]
+      renderWithFrames(cues, 4)
+      mockDispatch.mockImplementation((action) =>
+        action?.type === "MOCK_SHIFT_INDEXES"
+          ? Promise.reject(new Error("shift failed"))
+          : Promise.resolve({})
+      )
+
+      await act(async () => {
+        fireEvent.click(screen.getAllByLabelText("Add Frame")[0])
+      })
+
+      await waitFor(() => {
+        expect(mockShowToast).toHaveBeenCalledWith(
+          expect.objectContaining({ title: "Error" })
+        )
+      })
+      expect(decrementIndexCount).toHaveBeenCalled()
+      expect(saveIndexCount).toHaveBeenCalledWith({
+        id: "presentation-1",
+        indexCount: 4,
+      })
+    })
+
+    it("does not shift when removing a frame with no cues after it", async () => {
+      renderWithFrames([], 3)
+
+      await act(async () => {
+        fireEvent.click(screen.getAllByLabelText("Remove Frame")[1])
+      })
+
+      await waitFor(() => {
+        expect(decrementIndexCount).toHaveBeenCalled()
+      })
+      expect(shiftPresentationIndexes).not.toHaveBeenCalled()
+    })
+
+    it("shifts a single cue left in one request when removing an earlier empty frame", async () => {
+      const cues = [buildCue({ id: "c1", index: 2 })]
+      renderWithFrames(cues, 4)
+
+      await act(async () => {
+        fireEvent.click(screen.getAllByLabelText("Remove Frame")[0])
+      })
+
+      await waitFor(() => {
+        expect(shiftPresentationIndexes).toHaveBeenCalledWith(
+          "presentation-1",
+          1,
+          "left"
+        )
+      })
+      expect(shiftPresentationIndexes).toHaveBeenCalledTimes(1)
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Removed frame in between",
+          description: expect.stringContaining("Moved 1 element(s) backwards"),
+        })
+      )
+    })
+
+    it("shifts several consecutive same-screen cues in a single request when removing a frame (previously racy)", async () => {
+      const cues = [
+        buildCue({ id: "c1", index: 2 }),
+        buildCue({ id: "c2", index: 3 }),
+        buildCue({ id: "c3", index: 4 }),
+      ]
+      renderWithFrames(cues, 6)
+
+      await act(async () => {
+        fireEvent.click(screen.getAllByLabelText("Remove Frame")[0])
+      })
+
+      await waitFor(() => {
+        expect(shiftPresentationIndexes).toHaveBeenCalledWith(
+          "presentation-1",
+          1,
+          "left"
+        )
+      })
+      expect(shiftPresentationIndexes).toHaveBeenCalledTimes(1)
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: expect.stringContaining("Moved 3 element(s) backwards"),
+        })
+      )
+      expect(mockShowToast).not.toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Error" })
+      )
+    })
+
+    it("shows an error and skips the index-count update when the removal shift request fails", async () => {
+      const cues = [buildCue({ id: "c1", index: 2 })]
+      renderWithFrames(cues, 4)
+      mockDispatch.mockImplementation((action) =>
+        action?.type === "MOCK_SHIFT_INDEXES"
+          ? Promise.reject(new Error("shift failed"))
+          : Promise.resolve({})
+      )
+
+      await act(async () => {
+        fireEvent.click(screen.getAllByLabelText("Remove Frame")[0])
+      })
+
+      await waitFor(() => {
+        expect(mockShowToast).toHaveBeenCalledWith(
+          expect.objectContaining({ title: "Error" })
+        )
+      })
+      expect(decrementIndexCount).not.toHaveBeenCalled()
+      expect(saveIndexCount).not.toHaveBeenCalled()
+    })
+
+    it("delegates to the confirmation dialog instead of shifting directly when the removed frame has a cue on it", async () => {
+      const cues = [buildCue({ id: "c1", index: 1 })]
+      renderWithFrames(cues, 3)
+
+      await act(async () => {
+        fireEvent.click(screen.getAllByLabelText("Remove Frame")[0])
+      })
+
+      expect(screen.getByTestId("mock-alert-dialog")).toBeInTheDocument()
+      expect(
+        screen.getByText(/Frame 1 has existing elements/)
+      ).toBeInTheDocument()
+      expect(shiftPresentationIndexes).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/client/tests/unit/StatusToolTip.test.jsx
+++ b/src/client/tests/unit/StatusToolTip.test.jsx
@@ -1,0 +1,60 @@
+/*
+ * StatusTooltip unit tests.
+ * Covers deriving the "loading"/"saved" status from the redux
+ * presentation.pendingSaves counter.
+ */
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { useSelector } from "react-redux"
+import StatusTooltip from "../../components/presentation/StatusToolTip"
+
+jest.mock("react-redux", () => ({
+  useSelector: jest.fn(),
+}))
+
+const renderWithPendingSaves = (pendingSaves) => {
+  useSelector.mockImplementation((selector) =>
+    selector({ presentation: { pendingSaves } })
+  )
+  return render(<StatusTooltip />)
+}
+
+describe("StatusTooltip", () => {
+  it("shows the loading spinner and becomes visible while a save is pending", () => {
+    renderWithPendingSaves(1)
+
+    expect(screen.getByText("Loading...")).toBeInTheDocument()
+    expect(screen.getByTestId("status-tooltip-badge")).toBeVisible()
+  })
+
+  it("shows the saved checkmark only once every overlapping save has finished", () => {
+    const { rerender } = renderWithPendingSaves(2)
+    expect(screen.getByText("Loading...")).toBeInTheDocument()
+
+    // One of the two overlapping saves finishing should not flip to "saved".
+    useSelector.mockImplementation((selector) =>
+      selector({ presentation: { pendingSaves: 1 } })
+    )
+    rerender(<StatusTooltip />)
+    expect(screen.getByText("Loading...")).toBeInTheDocument()
+
+    useSelector.mockImplementation((selector) =>
+      selector({ presentation: { pendingSaves: 0 } })
+    )
+    rerender(<StatusTooltip />)
+    expect(screen.queryByText("Loading...")).not.toBeInTheDocument()
+  })
+
+  it("shows the saved checkmark when nothing is pending", () => {
+    renderWithPendingSaves(0)
+
+    expect(screen.queryByText("Loading...")).not.toBeInTheDocument()
+  })
+
+  it("stays hidden on initial mount instead of flashing the saved checkmark", () => {
+    renderWithPendingSaves(0)
+
+    expect(screen.getByTestId("status-tooltip-badge")).not.toBeVisible()
+  })
+})

--- a/src/client/tests/unit/presentationReducer.test.js
+++ b/src/client/tests/unit/presentationReducer.test.js
@@ -22,6 +22,8 @@ import reducer, {
   decrementScreenCount,
   shiftPresentationIndexes,
   updatePresentationName,
+  beginSave,
+  endSave,
 } from "../../redux/presentationReducer.js"
 import {
   saveIndexCount,
@@ -153,7 +155,7 @@ describe("presentationReducer reducer", () => {
     name: "",
     screenCount: 3,
     indexCount: 5,
-    saving: false,
+    pendingSaves: 0,
   }
 
   it("should handle setPresentationInfo", () => {
@@ -428,7 +430,7 @@ describe("presentationReducer reducer", () => {
       name: "Test Presentation",
       screenCount: 4,
       indexCount: 5,
-      saving: false,
+      pendingSaves: 0,
     }
     const action = { type: removePresentation.type }
 
@@ -1108,7 +1110,7 @@ describe("presentationReducer asynchronous actions", () => {
     expect(state.cues[2].index).toBe(3) // Should shift right
   })
 
-  it("should toggle saving during saveIndexCount lifecycle", () => {
+  it("should toggle pendingSaves during saveIndexCount lifecycle", () => {
     const store = makeStore()
 
     const initialState = {
@@ -1123,27 +1125,27 @@ describe("presentationReducer asynchronous actions", () => {
     store.dispatch(setPresentationInfo(initialState))
 
     // Simulate pending/fulfilled/rejected action sequence without running the thunk body.
-    // pending should set saving true
+    // pending should increment pendingSaves
     store.dispatch({ type: saveIndexCount.pending.type })
-    expect(store.getState().presentation.saving).toBe(true)
+    expect(store.getState().presentation.pendingSaves).toBe(1)
 
-    // fulfilled should set saving false and update indexCount and filter cues
+    // fulfilled should decrement pendingSaves and update indexCount and filter cues
     const payload = { indexCount: 2 }
     store.dispatch({ type: saveIndexCount.fulfilled.type, payload })
-    expect(store.getState().presentation.saving).toBe(false)
+    expect(store.getState().presentation.pendingSaves).toBe(0)
     expect(store.getState().presentation.indexCount).toBe(2)
     expect(store.getState().presentation.cues.every((c) => c.index < 2)).toBe(
       true
     )
 
-    // rejected should also ensure saving is false
+    // rejected should also decrement pendingSaves
     store.dispatch({ type: saveIndexCount.pending.type })
-    expect(store.getState().presentation.saving).toBe(true)
+    expect(store.getState().presentation.pendingSaves).toBe(1)
     store.dispatch({ type: saveIndexCount.rejected.type })
-    expect(store.getState().presentation.saving).toBe(false)
+    expect(store.getState().presentation.pendingSaves).toBe(0)
   })
 
-  it("should toggle saving during saveScreenCount lifecycle", () => {
+  it("should toggle pendingSaves during saveScreenCount lifecycle", () => {
     const store = makeStore()
 
     const initialState = {
@@ -1158,24 +1160,47 @@ describe("presentationReducer asynchronous actions", () => {
 
     store.dispatch(setPresentationInfo(initialState))
 
-    // pending should set saving true
+    // pending should increment pendingSaves
     store.dispatch({ type: saveScreenCount.pending.type })
-    expect(store.getState().presentation.saving).toBe(true)
+    expect(store.getState().presentation.pendingSaves).toBe(1)
 
-    // fulfilled should set saving false, update screenCount and remove cues exceeding new screenCount
+    // fulfilled should decrement pendingSaves, update screenCount and remove cues exceeding new screenCount
     const payload = { screenCount: 2, removedCuesCount: 1 }
     store.dispatch({ type: saveScreenCount.fulfilled.type, payload })
-    expect(store.getState().presentation.saving).toBe(false)
+    expect(store.getState().presentation.pendingSaves).toBe(0)
     expect(store.getState().presentation.screenCount).toBe(2)
     expect(store.getState().presentation.cues.every((c) => c.screen <= 2)).toBe(
       true
     )
 
-    // rejected should also ensure saving is false
+    // rejected should also decrement pendingSaves
     store.dispatch({ type: saveScreenCount.pending.type })
-    expect(store.getState().presentation.saving).toBe(true)
+    expect(store.getState().presentation.pendingSaves).toBe(1)
     store.dispatch({ type: saveScreenCount.rejected.type })
-    expect(store.getState().presentation.saving).toBe(false)
+    expect(store.getState().presentation.pendingSaves).toBe(0)
+  })
+
+  it("should not report saved until every overlapping save finishes", () => {
+    const store = makeStore()
+
+    // Two saves start before either finishes...
+    store.dispatch(beginSave())
+    store.dispatch(beginSave())
+    expect(store.getState().presentation.pendingSaves).toBe(2)
+
+    // ...the first finishing should not flip the status back to "saved".
+    store.dispatch(endSave())
+    expect(store.getState().presentation.pendingSaves).toBe(1)
+
+    store.dispatch(endSave())
+    expect(store.getState().presentation.pendingSaves).toBe(0)
+  })
+
+  it("should not let pendingSaves go negative on an unmatched endSave", () => {
+    const store = makeStore()
+
+    store.dispatch(endSave())
+    expect(store.getState().presentation.pendingSaves).toBe(0)
   })
 
   it("should handle error in update presentation cues swapped", async () => {


### PR DESCRIPTION
**Changes**
- Fixed a race condition which could occur when adding or removing a frame in a presentation
  - Cues shifted by the frame edit are now bundled and updated all at once
  - Created a new helper function to reduce code duplication
- Removing the last frame now correctly triggers a toast
- Re-enabled the presentation save status badge in the new editor UI
- Improved presentation save status handling:
  - Presentation save status is now stored in redux instead of EditMode state. This should reduce component re-renders while removing some of the EditMode bloat.
  - Save state is now an integer instead of boolean to keep track of multiple events at once

Closes #843 
Closes #844 