### PR TITLE
feat: add local MongoDB service to dev docker compose

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -6,14 +6,14 @@ VITE_DEV_PORT=3000
 # Express jwt secret
 SECRET= # Generate your own using python.secrets.token_hex(16)
 
-# Mongodb connection string used when running app.
+# MongoDB connection string used when running the app.
 # Leave empty to use the bundled local MongoDB in Docker (npm run start),
 # which defaults to mongodb://mongo:27017/muvico. Set it to override, e.g. a
 # remote DB, or mongodb://localhost:27017/muvico for a host run (npm run dev).
 MONGODB_URI=
-# Mongodb connection string for e2e tests. Empty defaults to the bundled local
-# MongoDB; for a host run use mongodb://localhost:27017/test.
-TEST_MONGODB_URI=
+# MongoDB connection string for e2e tests. Required when running Playwright e2e.
+# With the bundled Docker MongoDB running, mongodb://localhost:27017/test works.
+TEST_MONGODB_URI=mongodb://localhost:27017/test
 
 # S3 style object storage endpoint
 PUBLIC_S3_ENDPOINT=

--- a/.env-template
+++ b/.env-template
@@ -6,9 +6,13 @@ VITE_DEV_PORT=3000
 # Express jwt secret
 SECRET= # Generate your own using python.secrets.token_hex(16)
 
-# Mongodb connection string used when running app
+# Mongodb connection string used when running app.
+# Leave empty to use the bundled local MongoDB in Docker (npm run start),
+# which defaults to mongodb://mongo:27017/muvico. Set it to override, e.g. a
+# remote DB, or mongodb://localhost:27017/muvico for a host run (npm run dev).
 MONGODB_URI=
-# Mongodb connection string used running e2e tests
+# Mongodb connection string for e2e tests. Empty defaults to the bundled local
+# MongoDB; for a host run use mongodb://localhost:27017/test.
 TEST_MONGODB_URI=
 
 # S3 style object storage endpoint

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ If you prefer to develop inside a Docker container (to match the production envi
    npm run start
    ```
 
-   This will spin up the necessary containers for the backend, frontend, and database.
+   This will spin up the necessary containers for the backend, frontend, and a local MongoDB instance. In Docker the app uses the `MONGODB_URI` from your `.env` if set; if it is empty, it defaults to the bundled local MongoDB (`mongodb://mongo:27017/muvico`). Its data is persisted in the `mongo_data` volume, and the database is also reachable from the host on `localhost:27017`.
 
 ### Running the Application in Production Mode
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ If you prefer to develop inside a Docker container (to match the production envi
    npm run start
    ```
 
-   This will spin up the necessary containers for the backend, frontend, and a local MongoDB instance. In Docker the app uses the `MONGODB_URI` from your `.env` if set; if it is empty, it defaults to the bundled local MongoDB (`mongodb://mongo:27017/muvico`). Its data is persisted in the `mongo_data` volume, and the database is also reachable from the host on `localhost:27017`.
+   This will spin up the necessary containers for the backend, frontend, and a local MongoDB instance. In Docker, the app uses the `MONGODB_URI` from your `.env` if set; if it is empty, it defaults to the bundled local MongoDB (`mongodb://mongo:27017/muvico`). Its data is persisted in the `mongo_data` volume, and the database is also reachable from the host on `localhost:27017`.
 
 ### Running the Application in Production Mode
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,7 +23,7 @@ services:
     image: mongo:8.2
     restart: unless-stopped
     ports:
-      - 27017:27017
+      - 127.0.0.1:27017:27017
     volumes:
       - mongo_data:/data/db
     container_name: dev_mongo

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,12 +7,37 @@ services:
     ports:
       - 3000:3000
       - 8000:8000
+    environment:
+      MONGODB_URI: ${MONGODB_URI:-mongodb://mongo:27017/muvico}
     volumes:
       - ./:/app
       - /app/node_modules
     container_name: dev_app
+    depends_on:
+      mongo:
+        condition: service_healthy
+    networks:
+      - dev_net
+
+  mongo:
+    image: mongo:8.2
+    restart: unless-stopped
+    ports:
+      - 27017:27017
+    volumes:
+      - mongo_data:/data/db
+    container_name: dev_mongo
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.runCommand('ping').ok"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
     networks:
       - dev_net
 
 networks:
   dev_net:
+
+volumes:
+  mongo_data:


### PR DESCRIPTION
Bundle a local MongoDB in the dev Docker environment so `npm run start` no longer depends on a shared remote (staging) database.

## Changes
- **`compose.yaml`**: add a `mongo:8.2` service (healthcheck + persistent `mongo_data` volume, exposed on `localhost:27017`); the `app` waits for it to be healthy. `MONGODB_URI` is set to `${MONGODB_URI:-mongodb://mongo:27017/muvico}` so the value from `.env` wins if set, and the bundled local DB is used as the default when it is empty.
- **`.env-template`** / **`README.md`**: document the behaviour.

Closes #853.