### PR TITLE
chore(tests): silence expected test noise and fix local MongoDB version mismatch

### DIFF
--- a/jest-mongodb-config.js
+++ b/jest-mongodb-config.js
@@ -1,6 +1,9 @@
 module.exports = {
   mongodbMemoryServerOptions: {
     autoStart: false,
+    binary: {
+      version: "8.2.1",
+    },
     instance: {},
   },
   useSharedDBForAllJestWorkers: false,

--- a/setup-jest.js
+++ b/setup-jest.js
@@ -17,6 +17,9 @@ if (typeof window !== "undefined" && window.localStorage) {
     // ignore (some envs may throw)
   }
 }
+if (typeof window !== "undefined" && window.HTMLMediaElement) {
+  window.HTMLMediaElement.prototype.load = () => {}
+}
 if (typeof window !== "undefined") {
   Object.defineProperty(window, "matchMedia", {
     writable: true,
@@ -34,11 +37,17 @@ if (typeof window !== "undefined") {
 }
 
 jest.mock("./src/client/public/icons/nextbutton.svg", () => "nextbutton.svg")
-jest.mock("./src/client/public/icons/previousbutton.svg", () => "previousbutton.svg")
+jest.mock(
+  "./src/client/public/icons/previousbutton.svg",
+  () => "previousbutton.svg"
+)
 jest.mock("./src/client/public/icons/pausebutton.svg", () => "pausebutton.svg")
 jest.mock("./src/client/public/icons/playbutton.svg", () => "playbutton.svg")
 jest.mock("./src/client/public/icons/screen.svg", () => "screen.svg")
 jest.mock("./src/client/public/icons/trash.svg", () => "trash.svg")
-jest.mock("./src/client/public/icons/Presentationsettings.svg", () => "Presentationsettings.svg")
+jest.mock(
+  "./src/client/public/icons/Presentationsettings.svg",
+  () => "Presentationsettings.svg"
+)
 jest.mock("./src/client/public/hy_logo.svg", () => "hy_logo.svg")
 jest.mock("./src/client/public/b_hy_logo.svg", () => "b_hy_logo.svg")

--- a/src/client/tests/unit/EditMode.test.jsx
+++ b/src/client/tests/unit/EditMode.test.jsx
@@ -1071,6 +1071,9 @@ describe("EditMode drag swapping", () => {
     })
 
     it("reverts the index-count increment when the shift request fails", async () => {
+      const consoleErrorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {})
       const cues = [buildCue({ id: "c1", index: 2 })]
       renderWithFrames(cues, 4)
       mockDispatch.mockImplementation((action) =>
@@ -1093,6 +1096,7 @@ describe("EditMode drag swapping", () => {
         id: "presentation-1",
         indexCount: 4,
       })
+      consoleErrorSpy.mockRestore()
     })
 
     it("does not shift when removing a frame with no cues after it", async () => {
@@ -1163,6 +1167,12 @@ describe("EditMode drag swapping", () => {
     })
 
     it("shows an error and skips the index-count update when the removal shift request fails", async () => {
+      // Silence the console.error the component logs for this deliberately
+      // triggered failure (see the sibling "reverts the index-count
+      // increment" test above for the same rationale).
+      const consoleErrorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {})
       const cues = [buildCue({ id: "c1", index: 2 })]
       renderWithFrames(cues, 4)
       mockDispatch.mockImplementation((action) =>
@@ -1182,6 +1192,7 @@ describe("EditMode drag swapping", () => {
       })
       expect(decrementIndexCount).not.toHaveBeenCalled()
       expect(saveIndexCount).not.toHaveBeenCalled()
+      consoleErrorSpy.mockRestore()
     })
 
     it("delegates to the confirmation dialog instead of shifting directly when the removed frame has a cue on it", async () => {
@@ -1258,6 +1269,12 @@ describe("EditMode drag swapping", () => {
     })
 
     it("skips shrinking the index count when the shift fails while removing a frame with a cue on it", async () => {
+      // Silence the console.error the component logs for this deliberately
+      // triggered failure (see the "reverts the index-count increment" test
+      // above for the same rationale).
+      const consoleErrorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {})
       const cues = [
         buildCue({ id: "c1", index: 1 }),
         buildCue({ id: "c2", index: 2 }),
@@ -1283,6 +1300,7 @@ describe("EditMode drag swapping", () => {
       })
       expect(decrementIndexCount).not.toHaveBeenCalled()
       expect(saveIndexCount).not.toHaveBeenCalled()
+      consoleErrorSpy.mockRestore()
     })
   })
 

--- a/src/client/tests/unit/EditMode.test.jsx
+++ b/src/client/tests/unit/EditMode.test.jsx
@@ -1074,29 +1074,32 @@ describe("EditMode drag swapping", () => {
       const consoleErrorSpy = jest
         .spyOn(console, "error")
         .mockImplementation(() => {})
-      const cues = [buildCue({ id: "c1", index: 2 })]
-      renderWithFrames(cues, 4)
-      mockDispatch.mockImplementation((action) =>
-        action?.type === "MOCK_SHIFT_INDEXES"
-          ? Promise.reject(new Error("shift failed"))
-          : Promise.resolve({})
-      )
-
-      await act(async () => {
-        fireEvent.click(screen.getAllByLabelText("Add Frame")[0])
-      })
-
-      await waitFor(() => {
-        expect(mockShowToast).toHaveBeenCalledWith(
-          expect.objectContaining({ title: "Error" })
+      try {
+        const cues = [buildCue({ id: "c1", index: 2 })]
+        renderWithFrames(cues, 4)
+        mockDispatch.mockImplementation((action) =>
+          action?.type === "MOCK_SHIFT_INDEXES"
+            ? Promise.reject(new Error("shift failed"))
+            : Promise.resolve({})
         )
-      })
-      expect(decrementIndexCount).toHaveBeenCalled()
-      expect(saveIndexCount).toHaveBeenCalledWith({
-        id: "presentation-1",
-        indexCount: 4,
-      })
-      consoleErrorSpy.mockRestore()
+
+        await act(async () => {
+          fireEvent.click(screen.getAllByLabelText("Add Frame")[0])
+        })
+
+        await waitFor(() => {
+          expect(mockShowToast).toHaveBeenCalledWith(
+            expect.objectContaining({ title: "Error" })
+          )
+        })
+        expect(decrementIndexCount).toHaveBeenCalled()
+        expect(saveIndexCount).toHaveBeenCalledWith({
+          id: "presentation-1",
+          indexCount: 4,
+        })
+      } finally {
+        consoleErrorSpy.mockRestore()
+      }
     })
 
     it("does not shift when removing a frame with no cues after it", async () => {
@@ -1167,32 +1170,32 @@ describe("EditMode drag swapping", () => {
     })
 
     it("shows an error and skips the index-count update when the removal shift request fails", async () => {
-      // Silence the console.error the component logs for this deliberately
-      // triggered failure (see the sibling "reverts the index-count
-      // increment" test above for the same rationale).
       const consoleErrorSpy = jest
         .spyOn(console, "error")
         .mockImplementation(() => {})
-      const cues = [buildCue({ id: "c1", index: 2 })]
-      renderWithFrames(cues, 4)
-      mockDispatch.mockImplementation((action) =>
-        action?.type === "MOCK_SHIFT_INDEXES"
-          ? Promise.reject(new Error("shift failed"))
-          : Promise.resolve({})
-      )
-
-      await act(async () => {
-        fireEvent.click(screen.getAllByLabelText("Remove Frame")[0])
-      })
-
-      await waitFor(() => {
-        expect(mockShowToast).toHaveBeenCalledWith(
-          expect.objectContaining({ title: "Error" })
+      try {
+        const cues = [buildCue({ id: "c1", index: 2 })]
+        renderWithFrames(cues, 4)
+        mockDispatch.mockImplementation((action) =>
+          action?.type === "MOCK_SHIFT_INDEXES"
+            ? Promise.reject(new Error("shift failed"))
+            : Promise.resolve({})
         )
-      })
-      expect(decrementIndexCount).not.toHaveBeenCalled()
-      expect(saveIndexCount).not.toHaveBeenCalled()
-      consoleErrorSpy.mockRestore()
+
+        await act(async () => {
+          fireEvent.click(screen.getAllByLabelText("Remove Frame")[0])
+        })
+
+        await waitFor(() => {
+          expect(mockShowToast).toHaveBeenCalledWith(
+            expect.objectContaining({ title: "Error" })
+          )
+        })
+        expect(decrementIndexCount).not.toHaveBeenCalled()
+        expect(saveIndexCount).not.toHaveBeenCalled()
+      } finally {
+        consoleErrorSpy.mockRestore()
+      }
     })
 
     it("delegates to the confirmation dialog instead of shifting directly when the removed frame has a cue on it", async () => {
@@ -1269,38 +1272,38 @@ describe("EditMode drag swapping", () => {
     })
 
     it("skips shrinking the index count when the shift fails while removing a frame with a cue on it", async () => {
-      // Silence the console.error the component logs for this deliberately
-      // triggered failure (see the "reverts the index-count increment" test
-      // above for the same rationale).
       const consoleErrorSpy = jest
         .spyOn(console, "error")
         .mockImplementation(() => {})
-      const cues = [
-        buildCue({ id: "c1", index: 1 }),
-        buildCue({ id: "c2", index: 2 }),
-      ]
-      renderWithFrames(cues, 4)
-      mockDispatch.mockImplementation((action) =>
-        action?.type === "MOCK_SHIFT_INDEXES"
-          ? Promise.reject(new Error("shift failed"))
-          : Promise.resolve({})
-      )
-
-      await act(async () => {
-        fireEvent.click(screen.getAllByLabelText("Remove Frame")[0])
-      })
-      await act(async () => {
-        fireEvent.click(screen.getByTestId("confirm-dialog-confirm"))
-      })
-
-      await waitFor(() => {
-        expect(mockShowToast).toHaveBeenCalledWith(
-          expect.objectContaining({ title: "Error" })
+      try {
+        const cues = [
+          buildCue({ id: "c1", index: 1 }),
+          buildCue({ id: "c2", index: 2 }),
+        ]
+        renderWithFrames(cues, 4)
+        mockDispatch.mockImplementation((action) =>
+          action?.type === "MOCK_SHIFT_INDEXES"
+            ? Promise.reject(new Error("shift failed"))
+            : Promise.resolve({})
         )
-      })
-      expect(decrementIndexCount).not.toHaveBeenCalled()
-      expect(saveIndexCount).not.toHaveBeenCalled()
-      consoleErrorSpy.mockRestore()
+
+        await act(async () => {
+          fireEvent.click(screen.getAllByLabelText("Remove Frame")[0])
+        })
+        await act(async () => {
+          fireEvent.click(screen.getByTestId("confirm-dialog-confirm"))
+        })
+
+        await waitFor(() => {
+          expect(mockShowToast).toHaveBeenCalledWith(
+            expect.objectContaining({ title: "Error" })
+          )
+        })
+        expect(decrementIndexCount).not.toHaveBeenCalled()
+        expect(saveIndexCount).not.toHaveBeenCalled()
+      } finally {
+        consoleErrorSpy.mockRestore()
+      }
     })
   })
 


### PR DESCRIPTION
Cleans up noisy test output from expected jsdom/console.error noise.
Fixes backend tests failing to start locally due to a MongoDB binary version mismatch (6.0.14 unavailable on Debian 12+; CI worked by coincidence on Ubuntu).

setup-jest.js: stub HTMLMediaElement.prototype.load
EditMode.test.jsx: mock console.error in the 3 deliberate-failure tests
jest-mongodb-config.js: pin MongoDB binary to 8.2.1
