### PR TITLE
feat: add layered timeline with multiple audio tracks

### DIFF
--- a/e2e/audio.spec.js
+++ b/e2e/audio.spec.js
@@ -15,8 +15,9 @@ const testuser = "audiotestuser"
 const testPw = "test12345"
 
 // addPresentation(page, "testi") defaults to screenCount = 2.
-// Timeline rows are zero-based: screen 1, screen 2, then audio track 1.
-const AUDIO_TRACK_ROW = 2
+// The helper coordinate includes the frame header offset; row coordinate 3 lands
+// on timeline row index 2, which is audio track 1.
+const AUDIO_TRACK_ROW = 3
 
 describe("Audio cues", () => {
   beforeEach(async ({ page, request }) => {

--- a/e2e/audio.spec.js
+++ b/e2e/audio.spec.js
@@ -14,9 +14,9 @@ const { test, describe, expect, beforeEach } = require("@playwright/test")
 const testuser = "audiotestuser"
 const testPw = "test12345"
 
-// addPresentation(page, "testi") defaults to screenCount = 2
-// => the audio row for this suite is always screen 3
-const AUDIO_ROW = 3
+// addPresentation(page, "testi") defaults to screenCount = 2.
+// Timeline rows are zero-based: screen 1, screen 2, then audio track 1.
+const AUDIO_TRACK_ROW = 2
 
 describe("Audio cues", () => {
   beforeEach(async ({ page, request }) => {
@@ -34,7 +34,7 @@ describe("Audio cues", () => {
     await page.goto("http://localhost:3000/home")
   })
 
-  test("user can upload an audio file and drag it onto the audio row", async ({
+  test("user can upload an audio file and drag it onto an audio track", async ({
     page,
   }) => {
     await page.getByText("testi").click()
@@ -46,10 +46,10 @@ describe("Audio cues", () => {
     })
     await expect(page.getByText("test-audio.mp3")).toBeVisible()
 
-    await dragPoolItemToGrid(page, "test-audio.mp3", 1, AUDIO_ROW)
+    await dragPoolItemToGrid(page, "test-audio.mp3", 1, AUDIO_TRACK_ROW)
 
     await expect(
-      page.getByText("Element test-audio.mp3 added to screen 3").first()
+      page.getByText("Element test-audio.mp3 added to audio track 1").first()
     ).toBeVisible()
     await expect(page.getByTestId("cue-test-audio.mp3")).toBeVisible()
   })
@@ -67,15 +67,15 @@ describe("Audio cues", () => {
     await dragPoolItemToGrid(page, "wrong-row.mp3", 1, 1)
 
     await expect(
-      page.getByText("Only audio on audio row").first()
+      page.getByText("Only audio on audio rows").first()
     ).toBeVisible()
     await expect(
-      page.getByText("Drag audio files to the audio row.").first()
+      page.getByText("Drag audio files to an audio track.").first()
     ).toBeVisible()
     await expect(page.getByTestId("cue-wrong-row.mp3")).not.toBeVisible()
   })
 
-  test("dragging a media file onto the audio row shows a validation toast", async ({
+  test("dragging a media file onto an audio track shows a validation toast", async ({
     page,
   }) => {
     await page.getByText("testi").click()
@@ -85,13 +85,13 @@ describe("Audio cues", () => {
       mimeType: "image/png",
       buffer: Buffer.from("fake image content"),
     })
-    await dragPoolItemToGrid(page, "test-image.png", 1, AUDIO_ROW)
+    await dragPoolItemToGrid(page, "test-image.png", 1, AUDIO_TRACK_ROW)
 
     await expect(
       page.getByText("Only images/videos on screen rows").first()
     ).toBeVisible()
     await expect(
-      page.getByText("Drag media to screen rows, not the audio row.").first()
+      page.getByText("Drag media to screen rows, not audio tracks.").first()
     ).toBeVisible()
     await expect(page.getByTestId("cue-test-image.png")).not.toBeVisible()
   })
@@ -119,7 +119,7 @@ describe("Audio cues", () => {
       mimeType: "audio/mpeg",
       buffer: Buffer.from("fake audio content"),
     })
-    await dragPoolItemToGrid(page, "loop-audio.mp3", 1, AUDIO_ROW)
+    await dragPoolItemToGrid(page, "loop-audio.mp3", 1, AUDIO_TRACK_ROW)
     await expect(page.getByTestId("cue-loop-audio.mp3")).toBeVisible()
 
     const cue = page.getByTestId("cue-loop-audio.mp3")

--- a/e2e/gridlayout.spec.js
+++ b/e2e/gridlayout.spec.js
@@ -8,12 +8,7 @@ import {
   dragPoolItemToGrid,
 } from "./helper"
 
-const {
-  test,
-  describe,
-  expect,
-  beforeEach,
-} = require("@playwright/test")
+const { test, describe, expect, beforeEach } = require("@playwright/test")
 
 const testuser = "gridlayoutuser"
 const testPw = "test12345"
@@ -68,7 +63,7 @@ describe("GridLayout", () => {
     await expect(
       page
         .getByText(
-          `Frame ${newIndex} element already exists on screen ${newScreen}. Do you want to replace it?`
+          `Frame ${newIndex} element already exists on screen ${newScreen}, layer 1. Do you want to replace it?`
         )
         .first()
     ).toBeVisible()

--- a/src/client/components/presentation/CuesForm.jsx
+++ b/src/client/components/presentation/CuesForm.jsx
@@ -101,6 +101,7 @@ const CuesForm = ({
   const [screen, setScreen] = useState(isAudioMode ? 0 : position?.screen || 1)
   const [cueId, setCueId] = useState("")
   const [loop, setLoop] = useState(false)
+  const [continuePlayback, setContinuePlayback] = useState(false)
   const [error, setError] = useState(null)
   const [color, setColor] = useState()
   const [selectedColor, setSelectedColor] = useState("#9244ff")
@@ -204,8 +205,11 @@ const CuesForm = ({
       setFile("")
       setActualFile(cueFile)
       setFileName(cueFile?.name || "")
-      setLoop(cueData.loop)
+      setLoop(Boolean(cueData.loop))
+      setContinuePlayback(Boolean(cueData.continuePlayback))
     } else {
+      setLoop(false)
+      setContinuePlayback(false)
       if (isAudioMode) {
         setFile("")
         setCueName("")
@@ -223,6 +227,8 @@ const CuesForm = ({
     setCueId,
     setFile,
     setColor,
+    setLoop,
+    setContinuePlayback,
     isAudioMode,
     position?.screen,
   ])
@@ -269,7 +275,16 @@ const CuesForm = ({
       }
     }
 
-    addCue({ file, index, cueName, screen, fileName, color, loop })
+    addCue({
+      file,
+      index,
+      cueName,
+      screen,
+      fileName,
+      color,
+      loop,
+      continuePlayback,
+    })
 
     setError(null)
     setFile("")
@@ -293,6 +308,8 @@ const CuesForm = ({
       color,
       file: fileToUse,
       fileName,
+      loop,
+      continuePlayback,
     }
 
     if (!actualFile && file !== "") {
@@ -513,6 +530,7 @@ const CuesForm = ({
                         type: "newCueFromForm",
                         cueName: normalizedCueName,
                         color: selectedColor || "#e014ee",
+                        opacity: 1,
                         elementType: "color",
                       }
 

--- a/src/client/components/presentation/EditMode.jsx
+++ b/src/client/components/presentation/EditMode.jsx
@@ -11,7 +11,7 @@
 - toggleAudioMute: function to toggle audio mute in show mode
 - indexCount: number of indexes (frames) in the presentation
  */
-import React, { useState, useRef, useEffect, useMemo } from "react"
+import React, { useState, useRef, useEffect, useMemo, useCallback } from "react"
 import { Box, Text, useOutsideClick, useColorModeValue } from "@chakra-ui/react"
 import "react-grid-layout/css/styles.css"
 import { useDispatch, useSelector } from "react-redux"
@@ -49,11 +49,18 @@ import { useCustomToast } from "../utils/toastUtils"
 import screenIcon from "../../public/icons/screen.svg"
 import {
   getAudioRow,
-  isCueTypeCompatibleWithRow,
-  isInsidePresentationGridCell,
   isAudioMimeType,
   isImageOrVideoMimeType,
 } from "../utils/fileTypeUtils"
+import {
+  buildRowModel,
+  DEFAULT_MAX_AUDIO_TRACKS,
+  DEFAULT_MAX_VISUAL_LAYERS,
+  laneAcceptsCueType,
+  laneAt,
+  planVisualLayerRemoval,
+} from "../utils/screenRowModel"
+import { normalizeCueOpacity } from "../utils/cueOpacityUtils"
 import mediaStore from "./mediaFileStore"
 
 /**
@@ -109,6 +116,12 @@ const EditMode = ({
   const [confirmAction, setConfirmAction] = useState(() => () => {})
   const [showAlert, setShowAlert] = useState(false)
   const [alertData, setAlertData] = useState({})
+  const [collapsedGroups, setCollapsedGroups] = useState({})
+  const [minimumGroupLanes, setMinimumGroupLanes] = useState({})
+  const toggleGroupCollapsed = (group) =>
+    setCollapsedGroups((prev) => ({ ...prev, [group]: !prev[group] }))
+  const ensureGroupExpanded = (group) =>
+    setCollapsedGroups((prev) => ({ ...prev, [group]: false }))
 
   // Generate frame labels for grid columns (Frame 0, Frame 1, etc.)
   const xLabels = useMemo(
@@ -124,18 +137,6 @@ const EditMode = ({
     () => cues.filter((cue) => cue.cueType === "visual"),
     [cues]
   )
-
-  // Generate screen labels for grid rows (Screen 1, Screen 2, ... Audio files)
-  const yLabels = useMemo(() => {
-    const labels = Array.from(
-      { length: presentation.screenCount },
-      (_, index) => `Screen ${index + 1}`
-    )
-
-    // Add audio row separately (always at the end)
-    labels.push("Audio files")
-    return labels
-  }, [presentation.screenCount])
 
   const [isDragging, setIsDragging] = useState(false)
   const [dragCursorMode, setDragCursorMode] = useState("default")
@@ -171,6 +172,8 @@ const EditMode = ({
   const wasCopiedRef = useRef(false)
   const dragStartPointerRef = useRef(null)
   const dragHasMovedRef = useRef(false)
+  const latestGridDragDataRef = useRef(null)
+  const latestGridDragCellRef = useRef(null)
   const headerActionsRef = useRef({
     addIndex: () => {},
     removeIndex: () => {},
@@ -183,7 +186,6 @@ const EditMode = ({
   const rowHeight = 100
   const gap = 10
   const frameHeaderHeight = Math.max(rowHeight - 45, 0)
-  const dragPreviewYOffset = Math.max(rowHeight - frameHeaderHeight, 0)
   const dragCommitDistancePx = 4
 
   const cueVisualSpanMap = useMemo(
@@ -191,24 +193,198 @@ const EditMode = ({
     [cues, indexCount]
   )
 
+  const rowModel = useMemo(
+    () =>
+      buildRowModel(
+        presentation.screenCount,
+        cues,
+        collapsedGroups,
+        minimumGroupLanes
+      ),
+    [presentation.screenCount, cues, collapsedGroups, minimumGroupLanes]
+  )
+
+  const gridCues = useMemo(
+    () =>
+      cues.filter((cue) => {
+        const row = rowModel.rows[rowModel.cueY[cue._id]]
+        return row && !row.collapsed
+      }),
+    [cues, rowModel]
+  )
+
+  const getActiveVisualCueStack = useCallback(
+    (screen, frameIndex) =>
+      cues
+        .filter(
+          (cue) =>
+            cue.cueType === "visual" && Number(cue.screen) === Number(screen)
+        )
+        .filter((cue) => {
+          const cueStartIndex = Number(cue.index)
+          const cueSpan = getCueVisualSpanFromMap(cue, cueVisualSpanMap)
+          const cueEndIndex = cueStartIndex + cueSpan - 1
+          return frameIndex >= cueStartIndex && frameIndex <= cueEndIndex
+        })
+        .sort(
+          (firstCue, secondCue) =>
+            Number(secondCue.layer ?? 0) - Number(firstCue.layer ?? 0)
+        ),
+    [cues, cueVisualSpanMap]
+  )
+
+  const collapsedVisualRowPreviews = useMemo(
+    () =>
+      rowModel.rows
+        .filter((row) => row.collapsed && row.kind === "screen")
+        .map((row) => ({
+          row,
+          frames: Array.from({ length: indexCount }, (_, frameIndex) => ({
+            frameIndex,
+            cues: getActiveVisualCueStack(row.screen, frameIndex),
+          })),
+        })),
+    [rowModel.rows, getActiveVisualCueStack, indexCount]
+  )
+
+  const getVisibleLaneCount = (group) =>
+    rowModel.rows.filter((row) => row.group === group).length
+
+  const addVisualLayer = (screen) => {
+    const group = `screen-${screen}`
+    const nextCount = Math.min(
+      DEFAULT_MAX_VISUAL_LAYERS,
+      getVisibleLaneCount(group) + 1
+    )
+    ensureGroupExpanded(group)
+    setMinimumGroupLanes((prev) => ({ ...prev, [group]: nextCount }))
+  }
+
+  const removeVisualLayer = async (screen, layer) => {
+    const group = `screen-${screen}`
+    const visibleCount = getVisibleLaneCount(group)
+    const layerToRemove = Number(layer)
+
+    if (!Number.isInteger(layerToRemove) || layerToRemove <= 0) return
+
+    const { removedCueIds, shiftedCues } = planVisualLayerRemoval(
+      cues,
+      screen,
+      layerToRemove
+    )
+    const nextCount = Math.max(1, visibleCount - 1)
+
+    try {
+      for (const cueId of removedCueIds) {
+        await dispatch(removeCue(id, cueId))
+      }
+
+      const cuesToShift = [...shiftedCues].sort(
+        (firstCue, secondCue) =>
+          Number(firstCue.layer ?? 0) - Number(secondCue.layer ?? 0)
+      )
+
+      for (const cue of cuesToShift) {
+        await dispatch(
+          updatePresentation(
+            id,
+            {
+              ...cue,
+              cueName: cue.name,
+              layer: cue.layer ?? 0,
+            },
+            cue._id
+          )
+        )
+      }
+
+      ensureGroupExpanded(group)
+      setMinimumGroupLanes((prev) => ({ ...prev, [group]: nextCount }))
+      showToast({
+        title: "Layer removed",
+        description: `Layer ${layerToRemove + 1} removed from screen ${screen}`,
+        status: "success",
+      })
+    } catch (error) {
+      console.error(error)
+      await dispatch(fetchPresentationInfo(id))
+      showToast({
+        title: "Error",
+        description: error.message || "Failed to remove layer",
+        status: "error",
+      })
+    }
+  }
+
+  const addAudioTrack = () => {
+    const nextCount = Math.min(
+      DEFAULT_MAX_AUDIO_TRACKS,
+      getVisibleLaneCount("audio") + 1
+    )
+    ensureGroupExpanded("audio")
+    setMinimumGroupLanes((prev) => ({ ...prev, audio: nextCount }))
+  }
+
+  const cueRowOf = (cue) => rowModel.cueY[cue._id] ?? 0
+
+  const laneScreenLayer = (yIndex) => {
+    const lane = laneAt(rowModel.rows, yIndex)
+    if (!lane) return { screen: 1, layer: 0 }
+    const isAudio = lane.kind === "audio-track" || lane.kind === "audio"
+    return {
+      screen: isAudio ? getAudioRow(presentation.screenCount) : lane.screen,
+      layer: lane.layer ?? 0,
+    }
+  }
+
+  const rowLabelForCue = (cue) =>
+    cue.cueType === "audio"
+      ? `audio track ${Number(cue.layer ?? 0) + 1}`
+      : `screen ${cue.screen}, layer ${Number(cue.layer ?? 0) + 1}`
+
+  const cueTypeForTarget = (screen, cueType) =>
+    cueType ||
+    (Number(screen) === getAudioRow(presentation.screenCount)
+      ? "audio"
+      : "visual")
+
+  const getRowCueConflict = (index, screen, layer, excludedCueId = null) =>
+    cues.find((cue) => {
+      const samePosition =
+        Number(cue.index) === Number(index) &&
+        Number(cue.screen) === Number(screen) &&
+        Number(cue.layer ?? 0) === Number(layer ?? 0)
+
+      if (!samePosition) {
+        return false
+      }
+
+      return !excludedCueId || cue._id !== excludedCueId
+    })
+
+  const isRowInsideGrid = (xIndex, yIndex) =>
+    Number(xIndex) >= 0 &&
+    Number(xIndex) < Number(indexCount) &&
+    Number(yIndex) >= 0 &&
+    Number(yIndex) < Number(rowModel.rowCount)
+
   const getCueEndIndex = (cue) =>
     Number(cue.index) + getCueVisualSpanFromMap(cue, cueVisualSpanMap) - 1
 
   const cueOccupiesSlot = (cue, xIndex, yIndex) =>
-    Number(cue.screen) === Number(yIndex) &&
+    cueRowOf(cue) === Number(yIndex) &&
     Number(xIndex) >= Number(cue.index) &&
     Number(xIndex) <= getCueEndIndex(cue)
 
   // Get cue at grid position (including ones spanning multiple cells)
   const getCueAtPosition = (xIndex, yIndex) =>
-    cues.find((cue) => cueOccupiesSlot(cue, xIndex, yIndex))
+    gridCues.find((cue) => cueOccupiesSlot(cue, xIndex, yIndex))
 
   // Get cue at grid position (only anchor cell - first cell of the cue)
   const getAnchorCueAtPosition = (xIndex, yIndex) =>
-    cues.find(
+    gridCues.find(
       (cue) =>
-        Number(cue.index) === Number(xIndex) &&
-        Number(cue.screen) === Number(yIndex)
+        Number(cue.index) === Number(xIndex) && cueRowOf(cue) === Number(yIndex)
     )
 
   const getContinuationPreviewSpanOverrides = (
@@ -222,7 +398,10 @@ const EditMode = ({
       yIndex,
       cueType,
       draggedCueId,
-      screenCount: presentation.screenCount,
+      isValidDropCell: laneAcceptsCueType(
+        laneAt(rowModel.rows, yIndex),
+        cueType
+      ),
       getCueAtPosition,
     })
   }
@@ -254,7 +433,9 @@ const EditMode = ({
     headerRowHeight: frameHeaderHeight,
     gap,
     indexCount,
-    screenCount: presentation.screenCount,
+    rows: rowModel.rows,
+    rowCount: rowModel.rowCount,
+    cueRowIndex: rowModel.cueY,
     selectedCue,
     setDragCursorMode,
     clearExternalDragPreview,
@@ -295,7 +476,7 @@ const EditMode = ({
 
   useEffect(() => {
     hideHoverPreview()
-  }, [cues, indexCount, presentation.screenCount, hideHoverPreview])
+  }, [cues, indexCount, rowModel.rowCount, hideHoverPreview])
 
   useEffect(() => {
     const clearTransientPreviews = () => {
@@ -496,15 +677,18 @@ const EditMode = ({
       dispatch(incrementScreenCount())
       await dispatch(saveScreenCount({ id, screenCount: newScreenNumber }))
 
-      // The server repositions the audio row's stored screen in the same
-      // request; refetch so local cues (including that row) match it.
       await dispatch(fetchPresentationInfo(id))
 
       const formData = createFormData(
         0,
         `initial element for screen ${newScreenNumber}`,
         newScreenNumber,
-        null
+        null,
+        undefined,
+        undefined,
+        false,
+        0,
+        1
       )
 
       await dispatch(createCue(id, formData))
@@ -564,8 +748,6 @@ const EditMode = ({
         saveScreenCount({ id, screenCount: currentScreenCount - 1 })
       )
 
-      // The server repositions the audio row's stored screen in the same
-      // request; refetch so local cues (including that row) match it.
       await dispatch(fetchPresentationInfo(id))
 
       // Show appropriate message based on whether cues were removed
@@ -618,13 +800,12 @@ const EditMode = ({
       rowHeight,
       gap
     )
-
     if (cueExists(xIndex, yIndex)) {
       const movingCue = getCueAtPosition(xIndex, yIndex)
       setSelectedCue(movingCue)
       updateDragPreviewCell({
         xIndex: Number(movingCue.index),
-        yIndex: Number(movingCue.screen),
+        yIndex: cueRowOf(movingCue),
       })
 
       if (event.target.closest(".react-grid-item")) {
@@ -691,18 +872,10 @@ const EditMode = ({
     const isBlockedCell = Boolean(
       hoveredCue && hoveredCue._id === copiedCue._id
     )
-    const isInsideGrid = isInsidePresentationGridCell({
-      xIndex,
-      yIndex,
-      indexCount,
-      screenCount: presentation.screenCount,
-    })
+    const isInsideGrid = isRowInsideGrid(xIndex, yIndex)
     const isValidDropCell =
-      isCueTypeCompatibleWithRow(
-        copiedCue.cueType,
-        yIndex,
-        presentation.screenCount
-      ) && !isBlockedCell
+      laneAcceptsCueType(laneAt(rowModel.rows, yIndex), copiedCue.cueType) &&
+      !isBlockedCell
 
     if (!isInsideGrid) {
       clearExternalPlacementPreview()
@@ -762,11 +935,13 @@ const EditMode = ({
     return {
       index: xIndex,
       cueName: `${copiedCue.name} copy`,
-      screen: yIndex,
+      ...laneScreenLayer(yIndex),
       file: fileObj,
       fileName: copiedCue.file?.name || null,
       color: copiedCue.color,
       loop: copiedCue.loop,
+      continuePlayback: Boolean(copiedCue.continuePlayback),
+      opacity: normalizeCueOpacity(copiedCue.opacity),
     }
   }
   // Fetch file object from URL - used for copying cues with files
@@ -783,6 +958,41 @@ const EditMode = ({
     hideDragPlacementPreview()
     cancelDragPreviewFrame()
     resetDragPointerTracking()
+  }
+
+  const renderCollapsedPreviewMedia = (cue) => {
+    const mediaUrl =
+      cue.file?.url || (cue.file?.name ? `/${cue.file.name}` : "")
+    const mediaType = cue.file?.type || cue.file?.mimeType || ""
+
+    if (mediaUrl && mediaType.startsWith("video/")) {
+      return (
+        <Box
+          as="video"
+          src={mediaUrl}
+          width="100%"
+          height="100%"
+          objectFit="cover"
+          muted
+          playsInline
+        />
+      )
+    }
+
+    if (mediaUrl && mediaType.startsWith("image/")) {
+      return (
+        <Box
+          as="img"
+          src={mediaUrl}
+          alt={cue.name || ""}
+          width="100%"
+          height="100%"
+          objectFit="cover"
+        />
+      )
+    }
+
+    return <Box width="100%" height="100%" bg={cue.color || "#111111"} />
   }
 
   // Handle mouse move - show hover previews and update drag preview position
@@ -827,8 +1037,8 @@ const EditMode = ({
       !cueExists &&
       xIndex >= 0 &&
       xIndex < indexCount &&
-      yIndex <= getAudioRow(presentation.screenCount) &&
-      yIndex >= 1
+      yIndex >= 0 &&
+      yIndex < rowModel.rowCount
     ) {
       showHoverPreview(xIndex, yIndex)
     } else {
@@ -880,23 +1090,17 @@ const EditMode = ({
 
       const moveToSamePosition =
         Number(selectedCue.index) === Number(xIndex) &&
-        Number(selectedCue.screen) === Number(yIndex)
+        cueRowOf(selectedCue) === Number(yIndex)
 
       if (moveToSamePosition) {
         clearInternalDragSpanPreview()
         return
       }
 
-      const isInsideGrid = isInsidePresentationGridCell({
-        xIndex,
-        yIndex,
-        indexCount,
-        screenCount: presentation.screenCount,
-      })
-      const isValidDropCell = isCueTypeCompatibleWithRow(
-        selectedCue.cueType,
-        yIndex,
-        presentation.screenCount
+      const isInsideGrid = isRowInsideGrid(xIndex, yIndex)
+      const isValidDropCell = laneAcceptsCueType(
+        laneAt(rowModel.rows, yIndex),
+        selectedCue.cueType
       )
 
       if (!isInsideGrid) {
@@ -915,11 +1119,13 @@ const EditMode = ({
         return
       }
 
+      const target = laneScreenLayer(yIndex)
       const movedCue = {
         ...selectedCue,
         index: xIndex,
         cueName: selectedCue.name,
-        screen: yIndex,
+        screen: target.screen,
+        layer: target.layer,
       }
 
       setSelectedCue(null)
@@ -965,6 +1171,14 @@ const EditMode = ({
     }
 
     const dragData = getDragDataFromDataTransfer(event.dataTransfer)
+    latestGridDragDataRef.current = dragData
+    latestGridDragCellRef.current = getPosition(
+      event,
+      containerRef,
+      columnWidth,
+      rowHeight,
+      gap
+    )
     const dragCueType = getCueTypeFromDragData(dragData)
     if (!dragCueType) {
       clearExternalPlacementPreview()
@@ -990,15 +1204,17 @@ const EditMode = ({
       event.clientY <= gridRect.bottom
 
     if (!pointerInsideGrid) {
+      latestGridDragDataRef.current = null
+      latestGridDragCellRef.current = null
       clearExternalPlacementPreview()
     }
   }
 
   // Compute grid layout from cues - determines cue position and size on grid
-  const layout = cues.map((cue) => ({
+  const layout = gridCues.map((cue) => ({
     i: cue._id.toString(),
     x: cue.index,
-    y: cue.screen,
+    y: cueRowOf(cue),
     w: getCueVisualSpanFromMap(cue, cueVisualSpanMap),
     h: 1,
     static: false,
@@ -1006,12 +1222,20 @@ const EditMode = ({
 
   // Add a new cue - checks for conflicts and saves to backend
   const addCue = async (cueData) => {
-    const { index, cueName, screen, file, loop, color } = cueData
+    const {
+      index,
+      cueName,
+      screen,
+      layer = 0,
+      file,
+      loop,
+      continuePlayback = false,
+      color,
+      opacity = 1,
+    } = cueData
 
     //Check if cue with same index and screen already exists
-    const existingCue = cues.find(
-      (cue) => cue.index === Number(index) && cue.screen === Number(screen)
-    )
+    const existingCue = getRowCueConflict(index, screen, layer)
 
     if (existingCue) {
       await handleCueExists(existingCue, cueData)
@@ -1025,7 +1249,10 @@ const EditMode = ({
       file || "",
       undefined,
       color,
-      loop || false
+      loop || false,
+      layer,
+      normalizeCueOpacity(opacity),
+      continuePlayback
     )
 
     try {
@@ -1034,7 +1261,11 @@ const EditMode = ({
       setTimeout(() => {
         showToast({
           title: "Element added",
-          description: `Element ${cueName} added to screen ${screen}`,
+          description: `Element ${cueName} added to ${rowLabelForCue({
+            cueType: cueTypeForTarget(screen, cueData.cueType),
+            screen,
+            layer,
+          })}`,
           status: "success",
         })
       }, 300)
@@ -1046,7 +1277,7 @@ const EditMode = ({
 
   const handleCueExists = async (existingCue, newCueData) => {
     setConfirmMessage(
-      `Frame ${newCueData.index} element already exists on screen ${newCueData.screen}. Do you want to replace it?`
+      `Frame ${newCueData.index} element already exists on ${rowLabelForCue(newCueData)}. Do you want to replace it?`
     )
     setConfirmAction(() => async () => {
       const updatedCueData = {
@@ -1075,10 +1306,11 @@ const EditMode = ({
       return
     }
 
-    const existingCue = cues.find(
-      (cue) =>
-        cue.index === Number(updatedCue.index) &&
-        cue.screen === Number(updatedCue.screen)
+    const existingCue = getRowCueConflict(
+      updatedCue.index,
+      updatedCue.screen,
+      updatedCue.layer ?? 0,
+      previousCueId
     )
 
     if (existingCue && existingCue._id !== previousCueId) {
@@ -1094,7 +1326,7 @@ const EditMode = ({
     previousCueId
   ) => {
     setConfirmMessage(
-      `${updatedCue.index} element already exists on screen ${updatedCue.screen}. Do you want to replace it?`
+      `${updatedCue.index} element already exists on ${rowLabelForCue(updatedCue)}. Do you want to replace it?`
     )
 
     setConfirmAction(() => async () => {
@@ -1136,6 +1368,8 @@ const EditMode = ({
       index: updatedCue.index,
       cueName: updatedCue.cueName,
       screen: updatedCue.screen,
+      layer: updatedCue.layer ?? existingCue.layer ?? 0,
+      opacity: normalizeCueOpacity(updatedCue.opacity ?? existingCue.opacity),
       file: fileObj,
       fileName: updatedCue.fileName,
     }
@@ -1164,11 +1398,7 @@ const EditMode = ({
       gap
     )
 
-    if (yIndex < 1 || yIndex > getAudioRow(presentation.screenCount)) {
-      return
-    }
-
-    if (xIndex < 0 || xIndex >= indexCount) {
+    if (!isRowInsideGrid(xIndex, yIndex)) {
       return
     }
 
@@ -1233,12 +1463,14 @@ const EditMode = ({
     const relativeDropX = dropX - containerRect.left
     const absoluteDropX = relativeDropX + containerScrollLeft
     const dropY = event.clientY - containerRect.top
-    const yAdjustedForHeader = dropY + dragPreviewYOffset
+    const timelineRowsTopOffset = frameHeaderHeight + gap
 
     const cellWidthWithGap = columnWidth + gap
     const cellHeightWithGap = rowHeight + gap
 
-    const yIndex = Math.floor(yAdjustedForHeader / cellHeightWithGap)
+    const yIndex = Math.floor(
+      (dropY - timelineRowsTopOffset) / cellHeightWithGap
+    )
     const xIndex = Math.floor(absoluteDropX / cellWidthWithGap)
 
     return { xIndex, yIndex }
@@ -1250,12 +1482,14 @@ const EditMode = ({
       ...targetCue,
       index: selectedCue.index,
       screen: selectedCue.screen,
+      layer: selectedCue.layer ?? 0,
     }
     // We need to create new objects to avoid mutating state directly when swapping
     const newSelectedCue = {
       ...selectedCue,
       index: targetCue.index,
       screen: targetCue.screen,
+      layer: targetCue.layer ?? 0,
     }
     // If either cue is audio, both must be audio - prevent swapping audio with visual elements
     const hasAudioCue =
@@ -1287,13 +1521,16 @@ const EditMode = ({
   const handleCueReplace = async (xIndex, yIndex, file) => {
     const existingCue = getCueAtPosition(xIndex, yIndex)
     if (!existingCue) return
+    const target = laneScreenLayer(yIndex)
 
     const updatedCue = {
       ...existingCue,
       index: xIndex,
       cueName: file.name,
-      screen: yIndex,
+      screen: target.screen,
+      layer: target.layer,
       file: file,
+      opacity: normalizeCueOpacity(existingCue.opacity),
     }
 
     await dispatchUpdateCue(existingCue._id, updatedCue)
@@ -1312,6 +1549,8 @@ const EditMode = ({
     } catch (e) {
       // ignore parsing error
     }
+    dragData = dragData || latestGridDragDataRef.current
+    latestGridDragDataRef.current = null
 
     const files = Array.from(event.dataTransfer.files)
     const mediaFiles = files.filter(
@@ -1323,27 +1562,50 @@ const EditMode = ({
       return
     }
 
-    const { xIndex, yIndex } = getPosition(
+    const dropCell = getPosition(
       event,
       containerRef,
       columnWidth,
       rowHeight,
       gap
     )
+    const fallbackDropCell = latestGridDragCellRef.current
+    const xIndex = Number.isFinite(dropCell.xIndex)
+      ? dropCell.xIndex
+      : fallbackDropCell?.xIndex
+    const yIndex = Number.isFinite(dropCell.yIndex)
+      ? dropCell.yIndex
+      : fallbackDropCell?.yIndex
+    latestGridDragCellRef.current = null
 
     if (dragData && dragData.type === "newCueFromForm") {
-      const audioRowIndex = getAudioRow(presentation.screenCount)
       const colorCueName = (dragData.cueName || "").trim()
+      const targetLane = laneAt(rowModel.rows, yIndex)
+      const target = laneScreenLayer(yIndex)
 
       // Handle different element types from the three boxes
       if (dragData.elementType === "color") {
+        if (
+          !isRowInsideGrid(xIndex, yIndex) ||
+          !laneAcceptsCueType(targetLane, "visual")
+        ) {
+          showToast({
+            title: "Only images/videos on screen rows",
+            description: "Drag visual elements to screen rows.",
+            status: "error",
+          })
+          return
+        }
+
         // Color element - no file
         const dataToSave = {
           index: xIndex,
           cueName: colorCueName,
-          screen: yIndex,
+          screen: target.screen,
+          layer: target.layer,
           file: null,
           color: dragData.color,
+          opacity: normalizeCueOpacity(dragData.opacity),
         }
 
         await addCue(dataToSave)
@@ -1355,6 +1617,7 @@ const EditMode = ({
         // Media or sound element - has a file
         const isSound = dragData.elementType === "sound"
         const fileId = isSound ? dragData.soundId : dragData.mediaId
+        const cueType = isSound ? "audio" : "visual"
 
         // Retrieve the file from mediaStore
         const file = mediaStore.getFile(fileId)
@@ -1370,18 +1633,17 @@ const EditMode = ({
         }
 
         // Validate screen placement
-        if (isSound && yIndex !== audioRowIndex && xIndex < indexCount) {
+        if (
+          !isRowInsideGrid(xIndex, yIndex) ||
+          !laneAcceptsCueType(targetLane, cueType)
+        ) {
           showToast({
-            title: "Only audio on audio row",
-            description: "Drag audio files to the audio row.",
-            status: "error",
-          })
-          return
-        }
-        if (!isSound && yIndex === audioRowIndex && xIndex < indexCount) {
-          showToast({
-            title: "Only images/videos on screen rows",
-            description: "Drag media to screen rows, not the audio row.",
+            title: isSound
+              ? "Only audio on audio rows"
+              : "Only images/videos on screen rows",
+            description: isSound
+              ? "Drag audio files to an audio track."
+              : "Drag media to screen rows, not audio tracks.",
             status: "error",
           })
           return
@@ -1391,8 +1653,10 @@ const EditMode = ({
         const dataToSave = {
           index: xIndex,
           cueName: dragData.cueName,
-          screen: yIndex,
+          screen: target.screen,
+          layer: target.layer,
           file: file,
+          opacity: 1,
         }
 
         await addCue(dataToSave)
@@ -1406,9 +1670,11 @@ const EditMode = ({
       const dataToSave = {
         index: xIndex,
         cueName: colorCueName,
-        screen: yIndex,
+        screen: target.screen,
+        layer: target.layer,
         file: null,
         color: dragData.color,
+        opacity: normalizeCueOpacity(dragData.opacity),
       }
 
       await addCue(dataToSave)
@@ -1416,24 +1682,15 @@ const EditMode = ({
     }
 
     const file = mediaFiles[0]
-    const audioRowIndex = getAudioRow(presentation.screenCount)
+    const fileCueType = isAudioMimeType(file?.type) ? "audio" : "visual"
+    const targetLane = laneAt(rowModel.rows, yIndex)
+    const target = laneScreenLayer(yIndex)
 
     if (
       isImageOrVideoMimeType(file?.type) &&
       xIndex < indexCount &&
-      yIndex === audioRowIndex
-    ) {
-      showToast({
-        title: "Only audio files on the audio row.",
-        description: "Click on an appropriate row to paste the element.",
-        status: "error",
-      })
-      return
-    }
-    if (
-      isAudioMimeType(file?.type) &&
-      yIndex !== audioRowIndex &&
-      xIndex < indexCount
+      (!isRowInsideGrid(xIndex, yIndex) ||
+        !laneAcceptsCueType(targetLane, "visual"))
     ) {
       showToast({
         title: "Only images/videos on screen rows.",
@@ -1442,10 +1699,23 @@ const EditMode = ({
       })
       return
     }
+    if (
+      isAudioMimeType(file?.type) &&
+      xIndex < indexCount &&
+      (!isRowInsideGrid(xIndex, yIndex) ||
+        !laneAcceptsCueType(targetLane, "audio"))
+    ) {
+      showToast({
+        title: "Only audio files on audio tracks.",
+        description: "Click on an appropriate row to paste the element.",
+        status: "error",
+      })
+      return
+    }
 
     if (anchorCueExists(xIndex, yIndex)) {
       setConfirmMessage(
-        `Index ${xIndex} element already exists on screen ${yIndex}. Do you want to replace it?`
+        `Index ${xIndex} element already exists on ${rowLabelForCue({ cueType: fileCueType, ...target })}. Do you want to replace it?`
       )
       setConfirmAction(() => async () => {
         handleCueReplace(xIndex, yIndex, file)
@@ -1453,13 +1723,23 @@ const EditMode = ({
       setIsConfirmOpen(true)
       return
     }
-    const formData = createFormData(xIndex, file.name, yIndex, file)
+    const formData = createFormData(
+      xIndex,
+      file.name,
+      target.screen,
+      file,
+      undefined,
+      undefined,
+      false,
+      target.layer,
+      1
+    )
 
     try {
       await dispatch(createCue(id, formData))
       showToast({
         title: "Element added",
-        description: `Element ${file.name} added to screen ${yIndex}`,
+        description: `Element ${file.name} added to ${rowLabelForCue({ cueType: fileCueType, ...target })}`,
         status: "success",
       })
     } catch (error) {
@@ -1505,7 +1785,7 @@ const EditMode = ({
           <Box
             className="screen-boxes"
             display="grid"
-            gridTemplateRows={`${frameHeaderHeight}px repeat(${yLabels.length}, ${rowHeight}px)`}
+            gridTemplateRows={`${frameHeaderHeight}px repeat(${rowModel.rowCount}, ${rowHeight}px)`}
             gap={`${gap}px`}
             left={0}
             zIndex={2}
@@ -1515,10 +1795,16 @@ const EditMode = ({
             <Box h={`${frameHeaderHeight}px`} bg="transparent" />
 
             <RowHeaders
-              yLabels={yLabels}
+              rows={rowModel.rows}
+              collapsedGroups={collapsedGroups}
+              onToggleGroupCollapsed={toggleGroupCollapsed}
+              onAddVisualLayer={addVisualLayer}
+              onRemoveVisualLayer={removeVisualLayer}
+              onAddAudioTrack={addAudioTrack}
+              maxVisualLayers={DEFAULT_MAX_VISUAL_LAYERS}
+              maxAudioTracks={DEFAULT_MAX_AUDIO_TRACKS}
               gap={gap}
               rowHeight={rowHeight}
-              columnWidth={columnWidth}
               screenCount={presentation.screenCount}
               isAudioMuted={isAudioMuted}
               screenIcon={screenIcon}
@@ -1546,7 +1832,7 @@ const EditMode = ({
             }}
           >
             <Box
-              height={`${(yLabels.length + 1) * (rowHeight + gap)}px`}
+              height={`${frameHeaderHeight + gap + rowModel.rowCount * rowHeight + Math.max(rowModel.rowCount - 1, 0) * gap}px`}
               minHeight="100%"
               width="100%"
               position="relative"
@@ -1617,7 +1903,9 @@ const EditMode = ({
               >
                 <GridLayoutComponent
                   layout={layout}
-                  cues={cues}
+                  cues={gridCues}
+                  cueRowIndex={rowModel.cueY}
+                  rowCount={rowModel.rowCount}
                   containerRef={containerRef}
                   columnWidth={columnWidth}
                   rowHeight={rowHeight}
@@ -1644,6 +1932,57 @@ const EditMode = ({
                   }
                 />
               </Box>
+
+              {collapsedVisualRowPreviews.map(({ row, frames }) =>
+                frames.map(({ frameIndex, cues: frameCues }) => (
+                  <Box
+                    key={`${row.group}-collapsed-preview-${frameIndex}`}
+                    data-testid={`collapsed-preview-${row.group}-${frameIndex}`}
+                    position="absolute"
+                    left={`${frameIndex * (columnWidth + gap)}px`}
+                    top={`${frameHeaderHeight + gap + row.y * (rowHeight + gap)}px`}
+                    width={`${columnWidth}px`}
+                    height={`${rowHeight}px`}
+                    borderRadius="10px"
+                    overflow="hidden"
+                    bg="rgba(255, 255, 255, 0.06)"
+                    border="1px solid rgba(255, 255, 255, 0.1)"
+                    pointerEvents="none"
+                    zIndex={0}
+                  >
+                    {frameCues.map((cue, stackIndex) => (
+                      <Box
+                        key={`${cue._id}-${stackIndex}`}
+                        position="absolute"
+                        inset="0"
+                        opacity={normalizeCueOpacity(cue.opacity)}
+                        zIndex={100 - Number(cue.layer ?? 0)}
+                      >
+                        {renderCollapsedPreviewMedia(cue)}
+                      </Box>
+                    ))}
+                    {frameCues.length > 0 && (
+                      <Text
+                        position="absolute"
+                        left="8px"
+                        bottom="6px"
+                        maxWidth={`${Math.max(columnWidth - 16, 40)}px`}
+                        color="white"
+                        fontSize="12px"
+                        fontWeight="700"
+                        lineHeight="1.1"
+                        whiteSpace="nowrap"
+                        overflow="hidden"
+                        textOverflow="ellipsis"
+                        textShadow="1px 1px 3px rgba(0,0,0,0.85)"
+                        zIndex={130}
+                      >
+                        {frameCues[frameCues.length - 1].name}
+                      </Text>
+                    )}
+                  </Box>
+                ))
+              )}
 
               {!isDragging && (
                 // Show placement preview for copied cue when not dragging - follows cursor and shows where the cue would be placed if clicked

--- a/src/client/components/presentation/EditModeContainer.jsx
+++ b/src/client/components/presentation/EditModeContainer.jsx
@@ -29,6 +29,10 @@ import { getAudioRow, isType, isAudioRow } from "../utils/fileTypeUtils"
 import KeyboardHandler from "../utils/keyboardHandler"
 import makeResizable from "../utils/ResizeElement"
 import { ScreensDisplay } from "./ScreensDisplay"
+import {
+  buildCueVisualSpanMap,
+  getCueVisualSpanFromMap,
+} from "../utils/cueVisualSpanUtils"
 
 // Base component for different subcomponents of the editor
 function EditorLayout(props) {
@@ -59,6 +63,8 @@ function EditorLayout(props) {
     isAutoplaying = false,
     audioSourceURL = "",
     audioLoop = false,
+    audioTracks = [],
+    allowContinuousAudio = false,
     toggleAutoplayInterval = () => {},
     onOpenTutorial = () => {},
     editModeBackground,
@@ -202,6 +208,8 @@ function EditorLayout(props) {
           toggleAutoplayInterval={toggleAutoplayInterval}
           audioSourceURL={audioSourceURL}
           audioLoop={audioLoop}
+          audioTracks={audioTracks}
+          allowContinuousAudio={allowContinuousAudio}
         />
         <Box mr={4}>
           <StatusTooltip />
@@ -310,22 +318,17 @@ const EditModeContainer = ({
   const [screens, setScreens] = useState({})
   const [mirroring, setMirroring] = useState({})
   const [isAutoplaying, setIsAutoplaying] = useState(false)
+  const [autoplayEnded, setAutoplayEnded] = useState(false)
   const [autoplayInterval, setAutoplayInterval] = useState(5)
   const [isTutorialOpen, setIsTutorialOpen] = useState(false)
   const autoplayTimerRef = useRef(null)
   const audioPreloadedUrlsRef = useRef(new Set())
   const cueIndexRef = useRef(cueIndex)
 
-  // organize cues by screen number and index for quick lookup
-  const cuesByScreen = useMemo(() => {
-    return (cues || []).reduce((acc, cue) => {
-      if (!acc[cue.screen]) {
-        acc[cue.screen] = {}
-      }
-      acc[cue.screen][cue.index] = cue
-      return acc
-    }, {})
-  }, [cues])
+  const cueVisualSpanMap = useMemo(
+    () => buildCueVisualSpanMap(cues, indexCount),
+    [cues, indexCount]
+  )
 
   // Initialize screen visibility state based on cues and screen count
   // - creates a visibility object with keys for each screen number and
@@ -374,29 +377,48 @@ const EditModeContainer = ({
     })
   }
 
-  const getLastValidCue = (screenNumber, index) => {
-    let currentIndex = index
+  const getActiveCuesForScreen = (screenNumber, index) => {
+    const currentIndex = Number(index)
 
-    while (currentIndex >= 0) {
-      if (cuesByScreen[screenNumber]?.[currentIndex]) {
-        return cuesByScreen[screenNumber][currentIndex]
-      }
-      currentIndex -= 1
-    }
-
-    return {}
+    return (cues || [])
+      .filter((cue) => Number(cue.screen) === Number(screenNumber))
+      .filter((cue) => {
+        const cueStartIndex = Number(cue.index)
+        const cueSpan = getCueVisualSpanFromMap(cue, cueVisualSpanMap)
+        const cueEndIndex = cueStartIndex + cueSpan - 1
+        return currentIndex >= cueStartIndex && currentIndex <= cueEndIndex
+      })
+      .sort(
+        (firstCue, secondCue) =>
+          Number(secondCue.layer ?? 0) - Number(firstCue.layer ?? 0)
+      )
   }
 
   const audioRow = getAudioRow(screenCount)
-  const currentAudioCue = getLastValidCue(audioRow, cueIndex)
-  const currentAudioFile = currentAudioCue?.file
-  const currentAudioSrc =
-    currentAudioFile?.url ||
-    (currentAudioFile?.name ? `/${currentAudioFile.name}` : "")
-  const isCurrentCueAudio = Boolean(
-    currentAudioCue && isType.audio(currentAudioFile)
-  )
-  const currentAudioLoop = Boolean(currentAudioCue?.loop)
+  const currentAudioTracks = getActiveCuesForScreen(audioRow, cueIndex)
+    .sort(
+      (firstCue, secondCue) =>
+        Number(firstCue.layer ?? 0) - Number(secondCue.layer ?? 0)
+    )
+    .filter((cue) => isType.audio(cue?.file))
+    .map((cue) => {
+      const file = cue.file
+      const src = file?.url || (file?.name ? `/${file.name}` : "")
+
+      return {
+        id: cue._id || `${cue.screen}-${cue.layer ?? 0}-${cue.index}`,
+        src,
+        loop: Boolean(cue.loop),
+        continuePlayback: Boolean(cue.continuePlayback),
+        layer: Number(cue.layer ?? 0),
+        name: cue.name,
+      }
+    })
+    .filter((track) => track.src)
+  const currentAudioCue = currentAudioTracks[0] || {}
+  const currentAudioSrc = currentAudioCue.src || ""
+  const isCurrentCueAudio = currentAudioTracks.length > 0
+  const currentAudioLoop = Boolean(currentAudioCue.loop)
 
   const handleScreenClose = useCallback((screenNumber) => {
     setScreens((prev) => ({
@@ -410,6 +432,7 @@ const EditModeContainer = ({
   }, [cueIndex])
 
   const toggleAutoplay = () => {
+    setAutoplayEnded(false)
     setIsAutoplaying((prev) => {
       const next = !prev
       if (next && typeof setCueIndex === "function") {
@@ -443,6 +466,7 @@ const EditModeContainer = ({
     autoplayTimerRef.current = setInterval(() => {
       const currentIndex = cueIndexRef.current
       if (currentIndex >= indexCount - 1) {
+        setAutoplayEnded(true)
         setIsAutoplaying(false)
         return
       }
@@ -464,6 +488,7 @@ const EditModeContainer = ({
 
   useEffect(() => {
     if (isAutoplaying && cueIndex >= indexCount - 1) {
+      setAutoplayEnded(true)
       setIsAutoplaying(false)
     }
   }, [cueIndex, indexCount, isAutoplaying])
@@ -549,6 +574,8 @@ const EditModeContainer = ({
         onOpenTutorial={handleOpenTutorial}
         audioSourceURL={currentAudioSrc}
         audioLoop={currentAudioLoop}
+        audioTracks={currentAudioTracks}
+        allowContinuousAudio={autoplayEnded}
         editModeBackground={editModeBackground}
         panelBackground={panelBackground}
         outlineColor={outlineColor}
@@ -564,7 +591,7 @@ const EditModeContainer = ({
       {Object.keys(screens).map((screenNumber) => {
         const mirroredScreen = mirroring[screenNumber]
         const sourceScreen = mirroredScreen ? mirroredScreen : screenNumber
-        const screenData = getLastValidCue(sourceScreen, cueIndex)
+        const screenData = getActiveCuesForScreen(sourceScreen, cueIndex)
 
         return (
           <Screen

--- a/src/client/components/presentation/EditModeHeaders.jsx
+++ b/src/client/components/presentation/EditModeHeaders.jsx
@@ -234,7 +234,7 @@ const RowHeadersBase = ({
                 _active={{ bg: "white" }}
                 boxShadow="0 2px 4px rgba(0,0,0,0.18)"
               >
-                écran
+                Screen
               </Button>
             </Box>
           )}
@@ -279,7 +279,7 @@ const RowHeadersBase = ({
                   _active={{ bg: "white" }}
                   boxShadow="0 2px 4px rgba(0,0,0,0.2)"
                 >
-                  calque
+                  Layer
                 </Button>
               )}
 
@@ -312,7 +312,7 @@ const RowHeadersBase = ({
                   _active={{ bg: "white" }}
                   boxShadow="0 2px 4px rgba(0,0,0,0.18)"
                 >
-                  écran
+                  Screen
                 </Button>
               )}
             </Box>

--- a/src/client/components/presentation/EditModeHeaders.jsx
+++ b/src/client/components/presentation/EditModeHeaders.jsx
@@ -2,18 +2,26 @@
 * components for rendering the row and column headers in the presentation editor, including controls for adding/removing screens and frames, and toggling audio mute.
  */
 import React from "react"
+import { Box, Text, IconButton, Button } from "@chakra-ui/react"
 import {
-  Box,
-  Text,
-  IconButton,
-} from "@chakra-ui/react"
-import { AddIcon, MinusIcon } from "@chakra-ui/icons"
+  AddIcon,
+  MinusIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
+} from "@chakra-ui/icons"
 import { SpeakerIcon, SpeakerMutedIcon } from "../../lib/icons"
 import trashIcon from "../../public/icons/trash.svg"
 
 // Base component for rendering row headers, memoized for performance optimization. Displays screen labels and an audio row with a mute/unmute button, as well as controls for adding/removing screens.
 const RowHeadersBase = ({
-  yLabels,
+  rows,
+  collapsedGroups,
+  onToggleGroupCollapsed,
+  onAddVisualLayer,
+  onRemoveVisualLayer,
+  onAddAudioTrack,
+  maxVisualLayers,
+  maxAudioTracks,
   gap,
   rowHeight,
   screenCount,
@@ -21,93 +29,166 @@ const RowHeadersBase = ({
   screenIcon,
   headerActionsRef,
 }) => {
-  const getScreenNumberFromLabel = (label) => {
-    const match = /^Screen\s+(\d+)$/.exec(label)
-    return match ? match[1] : null
-  }
+  return rows.map((row) => {
+    const isAudio = row.kind === "audio-track" || row.kind === "audio"
+    const groupRows = rows.filter((candidate) => candidate.group === row.group)
+    const lastGroupRow = groupRows[groupRows.length - 1]
+    const isVisualGroupEnd =
+      !isAudio &&
+      (row.kind === "layer" || row.kind === "screen") &&
+      Number(row.y) === Number(lastGroupRow?.y)
+    const isLastScreenStart =
+      row.groupStart && !isAudio && Number(row.screen) === Number(screenCount)
+    const isLastScreenEnd =
+      isVisualGroupEnd && Number(row.screen) === Number(screenCount)
+    const isCollapsed = Boolean(collapsedGroups?.[row.group])
+    const canAddVisualLayer =
+      isVisualGroupEnd &&
+      Number(row.count ?? row.laneTotal ?? 1) < maxVisualLayers
+    const canRemoveVisualLayer =
+      row.kind === "layer" &&
+      !isAudio &&
+      Number(row.layer ?? 0) > 0 &&
+      Boolean(row.canRemoveLayer)
+    const canAddAudioTrack =
+      row.groupStart && isAudio && Number(row.count ?? row.laneTotal ?? 1) < maxAudioTracks
 
-  return yLabels.map((label, index) => (
-    <Box
-      key={label}
-      display="flex"
-      alignItems="center"
-      justifyContent="center"
-      bg={label === "Audio files" ? "rgb(204, 46, 252)" : "purple.200"}
-      border="2px solid #b55fe0"
-      marginRight={`${gap}px`}
-      h={`${rowHeight}px`}
-      width="120px"
-      position="relative"
-    >
-      <Box fontWeight="bold" color="black">
-        {label === "Audio files" ? (
+    return (
+      <Box
+        key={`${row.kind}-${row.group}-${row.layer ?? "merged"}-${row.y}`}
+        display="flex"
+        alignItems="center"
+        justifyContent={row.groupStart ? "space-between" : "center"}
+        bg={isAudio ? "rgb(204, 46, 252)" : "purple.200"}
+        border="2px solid #b55fe0"
+        marginRight={`${gap}px`}
+        h={`${rowHeight}px`}
+        width="120px"
+        position="relative"
+        px="6px"
+      >
+        {row.groupStart && (
           <IconButton
-            icon={isAudioMuted ? <SpeakerMutedIcon boxSize="55px" /> : <SpeakerIcon boxSize="55px" />}
-            sx={{
-              width: "65px",
-              height: "65px",
-              padding: "10px",
-            }}
-            _hover={{ color: "rgb(99, 76, 107)" }}
-            textColor={"black"}
+            icon={isCollapsed ? <ChevronRightIcon /> : <ChevronDownIcon />}
+            size="xs"
             variant="ghost"
-            draggable={false}
-            aria-label="Mute/unmute audio"
-            title={isAudioMuted ? "Unmute audio" : "Mute audio"}
-            onMouseDown={(e) => {
-              e.stopPropagation()
-              headerActionsRef.current.toggleAudioMute()
+            color="black"
+            aria-label={isCollapsed ? "Expand row group" : "Collapse row group"}
+            title={isCollapsed ? "Expand" : "Collapse"}
+            onClick={(event) => {
+              event.stopPropagation()
+              onToggleGroupCollapsed(row.group)
             }}
           />
-        ) : (
-          <Box position="relative" width="65px" height="65px">
-            <Box
-              as="img"
-              src={screenIcon}
-              alt=""
-              width="65px"
-              height="65px"
-              aria-hidden="true"
+        )}
+
+      <Box
+        fontWeight="bold"
+        color="black"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        gap="4px"
+        flex="1"
+        minW={0}
+      >
+        {isAudio && row.groupStart ? (
+          <>
+            <IconButton
+              icon={
+                isAudioMuted ? (
+                  <SpeakerMutedIcon boxSize="36px" />
+                ) : (
+                  <SpeakerIcon boxSize="36px" />
+                )
+              }
+              sx={{
+                width: "44px",
+                height: "44px",
+                padding: "4px",
+              }}
+              _hover={{ color: "rgb(99, 76, 107)" }}
+              textColor={"black"}
+              variant="ghost"
+              draggable={false}
+              aria-label="Mute/unmute audio"
+              title={isAudioMuted ? "Unmute audio" : "Mute audio"}
+              onMouseDown={(e) => {
+                e.stopPropagation()
+                headerActionsRef.current.toggleAudioMute()
+              }}
             />
-            <Text
-              as="span"
-              position="absolute"
-              top="43%"
-              left="50%"
-              transform="translate(-50%, -50%)"
-              fontSize="24px"
-              fontWeight="700"
-              lineHeight="1"
-              color="black"
-              pointerEvents="none"
-            >
-              {getScreenNumberFromLabel(label)}
+            <Text as="span" fontSize="13px" lineHeight="1" noOfLines={1}>
+              {row.collapsed ? `${row.count} tracks` : row.label}
             </Text>
-          </Box>
+          </>
+        ) : !isAudio && row.groupStart ? (
+          <>
+            <Box position="relative" width="50px" height="50px" flexShrink={0}>
+              <Box
+                as="img"
+                src={screenIcon}
+                alt=""
+                width="50px"
+                height="50px"
+                aria-hidden="true"
+              />
+              <Text
+                as="span"
+                position="absolute"
+                top="43%"
+                left="50%"
+                transform="translate(-50%, -50%)"
+                fontSize="19px"
+                fontWeight="700"
+                lineHeight="1"
+                color="black"
+                pointerEvents="none"
+              >
+                {row.screen}
+              </Text>
+            </Box>
+            <Text as="span" fontSize="13px" lineHeight="1" noOfLines={1}>
+              {row.collapsed ? `${row.count} layers` : row.label}
+            </Text>
+          </>
+        ) : (
+          <Text as="span" fontSize="13px" lineHeight="1" noOfLines={1}>
+            {row.label}
+          </Text>
         )}
       </Box>
 
-      {label !== "Audio files" && (
+      {!isAudio && (
         <>
-          {index === screenCount - 1 && screenCount < 8 && (
+          {row.kind === "layer" && Number(row.layer ?? 0) > 0 && (
             <IconButton
-              icon={<AddIcon />}
+              icon={<MinusIcon boxSize="9px" />}
               size="xs"
               variant="solid"
               color="black"
+              bg="orange.100"
+              border="1px solid rgba(221, 107, 32, 0.48)"
+              borderRadius="6px"
               position="absolute"
-              bottom="1px"
-              right="1px"
-              aria-label="Add screen"
-              title="Add screen"
-              onClick={() => {
-                headerActionsRef.current.increaseScreenCount()
+              top="50%"
+              right="4px"
+              transform="translateY(-50%)"
+              aria-label={`Remove layer from screen ${row.screen}`}
+              title={
+                canRemoveVisualLayer
+                  ? "Remove layer"
+                  : "Base layer cannot be removed"
+              }
+              isDisabled={!canRemoveVisualLayer}
+              onClick={(event) => {
+                event.stopPropagation()
+                onRemoveVisualLayer(row.screen, row.layer)
               }}
               _hover={{
-                bg: "rgba(72, 187, 120, 0.22)",
-                borderColor: "green.400",
+                bg: "orange.50",
+                borderColor: "orange.400",
                 color: "black",
-                transform: "scale(1.1)",
               }}
               _active={{ bg: "white" }}
               boxShadow="0 2px 4px rgba(0,0,0,0.2)"
@@ -115,30 +196,160 @@ const RowHeadersBase = ({
             />
           )}
 
-          {index === screenCount - 1 && screenCount > 1 && (
-            <IconButton
-              icon={<MinusIcon />}
-              size="xs"
-              variant="solid"
-              color="black"
+          {isLastScreenStart && screenCount > 1 && (
+            <Box
               position="absolute"
-              top="1px"
-              right="1px"
-              aria-label="Remove screen"
-              title="Remove screen"
-              onClick={() => {
-                headerActionsRef.current.decreaseScreenCount()
-              }}
-              _hover={{ bg: "white", borderColor: "white", transform: "scale(1.1)" }}
-              _active={{ bg: "white" }}
-              boxShadow="0 2px 4px rgba(0,0,0,0.2)"
+              top="4px"
+              right="4px"
+              display="flex"
+              flexDirection="column"
+              alignItems="stretch"
+              gap="3px"
               zIndex="10"
-            />
+            >
+              <Button
+                leftIcon={<MinusIcon boxSize="8px" />}
+                size="xs"
+                variant="solid"
+                color="black"
+                bg="red.100"
+                border="1px solid rgba(197, 48, 48, 0.45)"
+                borderRadius="6px"
+                height="20px"
+                minW="60px"
+                px="4px"
+                fontSize="10px"
+                lineHeight="1"
+                aria-label="Remove screen"
+                title="Remove screen"
+                onClick={(event) => {
+                  event.stopPropagation()
+                  headerActionsRef.current.decreaseScreenCount()
+                }}
+                _hover={{
+                  bg: "red.50",
+                  borderColor: "red.400",
+                  color: "black",
+                }}
+                _active={{ bg: "white" }}
+                boxShadow="0 2px 4px rgba(0,0,0,0.18)"
+              >
+                écran
+              </Button>
+            </Box>
+          )}
+
+          {isVisualGroupEnd &&
+            (canAddVisualLayer || (isLastScreenEnd && screenCount < 8)) && (
+            <Box
+              position="absolute"
+              left="6px"
+              right="6px"
+              bottom="-16px"
+              display="flex"
+              gap="4px"
+              zIndex="30"
+            >
+              {canAddVisualLayer && (
+                <Button
+                  leftIcon={<AddIcon boxSize="8px" />}
+                  size="xs"
+                  variant="solid"
+                  color="black"
+                  bg="green.100"
+                  border="1px solid rgba(34, 139, 34, 0.45)"
+                  borderRadius="6px"
+                  height="22px"
+                  flex="1"
+                  minW="0"
+                  px="4px"
+                  fontSize="10px"
+                  lineHeight="1"
+                  aria-label={`Add layer to screen ${row.screen}`}
+                  title="Add layer"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    onAddVisualLayer(row.screen)
+                  }}
+                  _hover={{
+                    bg: "green.50",
+                    borderColor: "green.400",
+                    color: "black",
+                  }}
+                  _active={{ bg: "white" }}
+                  boxShadow="0 2px 4px rgba(0,0,0,0.2)"
+                >
+                  calque
+                </Button>
+              )}
+
+              {isLastScreenEnd && screenCount < 8 && (
+                <Button
+                  leftIcon={<AddIcon boxSize="8px" />}
+                  size="xs"
+                  variant="solid"
+                  color="black"
+                  bg="blue.100"
+                  border="1px solid rgba(49, 130, 206, 0.48)"
+                  borderRadius="6px"
+                  height="22px"
+                  flex="1"
+                  minW="0"
+                  px="4px"
+                  fontSize="10px"
+                  lineHeight="1"
+                  aria-label="Add screen"
+                  title="Add screen"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    headerActionsRef.current.increaseScreenCount()
+                  }}
+                  _hover={{
+                    bg: "blue.50",
+                    borderColor: "blue.400",
+                    color: "black",
+                  }}
+                  _active={{ bg: "white" }}
+                  boxShadow="0 2px 4px rgba(0,0,0,0.18)"
+                >
+                  écran
+                </Button>
+              )}
+            </Box>
           )}
         </>
       )}
-    </Box>
-  ))
+
+      {row.groupStart && isAudio && (
+        <IconButton
+          icon={<AddIcon />}
+          size="xs"
+          variant="solid"
+          color="black"
+          position="absolute"
+          bottom="1px"
+          right="1px"
+          aria-label="Add audio track"
+          title="Add audio track"
+          isDisabled={!canAddAudioTrack}
+          onClick={(event) => {
+            event.stopPropagation()
+            onAddAudioTrack()
+          }}
+          _hover={{
+            bg: "rgba(72, 187, 120, 0.22)",
+            borderColor: "green.400",
+            color: "black",
+            transform: "scale(1.1)",
+          }}
+          _active={{ bg: "white" }}
+          boxShadow="0 2px 4px rgba(0,0,0,0.2)"
+          zIndex="10"
+        />
+      )}
+      </Box>
+    )
+  })
 }
 
 // Base component for rendering column headers, memoized for performance optimization. Displays frame labels and controls for adding/removing frames.

--- a/src/client/components/presentation/GridLayoutComponent.jsx
+++ b/src/client/components/presentation/GridLayoutComponent.jsx
@@ -20,6 +20,7 @@ import {
   ArrowForwardIcon,
   EditIcon,
   ChevronDownIcon,
+  TimeIcon,
 } from "@chakra-ui/icons"
 import GridLayout from "react-grid-layout"
 import "react-grid-layout/css/styles.css"
@@ -27,11 +28,11 @@ import { useDispatch } from "react-redux"
 import { updatePresentation, removeCue } from "../../redux/presentationReducer"
 import { useCustomToast } from "../utils/toastUtils"
 import Dialog from "../utils/AlertDialog"
-import { getAudioRow } from "../utils/fileTypeUtils"
 import {
   buildCueVisualSpanMap,
   getCueVisualSpanFromMap,
 } from "../utils/cueVisualSpanUtils"
+import { normalizeCueOpacity } from "../utils/cueOpacityUtils"
 
 const renderElementBasedOnIndex = (currentIndex, cues, cue) => {
   if (cue.index > currentIndex) {
@@ -57,6 +58,9 @@ const renderElementBasedOnIndex = (currentIndex, cues, cue) => {
 }
 
 const renderMedia = (cue, cueIndex, cues, isAudioMuted, screenCount) => {
+  const visualOpacity =
+    cue.cueType === "visual" ? normalizeCueOpacity(cue.opacity) : 1
+
   if (cue.file == null) {
     return (
       <Box
@@ -65,6 +69,7 @@ const renderMedia = (cue, cueIndex, cues, isAudioMuted, screenCount) => {
           height: "100%",
           backgroundColor: cue.color || "#e014ee",
           borderRadius: "10px",
+          opacity: visualOpacity,
         }}
       />
     )
@@ -81,6 +86,7 @@ const renderMedia = (cue, cueIndex, cues, isAudioMuted, screenCount) => {
           objectFit: "cover",
           borderRadius: "10px",
           userSelect: "none",
+          opacity: visualOpacity,
         }}
         muted
         playsInline
@@ -99,6 +105,7 @@ const renderMedia = (cue, cueIndex, cues, isAudioMuted, screenCount) => {
           objectFit: "cover",
           borderRadius: "10px",
           userSelect: "none",
+          opacity: visualOpacity,
         }}
       />
     )
@@ -116,6 +123,8 @@ const GridLayoutComponent = ({
   id,
   layout,
   cues,
+  cueRowIndex = {},
+  rowCount = 1,
   setCopiedCue,
   setIsCopied,
   columnWidth,
@@ -145,6 +154,8 @@ const GridLayoutComponent = ({
     () => buildCueVisualSpanMap(cues, indexCount),
     [cues, indexCount]
   )
+  const gridWidth = indexCount * columnWidth + Math.max(indexCount - 1, 0) * gap
+  const gridHeight = rowCount * rowHeight + Math.max(rowCount - 1, 0) * gap
 
   const handleLoopToggle = async (cue) => {
     const updatedCue = {
@@ -152,9 +163,12 @@ const GridLayoutComponent = ({
       cueName: cue.name,
       index: cue.index,
       screen: cue.screen,
+      layer: cue.layer ?? 0,
       file: cue.file,
       color: cue.color,
       loop: !cue.loop,
+      continuePlayback: Boolean(cue.continuePlayback),
+      opacity: normalizeCueOpacity(cue.opacity),
     }
 
     const result = await dispatch(updatePresentation(id, updatedCue))
@@ -170,6 +184,41 @@ const GridLayoutComponent = ({
       })
     } catch (e) {
       console.log("Error printing toast about loop toggle: ", e)
+    }
+  }
+
+  const handleContinuePlaybackToggle = async (cue) => {
+    const updatedCue = {
+      cueId: cue._id,
+      cueName: cue.name,
+      index: cue.index,
+      screen: cue.screen,
+      layer: cue.layer ?? 0,
+      file: cue.file,
+      color: cue.color,
+      loop: Boolean(cue.loop),
+      continuePlayback: !cue.continuePlayback,
+      opacity: normalizeCueOpacity(cue.opacity),
+    }
+
+    const result = await dispatch(updatePresentation(id, updatedCue))
+    const updatedCueFromRedux = result?.payload
+
+    try {
+      showToast({
+        title: updatedCueFromRedux.continuePlayback
+          ? "Continuous audio enabled"
+          : "Continuous audio disabled",
+        description: `${updatedCueFromRedux.name} will ${
+          updatedCueFromRedux.continuePlayback
+            ? "keep playing after the sequence ends"
+            : "stop with the sequence"
+        }`,
+        status: "info",
+        duration: 2000,
+      })
+    } catch (e) {
+      console.log("Error printing toast about continuous audio toggle: ", e)
     }
   }
 
@@ -297,22 +346,44 @@ const GridLayoutComponent = ({
             }}
           />
           {cue.file != null && cue.cueType === "audio" && (
-            <IconButton
-              icon={cue.loop ? <RepeatIcon /> : <ArrowForwardIcon />}
-              size="xs"
-              w="100%"
-              h="30px"
-              borderRadius="0 0 0.375rem 0.375rem"
-              _hover={{ bg: "green.600", color: "white" }}
-              backgroundColor="green.500"
-              draggable={false}
-              aria-label={`Loop audio ${cue.name}`}
-              title={cue.loop ? "Disable loop" : "Enable loop"}
-              onMouseDown={(e) => {
-                e.stopPropagation()
-                handleLoopToggle(cue)
-              }}
-            />
+            <>
+              <IconButton
+                icon={cue.loop ? <RepeatIcon /> : <ArrowForwardIcon />}
+                size="xs"
+                w="100%"
+                h="30px"
+                borderRadius={0}
+                _hover={{ bg: "green.600", color: "white" }}
+                backgroundColor="green.500"
+                draggable={false}
+                aria-label={`Loop audio ${cue.name}`}
+                title={cue.loop ? "Disable loop" : "Enable loop"}
+                onMouseDown={(e) => {
+                  e.stopPropagation()
+                  handleLoopToggle(cue)
+                }}
+              />
+              <IconButton
+                icon={<TimeIcon />}
+                size="xs"
+                w="100%"
+                h="30px"
+                borderRadius="0 0 0.375rem 0.375rem"
+                _hover={{ bg: "blue.600", color: "white" }}
+                backgroundColor={cue.continuePlayback ? "blue.500" : "gray.500"}
+                draggable={false}
+                aria-label={`Continue audio ${cue.name}`}
+                title={
+                  cue.continuePlayback
+                    ? "Disable continuous playback"
+                    : "Enable continuous playback"
+                }
+                onMouseDown={(e) => {
+                  e.stopPropagation()
+                  handleContinuePlaybackToggle(cue)
+                }}
+              />
+            </>
           )}
         </MenuList>
       </Portal>
@@ -322,409 +393,442 @@ const GridLayoutComponent = ({
   // helper functions for managing drag-and-drop interactions in the presentation editor
   return (
     <>
-      <GridLayout
-        className="layout"
-        layout={layout}
-        cols={indexCount}
-        rowHeight={rowHeight}
-        width={indexCount * columnWidth + (indexCount - 1) * gap}
-        isDraggable={false}
-        isResizable={false}
-        compactType={null}
-        isBounded={false}
-        preventCollision={true}
-        margin={[gap, gap]}
-        containerPadding={[0, 0]}
-        useCSSTransforms={true}
-        maxRows={Math.max(
-          ...cues.map((cue) => cue.screen),
-          getAudioRow(screenCount)
-        )}
+      <Box
+        position="relative"
+        width={`${gridWidth}px`}
+        minHeight={`${gridHeight}px`}
       >
-        {cues.map((cue) => {
-          const overriddenCueVisualSpan = Number(
-            previewCueSpanOverrides[cue._id]
-          )
-          const actualCueVisualSpan = getCueVisualSpanFromMap(
-            cue,
-            cueVisualSpanMap
-          )
-          const previewCueVisualSpan =
-            Number.isInteger(overriddenCueVisualSpan) &&
-            overriddenCueVisualSpan > 0
-              ? overriddenCueVisualSpan
-              : actualCueVisualSpan
-          const hasContinuation = actualCueVisualSpan > 1
-          const isTerminalContinuationPreview =
-            Number.isInteger(overriddenCueVisualSpan) &&
-            overriddenCueVisualSpan === 1
-          const hasVisibleContinuation =
-            previewCueVisualSpan > 1 || isTerminalContinuationPreview
-          const cueVisualSpan = previewCueVisualSpan
-          const continuationSlotCount = Math.max(cueVisualSpan - 1, 0)
-          const continuationInset = 0
-          const continuationDividerWidth = gap > 2 ? 2 : Math.max(gap, 1)
-          const continuationDividerOffset = Math.max(
-            (gap - continuationDividerWidth) / 2,
-            0
-          )
-          const continuationStartLeft = columnWidth
-          const anchorContinuationDividerWidth =
-            gap > 0
-              ? Math.max(
-                  gap - continuationDividerOffset,
-                  continuationDividerWidth
-                )
-              : continuationDividerWidth
-          const anchorContinuationSeamLeft = continuationStartLeft
-          const continuationVisualOpacity = 0.76
-          const segmentBorderColor = "rgba(255, 255, 255, 0.24)"
-          const segmentBorderHoverColor = "rgba(255, 255, 255, 0.42)"
-          const cueMediaUrl =
-            cue.file?.url || (cue.file?.name ? `/${cue.file.name}` : "")
-          const cueIsVideo = cue.file?.type?.startsWith("video/")
-          const isVisualCue = cue.cueType === "visual"
-          const isDraggingOriginCue = isDragging && draggingCueId === cue._id
-          const suppressCueHoverEffects = isDragging || isCopied
-
-          return (
-            <div
-              key={cue._id}
-              data-testid={`cue-${cue.name}`}
-              data-grid={{
-                x: cue.index,
-                y: cue.screen - 1,
-                w: cueVisualSpan,
-                h: 1,
-                minH: 1,
-                maxH: 1,
-                static: false,
-              }}
-              id={`cue-screen-${cue.screen}-index-${cue.index}`}
-            >
+        <Box
+          data-testid="grid-empty-cells"
+          position="absolute"
+          inset="0"
+          pointerEvents="none"
+          zIndex={0}
+        >
+          {Array.from({ length: rowCount }).map((_, rowIndex) =>
+            Array.from({ length: indexCount }).map((__, columnIndex) => (
               <Box
-                position="relative"
-                h="100%"
-                overflow="hidden"
+                key={`empty-cell-${rowIndex}-${columnIndex}`}
+                data-testid={`grid-empty-cell-${rowIndex}-${columnIndex}`}
+                position="absolute"
+                left={`${columnIndex * (columnWidth + gap)}px`}
+                top={`${rowIndex * (rowHeight + gap)}px`}
+                width={`${columnWidth}px`}
+                height={`${rowHeight}px`}
                 borderRadius="10px"
-                cursor={
-                  isDragging
-                    ? "grabbing"
-                    : isCopied
-                      ? interactionCursor || "copy"
-                      : "grab"
-                }
-                data-cue-content-id={cue._id}
-                opacity={isDraggingOriginCue ? 0.58 : 1}
-                transform="translateY(0)"
-                transition="opacity 90ms linear, transform 140ms ease, box-shadow 140ms ease"
-                _hover={
-                  suppressCueHoverEffects
-                    ? {}
-                    : {
-                        transform: "translateY(-1px)",
-                        boxShadow: "0 8px 18px rgba(0, 0, 0, 0.24)",
-                      }
-                }
-                sx={
-                  suppressCueHoverEffects
-                    ? {}
-                    : {
-                        "&:hover [data-cue-anchor-border], &:hover [data-cue-continuation-border]":
-                          {
-                            borderColor: segmentBorderHoverColor,
-                          },
-                        "&:hover [data-cue-seam-divider]": {
-                          backgroundColor: segmentBorderHoverColor,
-                        },
-                        "&:hover [data-cue-anchor-hover-tint]": {
-                          opacity: 0.18,
-                        },
-                      }
-                }
+                bg="rgba(12, 10, 18, 0.46)"
+                border="1px solid rgba(255, 255, 255, 0.12)"
+              />
+            ))
+          )}
+        </Box>
+        <GridLayout
+          className="layout"
+          layout={layout}
+          cols={indexCount}
+          rowHeight={rowHeight}
+          width={gridWidth}
+          isDraggable={false}
+          isResizable={false}
+          compactType={null}
+          isBounded={false}
+          preventCollision={true}
+          margin={[gap, gap]}
+          containerPadding={[0, 0]}
+          useCSSTransforms={true}
+          maxRows={rowCount}
+          style={{
+            position: "relative",
+            zIndex: 1,
+            minHeight: `${gridHeight}px`,
+          }}
+        >
+          {cues.map((cue) => {
+            const overriddenCueVisualSpan = Number(
+              previewCueSpanOverrides[cue._id]
+            )
+            const actualCueVisualSpan = getCueVisualSpanFromMap(
+              cue,
+              cueVisualSpanMap
+            )
+            const previewCueVisualSpan =
+              Number.isInteger(overriddenCueVisualSpan) &&
+              overriddenCueVisualSpan > 0
+                ? overriddenCueVisualSpan
+                : actualCueVisualSpan
+            const hasContinuation = actualCueVisualSpan > 1
+            const isTerminalContinuationPreview =
+              Number.isInteger(overriddenCueVisualSpan) &&
+              overriddenCueVisualSpan === 1
+            const hasVisibleContinuation =
+              previewCueVisualSpan > 1 || isTerminalContinuationPreview
+            const cueVisualSpan = previewCueVisualSpan
+            const continuationSlotCount = Math.max(cueVisualSpan - 1, 0)
+            const continuationInset = 0
+            const continuationDividerWidth = gap > 2 ? 2 : Math.max(gap, 1)
+            const continuationDividerOffset = Math.max(
+              (gap - continuationDividerWidth) / 2,
+              0
+            )
+            const continuationStartLeft = columnWidth
+            const anchorContinuationDividerWidth =
+              gap > 0
+                ? Math.max(
+                    gap - continuationDividerOffset,
+                    continuationDividerWidth
+                  )
+                : continuationDividerWidth
+            const anchorContinuationSeamLeft = continuationStartLeft
+            const continuationVisualOpacity = 0.76
+            const segmentBorderColor = "rgba(255, 255, 255, 0.24)"
+            const segmentBorderHoverColor = "rgba(255, 255, 255, 0.42)"
+            const cueMediaUrl =
+              cue.file?.url || (cue.file?.name ? `/${cue.file.name}` : "")
+            const cueIsVideo = cue.file?.type?.startsWith("video/")
+            const isVisualCue = cue.cueType === "visual"
+            const isDraggingOriginCue = isDragging && draggingCueId === cue._id
+            const suppressCueHoverEffects = isDragging || isCopied
+            const cueGridRow = cueRowIndex[cue._id] ?? 0
+
+            return (
+              <div
+                key={cue._id}
+                data-testid={`cue-${cue.name}`}
+                data-grid={{
+                  x: cue.index,
+                  y: cueGridRow,
+                  w: cueVisualSpan,
+                  h: 1,
+                  minH: 1,
+                  maxH: 1,
+                  static: false,
+                }}
+                id={`cue-screen-${cue.screen}-index-${cue.index}`}
               >
-                {!isDragging && EditModeCueButtons(cue)}
+                <Box
+                  position="relative"
+                  h="100%"
+                  overflow="hidden"
+                  borderRadius="10px"
+                  cursor={
+                    isDragging
+                      ? "grabbing"
+                      : isCopied
+                        ? interactionCursor || "copy"
+                        : "grab"
+                  }
+                  data-cue-content-id={cue._id}
+                  opacity={isDraggingOriginCue ? 0.58 : 1}
+                  transform="translateY(0)"
+                  transition="opacity 90ms linear, transform 140ms ease, box-shadow 140ms ease"
+                  _hover={
+                    suppressCueHoverEffects
+                      ? {}
+                      : {
+                          transform: "translateY(-1px)",
+                          boxShadow: "0 8px 18px rgba(0, 0, 0, 0.24)",
+                        }
+                  }
+                  sx={
+                    suppressCueHoverEffects
+                      ? {}
+                      : {
+                          "&:hover [data-cue-anchor-border], &:hover [data-cue-continuation-border]":
+                            {
+                              borderColor: segmentBorderHoverColor,
+                            },
+                          "&:hover [data-cue-seam-divider]": {
+                            backgroundColor: segmentBorderHoverColor,
+                          },
+                          "&:hover [data-cue-anchor-hover-tint]": {
+                            opacity: 0.18,
+                          },
+                        }
+                  }
+                >
+                  {!isDragging && EditModeCueButtons(cue)}
 
-                {hasContinuation && isVisualCue ? (
-                  <Box
-                    data-testid={`cue-anchor-media-overlay-${cue._id}`}
-                    position="absolute"
-                    left="0"
-                    top="0"
-                    width={`${columnWidth}px`}
-                    height="100%"
-                    borderRadius={
-                      hasVisibleContinuation ? "10px 0 0 10px" : "10px"
-                    }
-                    overflow="hidden"
-                    pointerEvents="none"
-                    zIndex={4}
-                    boxShadow={
-                      hasVisibleContinuation
-                        ? "inset 0 0 0 1px rgba(255, 255, 255, 0.14), 2px 6px 12px rgba(0, 0, 0, 0.18)"
-                        : "none"
-                    }
-                  >
-                    {cueMediaUrl ? (
-                      cueIsVideo ? (
-                        <video
-                          src={cueMediaUrl}
-                          draggable={false}
-                          style={{
-                            width: "100%",
-                            height: "100%",
-                            objectFit: "cover",
-                            borderRadius: hasVisibleContinuation
-                              ? "10px 0 0 10px"
-                              : "10px",
-                          }}
-                          muted
-                          playsInline
-                          controls={false}
-                        />
-                      ) : (
-                        <Box
-                          as="img"
-                          src={cueMediaUrl}
-                          alt={cue.name}
-                          draggable={false}
-                          width="100%"
-                          height="100%"
-                          objectFit="cover"
-                          borderRadius={
-                            hasVisibleContinuation ? "10px 0 0 10px" : "10px"
-                          }
-                        />
-                      )
-                    ) : (
-                      <Box
-                        width="100%"
-                        height="100%"
-                        bg={cue.color || "#e014ee"}
-                      />
-                    )}
-                  </Box>
-                ) : (
-                  renderMedia(cue, cueIndex, cues, isAudioMuted, screenCount)
-                )}
-
-                {hasContinuation && (
-                  <>
+                  {hasContinuation && isVisualCue ? (
                     <Box
-                      data-cue-anchor-hover-tint
+                      data-testid={`cue-anchor-media-overlay-${cue._id}`}
                       position="absolute"
-                      top={`${continuationInset}px`}
-                      bottom={`${continuationInset}px`}
                       left="0"
+                      top="0"
                       width={`${columnWidth}px`}
-                      bg="rgba(255, 255, 255, 0.2)"
-                      opacity={0}
-                      transition="opacity 140ms ease"
-                      pointerEvents="none"
-                      zIndex={5}
-                    />
-
-                    <Box
-                      data-testid={`cue-continuation-overlay-${cue._id}`}
-                      position="absolute"
-                      top={`${continuationInset}px`}
-                      bottom={`${continuationInset}px`}
-                      left={`${continuationStartLeft}px`}
-                      right="0"
-                      borderRadius="0 8px 8px 0"
-                      overflow="hidden"
-                      opacity={
-                        hasVisibleContinuation ? continuationVisualOpacity : 0
-                      }
-                      pointerEvents="none"
-                      zIndex={2}
-                    >
-                      {isVisualCue && cueMediaUrl ? (
-                        <>
-                          {cueIsVideo ? (
-                            <video
-                              src={cueMediaUrl}
-                              draggable={false}
-                              style={{
-                                width: "100%",
-                                height: "100%",
-                                objectFit: "cover",
-                                filter:
-                                  "saturate(48%) brightness(0.8) contrast(0.94) blur(6px)",
-                              }}
-                              muted
-                              playsInline
-                              controls={false}
-                            />
-                          ) : (
-                            <Box
-                              as="img"
-                              src={cueMediaUrl}
-                              alt={`${cue.name} continuation`}
-                              draggable={false}
-                              width="100%"
-                              height="100%"
-                              objectFit="cover"
-                              filter="saturate(48%) brightness(0.8) contrast(0.94) blur(6px)"
-                            />
-                          )}
-
-                          <Box
-                            position="absolute"
-                            inset="0"
-                            bg="linear-gradient(90deg, rgba(14, 20, 29, 0.1) 0%, rgba(14, 20, 29, 0.22) 50%, rgba(14, 20, 29, 0.5) 100%)"
-                          />
-                        </>
-                      ) : (
-                        <>
-                          <Box
-                            width="100%"
-                            height="100%"
-                            bg={cue.color || "rgba(20, 24, 33, 0.72)"}
-                            filter="saturate(50%) brightness(0.88)"
-                          />
-                          <Box
-                            position="absolute"
-                            inset="0"
-                            bg="linear-gradient(90deg, rgba(255, 255, 255, 0.16) 0%, rgba(176, 193, 223, 0.12) 35%, rgba(14, 20, 29, 0.32) 100%)"
-                          />
-                        </>
-                      )}
-                    </Box>
-
-                    <Box
-                      data-cue-anchor-border
-                      position="absolute"
-                      top={`${continuationInset}px`}
-                      bottom={`${continuationInset}px`}
-                      left="0"
-                      width={`${columnWidth}px`}
-                      border="1px solid"
-                      borderColor={segmentBorderColor}
-                      borderRightWidth={hasVisibleContinuation ? "0" : "1px"}
+                      height="100%"
                       borderRadius={
                         hasVisibleContinuation ? "10px 0 0 10px" : "10px"
                       }
-                      transition="border-color 140ms ease"
-                      pointerEvents="none"
-                      zIndex={6}
-                    />
-
-                    <Box
-                      data-cue-continuation-border
-                      position="absolute"
-                      top={`${continuationInset}px`}
-                      bottom={`${continuationInset}px`}
-                      left={`${continuationStartLeft}px`}
-                      right="0"
-                      border="1px solid"
-                      borderColor={segmentBorderColor}
-                      borderLeftWidth="0"
-                      borderRadius="0 8px 8px 0"
-                      opacity={hasVisibleContinuation ? 1 : 0}
-                      transition="border-color 140ms ease"
-                      pointerEvents="none"
-                      zIndex={6}
-                    />
-
-                    <Box
-                      data-cue-seam-divider
-                      position="absolute"
-                      top={`${continuationInset}px`}
-                      bottom={`${continuationInset}px`}
-                      left={`${anchorContinuationSeamLeft}px`}
-                      width={`${anchorContinuationDividerWidth}px`}
-                      bg={segmentBorderColor}
-                      opacity={hasVisibleContinuation ? 1 : 0}
-                      transition="background-color 140ms ease"
-                      pointerEvents="none"
-                      zIndex={6}
-                    />
-
-                    {gap > 0 &&
-                      continuationSlotCount > 1 &&
-                      Array.from({ length: continuationSlotCount - 1 }).map(
-                        (_, dividerIndex) => {
-                          const dividerLeft =
-                            continuationStartLeft +
-                            (dividerIndex + 1) * (columnWidth + gap) +
-                            continuationDividerOffset
-                          return (
-                            <Box
-                              key={`${cue._id}-continuation-divider-${dividerIndex}`}
-                              data-testid={`cue-continuation-divider-${cue._id}-${dividerIndex}`}
-                              position="absolute"
-                              top={`${continuationInset}px`}
-                              bottom={`${continuationInset}px`}
-                              left={`${dividerLeft}px`}
-                              width={`${continuationDividerWidth}px`}
-                              bg="linear-gradient(180deg, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0.08) 100%)"
-                              pointerEvents="none"
-                              zIndex={3}
-                            />
-                          )
-                        }
-                      )}
-                  </>
-                )}
-
-                {isDraggingOriginCue && (
-                  <Box
-                    data-testid={`cue-drag-origin-indicator-${cue._id}`}
-                    position="absolute"
-                    left="0"
-                    top="0"
-                    width={`${columnWidth}px`}
-                    height="100%"
-                    border="2px dashed"
-                    borderColor="#c9b7f8"
-                    borderRadius="10px"
-                    bg="rgba(201, 183, 248, 0.16)"
-                    boxShadow="none"
-                    pointerEvents="none"
-                    zIndex={8}
-                  />
-                )}
-
-                {cue.name?.trim() && (
-                  <Tooltip
-                    label={cue.name}
-                    placement="top"
-                    hasArrow
-                    isDisabled={isDragging}
-                  >
-                    <Text
-                      data-testid={`cue-label-${cue._id}`}
-                      position="absolute"
-                      top="50%"
-                      left="8px"
-                      transform="translateY(-50%)"
-                      color="white"
-                      fontWeight="bold"
-                      bg="rgba(0, 0, 0, 0.5)"
-                      p={2}
-                      borderRadius="md"
-                      whiteSpace="nowrap"
                       overflow="hidden"
-                      textOverflow="ellipsis"
-                      display="inline-block"
-                      maxWidth={`${Math.max(columnWidth - 16, 40)}px`}
-                      textAlign="left"
-                      cursor="default"
                       pointerEvents="none"
-                      userSelect="none"
-                      zIndex={7}
-                      style={{ textShadow: "2px 2px 4px rgb(0, 0, 0)" }}
+                      zIndex={4}
+                      boxShadow={
+                        hasVisibleContinuation
+                          ? "inset 0 0 0 1px rgba(255, 255, 255, 0.14), 2px 6px 12px rgba(0, 0, 0, 0.18)"
+                          : "none"
+                      }
                     >
-                      {cue.name}
-                    </Text>
-                  </Tooltip>
-                )}
-              </Box>
-            </div>
-          )
-        })}
-      </GridLayout>
+                      {cueMediaUrl ? (
+                        cueIsVideo ? (
+                          <video
+                            src={cueMediaUrl}
+                            draggable={false}
+                            style={{
+                              width: "100%",
+                              height: "100%",
+                              objectFit: "cover",
+                              borderRadius: hasVisibleContinuation
+                                ? "10px 0 0 10px"
+                                : "10px",
+                            }}
+                            muted
+                            playsInline
+                            controls={false}
+                          />
+                        ) : (
+                          <Box
+                            as="img"
+                            src={cueMediaUrl}
+                            alt={cue.name}
+                            draggable={false}
+                            width="100%"
+                            height="100%"
+                            objectFit="cover"
+                            borderRadius={
+                              hasVisibleContinuation ? "10px 0 0 10px" : "10px"
+                            }
+                          />
+                        )
+                      ) : (
+                        <Box
+                          width="100%"
+                          height="100%"
+                          bg={cue.color || "#e014ee"}
+                        />
+                      )}
+                    </Box>
+                  ) : (
+                    renderMedia(cue, cueIndex, cues, isAudioMuted, screenCount)
+                  )}
+
+                  {hasContinuation && (
+                    <>
+                      <Box
+                        data-cue-anchor-hover-tint
+                        position="absolute"
+                        top={`${continuationInset}px`}
+                        bottom={`${continuationInset}px`}
+                        left="0"
+                        width={`${columnWidth}px`}
+                        bg="rgba(255, 255, 255, 0.2)"
+                        opacity={0}
+                        transition="opacity 140ms ease"
+                        pointerEvents="none"
+                        zIndex={5}
+                      />
+
+                      <Box
+                        data-testid={`cue-continuation-overlay-${cue._id}`}
+                        position="absolute"
+                        top={`${continuationInset}px`}
+                        bottom={`${continuationInset}px`}
+                        left={`${continuationStartLeft}px`}
+                        right="0"
+                        borderRadius="0 8px 8px 0"
+                        overflow="hidden"
+                        opacity={
+                          hasVisibleContinuation ? continuationVisualOpacity : 0
+                        }
+                        pointerEvents="none"
+                        zIndex={2}
+                      >
+                        {isVisualCue && cueMediaUrl ? (
+                          <>
+                            {cueIsVideo ? (
+                              <video
+                                src={cueMediaUrl}
+                                draggable={false}
+                                style={{
+                                  width: "100%",
+                                  height: "100%",
+                                  objectFit: "cover",
+                                  filter:
+                                    "saturate(48%) brightness(0.8) contrast(0.94) blur(6px)",
+                                }}
+                                muted
+                                playsInline
+                                controls={false}
+                              />
+                            ) : (
+                              <Box
+                                as="img"
+                                src={cueMediaUrl}
+                                alt={`${cue.name} continuation`}
+                                draggable={false}
+                                width="100%"
+                                height="100%"
+                                objectFit="cover"
+                                filter="saturate(48%) brightness(0.8) contrast(0.94) blur(6px)"
+                              />
+                            )}
+
+                            <Box
+                              position="absolute"
+                              inset="0"
+                              bg="linear-gradient(90deg, rgba(14, 20, 29, 0.1) 0%, rgba(14, 20, 29, 0.22) 50%, rgba(14, 20, 29, 0.5) 100%)"
+                            />
+                          </>
+                        ) : (
+                          <>
+                            <Box
+                              width="100%"
+                              height="100%"
+                              bg={cue.color || "rgba(20, 24, 33, 0.72)"}
+                              filter="saturate(50%) brightness(0.88)"
+                            />
+                            <Box
+                              position="absolute"
+                              inset="0"
+                              bg="linear-gradient(90deg, rgba(255, 255, 255, 0.16) 0%, rgba(176, 193, 223, 0.12) 35%, rgba(14, 20, 29, 0.32) 100%)"
+                            />
+                          </>
+                        )}
+                      </Box>
+
+                      <Box
+                        data-cue-anchor-border
+                        position="absolute"
+                        top={`${continuationInset}px`}
+                        bottom={`${continuationInset}px`}
+                        left="0"
+                        width={`${columnWidth}px`}
+                        border="1px solid"
+                        borderColor={segmentBorderColor}
+                        borderRightWidth={hasVisibleContinuation ? "0" : "1px"}
+                        borderRadius={
+                          hasVisibleContinuation ? "10px 0 0 10px" : "10px"
+                        }
+                        transition="border-color 140ms ease"
+                        pointerEvents="none"
+                        zIndex={6}
+                      />
+
+                      <Box
+                        data-cue-continuation-border
+                        position="absolute"
+                        top={`${continuationInset}px`}
+                        bottom={`${continuationInset}px`}
+                        left={`${continuationStartLeft}px`}
+                        right="0"
+                        border="1px solid"
+                        borderColor={segmentBorderColor}
+                        borderLeftWidth="0"
+                        borderRadius="0 8px 8px 0"
+                        opacity={hasVisibleContinuation ? 1 : 0}
+                        transition="border-color 140ms ease"
+                        pointerEvents="none"
+                        zIndex={6}
+                      />
+
+                      <Box
+                        data-cue-seam-divider
+                        position="absolute"
+                        top={`${continuationInset}px`}
+                        bottom={`${continuationInset}px`}
+                        left={`${anchorContinuationSeamLeft}px`}
+                        width={`${anchorContinuationDividerWidth}px`}
+                        bg={segmentBorderColor}
+                        opacity={hasVisibleContinuation ? 1 : 0}
+                        transition="background-color 140ms ease"
+                        pointerEvents="none"
+                        zIndex={6}
+                      />
+
+                      {gap > 0 &&
+                        continuationSlotCount > 1 &&
+                        Array.from({ length: continuationSlotCount - 1 }).map(
+                          (_, dividerIndex) => {
+                            const dividerLeft =
+                              continuationStartLeft +
+                              (dividerIndex + 1) * (columnWidth + gap) +
+                              continuationDividerOffset
+                            return (
+                              <Box
+                                key={`${cue._id}-continuation-divider-${dividerIndex}`}
+                                data-testid={`cue-continuation-divider-${cue._id}-${dividerIndex}`}
+                                position="absolute"
+                                top={`${continuationInset}px`}
+                                bottom={`${continuationInset}px`}
+                                left={`${dividerLeft}px`}
+                                width={`${continuationDividerWidth}px`}
+                                bg="linear-gradient(180deg, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0.08) 100%)"
+                                pointerEvents="none"
+                                zIndex={3}
+                              />
+                            )
+                          }
+                        )}
+                    </>
+                  )}
+
+                  {isDraggingOriginCue && (
+                    <Box
+                      data-testid={`cue-drag-origin-indicator-${cue._id}`}
+                      position="absolute"
+                      left="0"
+                      top="0"
+                      width={`${columnWidth}px`}
+                      height="100%"
+                      border="2px dashed"
+                      borderColor="#c9b7f8"
+                      borderRadius="10px"
+                      bg="rgba(201, 183, 248, 0.16)"
+                      boxShadow="none"
+                      pointerEvents="none"
+                      zIndex={8}
+                    />
+                  )}
+
+                  {cue.name?.trim() && (
+                    <Tooltip
+                      label={cue.name}
+                      placement="top"
+                      hasArrow
+                      isDisabled={isDragging}
+                    >
+                      <Text
+                        data-testid={`cue-label-${cue._id}`}
+                        position="absolute"
+                        top="50%"
+                        left="8px"
+                        transform="translateY(-50%)"
+                        color="white"
+                        fontWeight="bold"
+                        bg="rgba(0, 0, 0, 0.5)"
+                        p={2}
+                        borderRadius="md"
+                        whiteSpace="nowrap"
+                        overflow="hidden"
+                        textOverflow="ellipsis"
+                        display="inline-block"
+                        maxWidth={`${Math.max(columnWidth - 16, 40)}px`}
+                        textAlign="left"
+                        cursor="default"
+                        pointerEvents="none"
+                        userSelect="none"
+                        zIndex={7}
+                        style={{ textShadow: "2px 2px 4px rgb(0, 0, 0)" }}
+                      >
+                        {cue.name}
+                      </Text>
+                    </Tooltip>
+                  )}
+                </Box>
+              </div>
+            )
+          })}
+        </GridLayout>
+      </Box>
       <Dialog
         isOpen={isDialogOpen}
         onClose={() => setIsDialogOpen(false)}

--- a/src/client/components/presentation/PresentationPlaybackControls.jsx
+++ b/src/client/components/presentation/PresentationPlaybackControls.jsx
@@ -9,7 +9,7 @@
  * - Autoplay instructions popover
  * - Audio player (if audio source URL is provided)
  */
-import React from "react"
+import React, { useEffect, useRef } from "react"
 import ClickablePopover from "../utils/ClickablePopover"
 
 import {
@@ -130,6 +130,46 @@ const CueNavigationNext = ({ cueIndex, updateCue, indexCount }) => (
   />
 )
 
+const CueAudioPlayer = ({
+  src,
+  loop,
+  isAutoplaying,
+  continuePlayback,
+  allowContinuousAudio,
+}) => {
+  const audioRef = useRef(null)
+  const hasStartedRef = useRef(false)
+
+  useEffect(() => {
+    const audio = audioRef.current
+    if (!audio) return
+
+    if (!isAutoplaying || !src) {
+      if (
+        (loop || continuePlayback) &&
+        allowContinuousAudio &&
+        hasStartedRef.current
+      ) {
+        return
+      }
+      audio.pause()
+      return
+    }
+
+    const playPromise = audio.play()
+    hasStartedRef.current = true
+    if (playPromise?.catch) {
+      playPromise.catch(() => {})
+    }
+  }, [src, loop, isAutoplaying, continuePlayback, allowContinuousAudio])
+
+  if (!src) return null
+
+  return (
+    <audio ref={audioRef} loop={loop} controls src={src} preload="metadata" />
+  )
+}
+
 // Shared playback controls for presentation navigation and autoplay.
 const PresentationPlaybackControls = ({
   screens,
@@ -143,54 +183,79 @@ const PresentationPlaybackControls = ({
   toggleAutoplayInterval,
   audioSourceURL,
   audioLoop = false,
-}) => (
-  <Box
-    bg=""
-    display="flex"
-    flexDirection="row"
-    alignItems="center"
-    justifyContent="left"
-    gap={4}
-    ml={2.5}
-    mt={1.5}
-  >
+  audioTracks = [],
+  allowContinuousAudio = false,
+}) => {
+  const resolvedAudioTracks =
+    audioTracks.length > 0
+      ? audioTracks
+      : audioSourceURL
+        ? [
+            {
+              id: audioSourceURL,
+              src: audioSourceURL,
+              loop: audioLoop,
+              continuePlayback: false,
+            },
+          ]
+        : []
+
+  return (
     <Box
-      id="presentation-frame-navigation"
+      bg=""
       display="flex"
       flexDirection="row"
       alignItems="center"
+      justifyContent="left"
       gap={4}
+      ml={2.5}
+      mt={1.5}
     >
-      <CueNavigationPrevious cueIndex={cueIndex} updateCue={updateCue} />
-      <Box w="150px" display="flex" justifyContent="center">
-        <Heading size="md" textAlign="center" whiteSpace="nowrap">
-          {cueIndex > 0 ? `Frame ${cueIndex}` : "Frame 0"}
-        </Heading>
+      <Box
+        id="presentation-frame-navigation"
+        display="flex"
+        flexDirection="row"
+        alignItems="center"
+        gap={4}
+      >
+        <CueNavigationPrevious cueIndex={cueIndex} updateCue={updateCue} />
+        <Box w="150px" display="flex" justifyContent="center">
+          <Heading size="md" textAlign="center" whiteSpace="nowrap">
+            {cueIndex > 0 ? `Frame ${cueIndex}` : "Frame 0"}
+          </Heading>
+        </Box>
+
+        <AutoplayControls
+          toggleAutoplay={toggleAutoplay}
+          isAutoplaying={isAutoplaying}
+        />
+        <CueNavigationNext
+          cueIndex={cueIndex}
+          updateCue={updateCue}
+          indexCount={indexCount}
+        />
       </Box>
+      <ScreenToggleButtons
+        screens={screens}
+        toggleAllScreens={toggleAllScreens}
+      />
 
-      <AutoplayControls
-        toggleAutoplay={toggleAutoplay}
-        isAutoplaying={isAutoplaying}
+      <AutoplayInterval
+        autoplayInterval={autoplayInterval}
+        toggleAutoplayInterval={toggleAutoplayInterval}
       />
-      <CueNavigationNext
-        cueIndex={cueIndex}
-        updateCue={updateCue}
-        indexCount={indexCount}
-      />
+      {resolvedAudioTracks.map((track, trackIndex) => (
+        <CueAudioPlayer
+          key={track.id || `${track.src}-${trackIndex}`}
+          src={track.src}
+          loop={Boolean(track.loop)}
+          isAutoplaying={isAutoplaying}
+          continuePlayback={Boolean(track.continuePlayback)}
+          allowContinuousAudio={allowContinuousAudio}
+        />
+      ))}
     </Box>
-    <ScreenToggleButtons
-      screens={screens}
-      toggleAllScreens={toggleAllScreens}
-    />
-
-    <AutoplayInterval
-      autoplayInterval={autoplayInterval}
-      toggleAutoplayInterval={toggleAutoplayInterval}
-    />
-    {audioSourceURL ? (
-      <audio autoPlay loop={audioLoop} controls src={audioSourceURL}></audio>
-    ) : null}
-  </Box>
-)
+  )
+}
 
 export default PresentationPlaybackControls

--- a/src/client/components/presentation/Screen.jsx
+++ b/src/client/components/presentation/Screen.jsx
@@ -18,48 +18,28 @@ import { isType } from "../utils/fileTypeUtils"
 import createCache from "@emotion/cache"
 import { CacheProvider } from "@emotion/react"
 import { getAnims } from "../../utils/transitionUtils"
+import { normalizeCueOpacity } from "../utils/cueOpacityUtils"
 
-//conditional rendering helper function based on file type
+const mediaFillProps = {
+  width: "100%",
+  height: "100%",
+  objectFit: "contain",
+}
+
 const renderMedia = (file, name, color) => {
-  console.log("Rendering media with file:", file) // Debug log to check file object
+  console.log("Rendering media with file:", file)
 
   if (!file) {
-    return (
-      <Box
-        bg={color}
-        // alt={name}
-        width="100%"
-        height="100vh"
-        objectFit="cover"
-      />
-    )
+    return <Box bg={color} width="100%" height="100%" />
   }
 
   if (isType.image(file)) {
     const imageSrc = file.url || `/${file.name}`
-    return (
-      <Image
-        src={imageSrc}
-        alt={name}
-        width="100%"
-        height="100vh"
-        objectFit="cover"
-      />
-    )
+    return <Image src={imageSrc} alt={name} {...mediaFillProps} />
   }
   // check if media is video
   if (isType.video(file)) {
-    return (
-      <video
-        src={file.url}
-        width="100%"
-        height="100%"
-        autoPlay
-        loop
-        muted
-        style={{ objectFit: "contain" }}
-      />
-    )
+    return <video src={file.url} style={mediaFillProps} autoPlay loop muted />
   }
   // check if media is audio
   if (isType.audio(file)) {
@@ -71,16 +51,48 @@ const renderMedia = (file, name, color) => {
     )
   }
   // if no media file, render a solid color background
-  return (
-    <Box
-      bg={color}
-      // alt={name}
-      width="100%"
-      height="100vh"
-      objectFit="cover"
-    />
-  )
+  return <Box bg={color} width="100%" height="100%" />
   // return <Text>Unsupported media type.</Text>
+}
+
+const normalizeCueStack = (screenData) => {
+  if (Array.isArray(screenData)) {
+    return screenData
+  }
+
+  return screenData ? [screenData] : []
+}
+
+const cueStackKey = (cueStack) =>
+  normalizeCueStack(cueStack)
+    .map(
+      (cue) =>
+        `${cue?._id || ""}:${cue?.index ?? ""}:${cue?.screen ?? ""}:${cue?.layer ?? 0}:${cue?.file?.url || ""}:${cue?.name || ""}:${cue?.color || ""}:${normalizeCueOpacity(cue?.opacity)}`
+    )
+    .join("|")
+
+const renderCueStack = (cueStack) => {
+  const normalizedStack = normalizeCueStack(cueStack)
+
+  if (normalizedStack.length === 0) {
+    return <Text>No media available for this cue.</Text>
+  }
+
+  return normalizedStack.map((cue, index) => (
+    <Box
+      key={`${cue._id || cue.name || "cue"}-${cue.index ?? "idx"}-${cue.screen ?? "screen"}-${cue.layer ?? index}-${index}`}
+      position="absolute"
+      inset="0"
+      zIndex={100 - Number(cue.layer ?? 0)}
+      opacity={normalizeCueOpacity(cue.opacity)}
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      overflow="hidden"
+    >
+      {renderMedia(cue.file, cue.name, cue.color)}
+    </Box>
+  ))
 }
 
 const ScreenContent = ({
@@ -92,6 +104,8 @@ const ScreenContent = ({
 }) => {
   const { enter: enterAnim, exit: exitAnim } = getAnims(transitionType)
   const animStyle = (kf) => (kf ? `${kf} 500ms ease-in-out forwards` : "none")
+  const currentCueStack = normalizeCueStack(currentScreenData)
+  const currentCueNames = currentCueStack.map((cue) => cue.name).filter(Boolean)
 
   return (
     <Box
@@ -101,6 +115,8 @@ const ScreenContent = ({
       height="100vh"
       display="flex"
       flexDirection="column"
+      position="relative"
+      overflow="hidden"
     >
       {/* Header with Screen Number on the left and Cue Name on the right */}
       <Box
@@ -119,13 +135,13 @@ const ScreenContent = ({
         >
           Screen {screenNumber}
         </Text>
-        {currentScreenData && (
+        {currentCueNames.length > 0 && (
           <Text
             fontSize="xl"
             textShadow="1px 0 2px #000000"
             style={{ visibility: showText ? "visible" : "hidden" }}
           >
-            Element Name: {currentScreenData.name}
+            Element Name: {currentCueNames.join(" / ")}
           </Text>
         )}
       </Box>
@@ -133,48 +149,40 @@ const ScreenContent = ({
       {/* Animates out previous cue media, if any */}
       {previousScreenData && (
         <Box
-          key={`${previousScreenData._id}-${previousScreenData.index}-${previousScreenData.screen}`}
+          key={`previous-${cueStackKey(previousScreenData)}`}
           data-testid="outgoing-cue-layer"
           flex="1"
           display="flex"
           justifyContent="center"
           alignItems="center"
           position="absolute"
-          width="100vw"
+          inset="0"
+          width="100%"
+          height="100%"
           zIndex={1}
           animation={animStyle(exitAnim)}
         >
-          {renderMedia(
-            previousScreenData.file,
-            previousScreenData.name,
-            previousScreenData.color
-          )}
+          {renderCueStack(previousScreenData)}
         </Box>
       )}
 
       {/* Animates in current cue media */}
       <Box
-        key={`${currentScreenData?._id}-${currentScreenData?.index}-${currentScreenData?.screen}`}
+        key={`current-${cueStackKey(currentScreenData)}`}
         data-testid="incoming-cue-layer"
         flex="1"
         display="flex"
         justifyContent="center"
         alignItems="center"
         position="absolute"
-        width="100vw"
+        inset="0"
+        width="100%"
+        height="100%"
         zIndex={1}
         color="white"
         animation={animStyle(enterAnim)}
       >
-        {currentScreenData.name != undefined ? (
-          renderMedia(
-            currentScreenData.file,
-            currentScreenData.name,
-            currentScreenData.color
-          )
-        ) : (
-          <Text>No media available for this cue.</Text>
-        )}
+        {renderCueStack(currentScreenData)}
       </Box>
     </Box>
   )
@@ -220,10 +228,14 @@ const Screen = ({
           const { document: doc } = newWindow
           doc.documentElement.style.margin = "0"
           doc.documentElement.style.padding = "0"
+          doc.documentElement.style.width = "100%"
+          doc.documentElement.style.height = "100%"
           doc.documentElement.style.overflow = "hidden"
           if (doc.body?.style) {
             doc.body.style.margin = "0"
             doc.body.style.padding = "0"
+            doc.body.style.width = "100%"
+            doc.body.style.height = "100%"
             doc.body.style.overflow = "hidden"
           }
         }
@@ -272,7 +284,7 @@ const Screen = ({
       })
       setEmotionCache(cache)
     }
-  }, [windowRef.current, emotionCache])
+  }, [isWindowReady, emotionCache])
 
   useEffect(() => {
     // After the window is ready, copy the Chakra styles
@@ -283,30 +295,30 @@ const Screen = ({
 
   useEffect(() => {
     // Update media states when screenData changes
-    if (screenData) {
-      // Skip update if screen is closed
-      if (!isWindowReady && !windowRef.current) {
-        return
-      }
+    const nextScreenData = normalizeCueStack(screenData)
 
+    if (!isWindowReady && !windowRef.current) {
+      return
+    }
+
+    if (nextScreenData.length > 0) {
       if (!currentScreenData) {
         setPreviousScreenData(null)
-        setCurrentScreenData(screenData)
+        setCurrentScreenData(nextScreenData)
       } else {
-        // Skip update if media URL, name or color hasn't changed
-        if (
-          currentScreenData?.file?.url === screenData?.file?.url &&
-          currentScreenData?.name === screenData?.name &&
-          currentScreenData?.color === screenData?.color
-        ) {
+        if (cueStackKey(currentScreenData) === cueStackKey(nextScreenData)) {
           return
         }
 
         setPreviousScreenData(currentScreenData)
-        setCurrentScreenData(screenData)
+        setCurrentScreenData(nextScreenData)
       }
+    } else if (currentScreenData && cueStackKey(currentScreenData) !== "") {
+      setPreviousScreenData(currentScreenData)
+      setCurrentScreenData([])
     }
-    windowRef.current.document.title = `Screen ${screenNumber} • ${screenData.index === 0 ? "Starting Frame" : `Frame ${screenData.index}`}`
+    const firstCue = nextScreenData[0]
+    windowRef.current.document.title = `Screen ${screenNumber} • ${firstCue?.index === 0 ? "Starting Frame" : `Frame ${firstCue?.index ?? ""}`}`
   }, [screenData, currentScreenData, isWindowReady, screenNumber])
 
   // Listeners for shift-press to show screen data on screens

--- a/src/client/components/presentation/ScreensDisplay.jsx
+++ b/src/client/components/presentation/ScreensDisplay.jsx
@@ -12,6 +12,10 @@ import { Button } from "@chakra-ui/react"
 import React, { useMemo } from "react"
 import { buildCueVisualSpanMap, getCueVisualSpanFromMap } from "../utils/cueVisualSpanUtils"
 import { isType } from "../utils/fileTypeUtils"
+import { normalizeCueOpacity } from "../utils/cueOpacityUtils"
+
+const sortByLayerPriority = (cues) =>
+  [...cues].sort((firstCue, secondCue) => Number(secondCue.layer ?? 0) - Number(firstCue.layer ?? 0))
 
 // Screens display component
 export const ScreensDisplay = ({
@@ -47,78 +51,100 @@ export const ScreensDisplay = ({
     return /\.(mp4|webm|ogg|mov|m4v)$/i.test(getCleanUrl(file)) // check common video file extensions
   }
 
-  // Get the current cue for the screen
-  const getCurrentCueForScreen = (screenNumber) => {
+  const getCurrentCueStackForScreen = (screenNumber) => {
     const cuesOnScreen = screenSortedCuesByScreen[Number(screenNumber)] || []
-    if (cuesOnScreen.length === 0) return null
+    if (cuesOnScreen.length === 0) return []
 
     const currentIndex = Number(cueIndex)
 
-    // Find the cue that should be displayed on the screen based on the current cue index and the visual span of each cue
-    const cueForScreen = [...cuesOnScreen]
-      .sort((firstCue, secondCue) => Number(secondCue.index) - Number(firstCue.index))
-      .find((cue) => {
+    const cueStack = cuesOnScreen
+      .filter((cue) => {
         const cueStartIndex = Number(cue.index)
         const cueSpan = getCueVisualSpanFromMap(cue, cueVisualSpanMap)
         const cueEndIndex = cueStartIndex + cueSpan - 1
         return currentIndex >= cueStartIndex && currentIndex <= cueEndIndex
       })
 
-    return cueForScreen || null
+    return sortByLayerPriority(cueStack)
+  }
+
+  const renderCuePreview = (cue) => {
+    if (cue?.file?.url) {
+      if (isImageFile(cue.file)) {
+        return (
+          <img
+            src={cue.file.url}
+            alt={cue.name}
+            style={{ width: "100%", height: "100%", objectFit: "contain" }}
+          />
+        )
+      }
+
+      if (isVideoFile(cue.file)) {
+        return (
+          <video
+            src={cue.file.url}
+            style={{ width: "100%", height: "100%", objectFit: "contain" }}
+            autoPlay
+            loop
+            muted
+            playsInline
+          />
+        )
+      }
+
+      return (
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "center", flex: 1 }}>
+          Unsupported content type
+        </div>
+      )
+    }
+
+    return (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: "100%",
+          height: "100%",
+          backgroundColor: cue.color || "#333",
+        }}
+      />
+    )
   }
 
   return (
     <div style={{ display: "flex", justifyContent: "space-evenly", alignItems: "stretch", flexWrap: "wrap", backgroundColor: editModeBackground, gap: "10px", padding: "10px", paddingBottom: "15px", width: "100%", height: "100%", overflow: "hidden" }}>
       {Array.from({ length: screenCount }).map((_, index) => {
         const screenNumber = index + 1
-        const screenData = getCurrentCueForScreen(screenNumber)
+        const screenStack = getCurrentCueStackForScreen(screenNumber)
 
         return (
-          <div key={screenNumber} style={{ flex: 1, display: "flex", flexDirection: "column", backgroundColor: "black", color: "white", overflow: "hidden", position: "relative" }}>
-            <div style={{ position: "absolute", top: "10px", left: "10px", zIndex: 10 }}>Screen {screenNumber}</div>
+          <div key={screenNumber} style={{ flex: 1, display: "flex", flexDirection: "column", backgroundColor: "black", color: "white", overflow: "hidden", position: "relative", aspectRatio: "16/9" }}>
+            <div style={{ position: "absolute", top: "10px", left: "10px", zIndex: 200 }}>Screen {screenNumber}</div>
             <Button
               size="xs"
               colorScheme={screens[screenNumber] ? "red" : "purple"}
               onClick={() => toggleScreenVisibility(screenNumber)}
-              style={{ position: "absolute", top: "10px", right: "10px", zIndex: 10 }}
+              style={{ position: "absolute", top: "10px", right: "10px", zIndex: 200 }}
             >
               {screens[screenNumber] ? "Close" : "Open"}
             </Button>
-            {screenData ? (
-              screenData?.file?.url ? (
-                isImageFile(screenData.file) ? (
-                  <img
-                    src={screenData.file.url}
-                    alt={screenData.name}
-                    style={{ width: "100%", height: "100%", objectFit: "contain", aspectRatio: "16/9" }} />
-                ) : isVideoFile(screenData.file) ? (
-                  <video
-                    src={screenData.file.url}
-                    style={{ width: "100%", height: "100%", objectFit: "contain", aspectRatio: "16/9" }}
-                    autoPlay
-                    loop
-                    muted
-                    playsInline />
-                ) : (
-                  <div style={{ display: "flex", alignItems: "center", justifyContent: "center", flex: 1 }}>
-                    Unsupported content type
-                  </div>
-                )
-              ) : (
+            {screenStack.length > 0 ? (
+              screenStack.map((cue) => (
                 <div
+                  key={cue._id}
                   style={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    flex: 1,
-                    width: "100%",
-                    height: "100%",
-                    backgroundColor: screenData.color || "#333",
+                    position: "absolute",
+                    inset: 0,
+                    zIndex: 5 + (100 - Number(cue.layer ?? 0)),
+                    opacity: normalizeCueOpacity(cue.opacity),
                   }}
                 >
-
+                  {renderCuePreview(cue)}
                 </div>
-              )
+              ))
             ) : (
               <div style={{ display: "flex", alignItems: "center", justifyContent: "center", flex: 1 }}>
                 No content

--- a/src/client/components/presentation/ToolBox.jsx
+++ b/src/client/components/presentation/ToolBox.jsx
@@ -9,6 +9,7 @@
 import { useEffect, useState } from "react"
 import {
   Button,
+  Box,
   FormControl,
   FormLabel,
   Input,
@@ -19,7 +20,16 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
+  Slider,
+  SliderFilledTrack,
+  SliderThumb,
+  SliderTrack,
+  Text,
 } from "@chakra-ui/react"
+import {
+  opacityFromPercent,
+  opacityPercentFromCue,
+} from "../utils/cueOpacityUtils"
 
 const Toolbox = ({
   isOpen,
@@ -28,10 +38,12 @@ const Toolbox = ({
   onSave,
 }) => {
   const [cueName, setCueName] = useState("")
+  const [opacityPercent, setOpacityPercent] = useState(100)
 
   useEffect(() => {
     if (isOpen) {
       setCueName(cue?.cueName || cue?.name || "")
+      setOpacityPercent(opacityPercentFromCue(cue))
     }
   }, [cue, isOpen])
 
@@ -47,6 +59,7 @@ const Toolbox = ({
       ...cue,
       cueName: trimmedName,
       name: trimmedName,
+      opacity: opacityFromPercent(opacityPercent),
     })
     onClose()
   }
@@ -73,6 +86,34 @@ const Toolbox = ({
                 autoFocus
               />
             </FormControl>
+            {cue.cueType !== "audio" && (
+              <FormControl mt={5}>
+                <Box
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="space-between"
+                  mb={2}
+                >
+                  <FormLabel mb={0}>Layer opacity</FormLabel>
+                  <Text fontSize="sm" fontWeight="bold">
+                    {opacityPercent}%
+                  </Text>
+                </Box>
+                <Slider
+                  aria-label="Layer opacity"
+                  min={0}
+                  max={100}
+                  step={5}
+                  value={opacityPercent}
+                  onChange={setOpacityPercent}
+                >
+                  <SliderTrack>
+                    <SliderFilledTrack />
+                  </SliderTrack>
+                  <SliderThumb />
+                </Slider>
+              </FormControl>
+            )}
           </ModalBody>
           <ModalFooter>
             <Button variant="ghost" onClick={onClose}>

--- a/src/client/components/presentation/editModeDragHelpers.js
+++ b/src/client/components/presentation/editModeDragHelpers.js
@@ -3,7 +3,6 @@
 extracting cue type from drag data, and retrieving drag data from the data transfer object during a drag event. 
 * These functions help ensure that cues are placed correctly on the grid and that the appropriate previews are shown during dragging.
  */
-import { isCueTypeCompatibleWithRow } from "../utils/fileTypeUtils"
 import mediaStore from "./mediaFileStore"
 
 export const areSpanOverrideMapsEqual = (firstMap, secondMap) => {
@@ -22,11 +21,9 @@ export const getContinuationShrinkSpanOverrides = ({
   yIndex,
   cueType,
   draggedCueId,
-  screenCount,
+  isValidDropCell = true,
   getCueAtPosition,
 }) => {
-  const isValidDropCell = isCueTypeCompatibleWithRow(cueType, yIndex, screenCount)
-
   if (!isValidDropCell) {
     return {}
   }

--- a/src/client/components/presentation/useEditModeDragPreviewController.js
+++ b/src/client/components/presentation/useEditModeDragPreviewController.js
@@ -9,10 +9,13 @@
  */
 
 import { useCallback, useEffect, useRef } from "react"
-import {
-  isCueTypeCompatibleWithRow,
-  isInsidePresentationGridCell,
-} from "../utils/fileTypeUtils"
+import { laneAcceptsCueType } from "../utils/screenRowModel"
+
+const isRowIndexInsideGrid = ({ xIndex, yIndex, indexCount, rowCount }) =>
+  Number(xIndex) >= 0 &&
+  Number(xIndex) < Number(indexCount) &&
+  Number(yIndex) >= 0 &&
+  Number(yIndex) < Number(rowCount)
 
 const applyPlacementPreviewStyles = ({
   previewElement,
@@ -21,7 +24,7 @@ const applyPlacementPreviewStyles = ({
   columnWidth,
   rowHeight,
   gap,
-  yOffset = 0,
+  yTopOffset = 0,
   isValidDropCell,
   validBorder,
   invalidBorder,
@@ -34,7 +37,7 @@ const applyPlacementPreviewStyles = ({
   }
 
   previewElement.style.display = "block"
-  previewElement.style.transform = `translate3d(${xIndex * (columnWidth + gap)}px, ${(yIndex * (rowHeight + gap)) - yOffset}px, 0)`
+  previewElement.style.transform = `translate3d(${xIndex * (columnWidth + gap)}px, ${yTopOffset + (yIndex * (rowHeight + gap))}px, 0)`
   previewElement.style.borderColor = isValidDropCell
     ? validBorder
     : invalidBorder
@@ -57,7 +60,9 @@ const useEditModeDragPreviewController = ({
   headerRowHeight,
   gap,
   indexCount,
-  screenCount,
+  rows,
+  rowCount,
+  cueRowIndex,
   selectedCue,
   setDragCursorMode,
   clearExternalDragPreview,
@@ -81,8 +86,7 @@ const useEditModeDragPreviewController = ({
   const dragPreviewCellRef = useRef(null)
   const dragPlacementLockedToAnchorRef = useRef(false)
 
-  // Offset to account for header row height in preview positioning
-  const dragPreviewYOffset = Math.max(rowHeight - (headerRowHeight ?? rowHeight), 0)
+  const timelineRowsTopOffset = (headerRowHeight ?? 0) + gap
 
   // Refs for external drag preview (dragging from media pool)
   const externalPlacementPreviewRef = useRef(null)
@@ -120,7 +124,7 @@ const useEditModeDragPreviewController = ({
     hoverCellRef.current = nextCell
     hoverPreviewRef.current.style.display = "block"
     hoverPreviewRef.current.style.left = `${xIndex * (columnWidth + gap)}px`
-    hoverPreviewRef.current.style.top = `${(yIndex * (rowHeight + gap)) - dragPreviewYOffset}px`
+    hoverPreviewRef.current.style.top = `${timelineRowsTopOffset + (yIndex * (rowHeight + gap))}px`
   }
 
   const updateDragPreviewCell = (nextCell) => {
@@ -202,7 +206,7 @@ const useEditModeDragPreviewController = ({
     }
 
     const pointerXIndex = Math.floor(pointerPosition.x / (columnWidth + gap))
-    const pointerYIndex = Math.floor((pointerPosition.y + dragPreviewYOffset) / (rowHeight + gap))
+    const pointerYIndex = Math.floor((pointerPosition.y - timelineRowsTopOffset) / (rowHeight + gap))
     // When dragging a cue and locking occurs, constrain placement to the cue's original position columns
     const lockPlacementToAnchor = Boolean(
       dragPlacementLockedToAnchorRef.current && selectedCue
@@ -211,7 +215,7 @@ const useEditModeDragPreviewController = ({
       ? Number(selectedCue.index)
       : pointerXIndex
     const yIndex = lockPlacementToAnchor
-      ? Number(selectedCue.screen)
+      ? Number(cueRowIndex?.[selectedCue._id] ?? 0)
       : pointerYIndex
 
     if (!selectedCue) {
@@ -222,11 +226,11 @@ const useEditModeDragPreviewController = ({
       return
     }
 
-    const isInsideGrid = isInsidePresentationGridCell({
+    const isInsideGrid = isRowIndexInsideGrid({
       xIndex,
       yIndex,
       indexCount,
-      screenCount,
+      rowCount,
     })
 
     if (!isInsideGrid) {
@@ -237,10 +241,9 @@ const useEditModeDragPreviewController = ({
       return
     }
 
-    const isValidDropCell = isCueTypeCompatibleWithRow(
-      selectedCue.cueType,
-      yIndex,
-      screenCount
+    const isValidDropCell = laneAcceptsCueType(
+      rows?.[yIndex],
+      selectedCue.cueType
     )
 
     setDragCursorMode(isValidDropCell ? "grabbing" : "not-allowed")
@@ -262,7 +265,7 @@ const useEditModeDragPreviewController = ({
       columnWidth,
       rowHeight,
       gap,
-      yOffset: dragPreviewYOffset,
+      yTopOffset: timelineRowsTopOffset,
       isValidDropCell,
       validBorder: dragPreviewValidBorder,
       invalidBorder: dragPreviewInvalidBorder,
@@ -276,12 +279,14 @@ const useEditModeDragPreviewController = ({
     dragPreviewInvalidBorder,
     dragPreviewValidBg,
     dragPreviewValidBorder,
-    dragPreviewYOffset,
     gap,
     getContinuationPreviewSpanOverrides,
     indexCount,
     rowHeight,
-    screenCount,
+    rows,
+    rowCount,
+    timelineRowsTopOffset,
+    cueRowIndex,
     selectedCue,
     setDragCursorMode,
     setInternalDragSpanOverridesIfChanged,
@@ -374,12 +379,12 @@ const useEditModeDragPreviewController = ({
     }
 
     const xIndex = Math.floor(pointerPosition.x / (columnWidth + gap))
-    const yIndex = Math.floor((pointerPosition.y + dragPreviewYOffset) / (rowHeight + gap))
-    const isInsideGrid = isInsidePresentationGridCell({
+    const yIndex = Math.floor((pointerPosition.y - timelineRowsTopOffset) / (rowHeight + gap))
+    const isInsideGrid = isRowIndexInsideGrid({
       xIndex,
       yIndex,
       indexCount,
-      screenCount,
+      rowCount,
     })
 
     if (!isInsideGrid) {
@@ -433,7 +438,7 @@ const useEditModeDragPreviewController = ({
     }
 
     const isValidDropCell =
-      isCueTypeCompatibleWithRow(input.cueType, yIndex, screenCount) &&
+      laneAcceptsCueType(rows?.[yIndex], input.cueType) &&
       !input.isBlockedCell?.(xIndex, yIndex)
     setDragCursorMode(isValidDropCell ? idleCursor : "not-allowed")
 
@@ -461,7 +466,7 @@ const useEditModeDragPreviewController = ({
       columnWidth,
       rowHeight,
       gap,
-      yOffset: dragPreviewYOffset,
+      yTopOffset: timelineRowsTopOffset,
       isValidDropCell,
       validBorder: dragPreviewValidBorder,
       invalidBorder: dragPreviewInvalidBorder,
@@ -477,12 +482,13 @@ const useEditModeDragPreviewController = ({
     dragPreviewInvalidBorder,
     dragPreviewValidBg,
     dragPreviewValidBorder,
-    dragPreviewYOffset,
     gap,
     getContinuationPreviewSpanOverrides,
     indexCount,
     rowHeight,
-    screenCount,
+    rows,
+    rowCount,
+    timelineRowsTopOffset,
     setDragCursorMode,
     setExternalDragSpanOverridesIfChanged,
   ])

--- a/src/client/components/utils/addInitialElements.js
+++ b/src/client/components/utils/addInitialElements.js
@@ -16,7 +16,12 @@ const addInitialElements = async (presentationId, screenCount, showToast, starti
         0,
         `initial element for screen ${screen}`,
         screen,
-        null
+        null,
+        undefined,
+        undefined,
+        false,
+        0,
+        1
       )
 
       formData.append("color", startingFrameColor)

--- a/src/client/components/utils/cueOpacityUtils.js
+++ b/src/client/components/utils/cueOpacityUtils.js
@@ -1,0 +1,17 @@
+export const DEFAULT_CUE_OPACITY = 1
+
+export const normalizeCueOpacity = (opacity) => {
+  const numericOpacity = Number(opacity)
+
+  if (!Number.isFinite(numericOpacity)) {
+    return DEFAULT_CUE_OPACITY
+  }
+
+  return Math.min(1, Math.max(0, numericOpacity))
+}
+
+export const opacityPercentFromCue = (cue) =>
+  Math.round(normalizeCueOpacity(cue?.opacity) * 100)
+
+export const opacityFromPercent = (percent) =>
+  normalizeCueOpacity(Number(percent) / 100)

--- a/src/client/components/utils/cueVisualSpanUtils.js
+++ b/src/client/components/utils/cueVisualSpanUtils.js
@@ -3,7 +3,7 @@
  */
 
 export const buildCueVisualSpanMap = (cues, indexCount) => {
-  const cuesByScreen = new Map()
+  const cuesByLane = new Map()
 
   cues.forEach((cue) => {
     const cueId = cue?._id
@@ -14,17 +14,15 @@ export const buildCueVisualSpanMap = (cues, indexCount) => {
       return
     }
 
-    if (!cuesByScreen.has(cueScreen)) {
-      cuesByScreen.set(cueScreen, [])
+    const laneKey = `${cueScreen}|${Number(cue?.layer ?? 0)}`
+    if (!cuesByLane.has(laneKey)) {
+      cuesByLane.set(laneKey, [])
     }
 
-    cuesByScreen.get(cueScreen).push(cue)
+    cuesByLane.get(laneKey).push(cue)
   })
-  // Sort cues within each screen by index and calculate visual spans
-  // Visual span is determined by the distance to the next cue on the same screen, 
-  // or to the end of the index range if it's the last cue.
   const spanMap = new Map()
-  cuesByScreen.forEach((screenCues) => {
+  cuesByLane.forEach((screenCues) => {
     const sortedCues = screenCues
       .slice()
       .sort((a, b) => Number(a.index) - Number(b.index))

--- a/src/client/components/utils/formDataUtils.js
+++ b/src/client/components/utils/formDataUtils.js
@@ -13,15 +13,27 @@
  * @returns {FormData} - The populated FormData object.
  * */
 
-
-export const createFormData = (index, name, screen, file, cueId, color, loop) => {
+export const createFormData = (
+  index,
+  name,
+  screen,
+  file,
+  cueId,
+  color,
+  loop,
+  layer = 0,
+  opacity = 1,
+  continuePlayback = false
+) => {
   const formData = new FormData()
   formData.append("index", index)
   formData.append("cueName", name)
   formData.append("screen", screen)
-  
-  if (file || file===null) {
-  formData.append("image", file)
+  formData.append("layer", layer)
+  formData.append("opacity", opacity)
+
+  if (file || file === null) {
+    formData.append("image", file)
   }
   if (file && file.driveId) {
     formData.append("driveId", file.driveId)
@@ -29,7 +41,7 @@ export const createFormData = (index, name, screen, file, cueId, color, loop) =>
   if (cueId) {
     formData.append("cueId", cueId)
   }
-  if (color){
+  if (color) {
     formData.append("color", color)
   }
   if (loop === undefined) {
@@ -37,6 +49,7 @@ export const createFormData = (index, name, screen, file, cueId, color, loop) =>
   } else {
     formData.append("loop", loop)
   }
+  formData.append("continuePlayback", Boolean(continuePlayback))
 
   return formData
 }

--- a/src/client/components/utils/screenRowModel.js
+++ b/src/client/components/utils/screenRowModel.js
@@ -1,0 +1,170 @@
+export const DEFAULT_MAX_VISUAL_LAYERS = 3
+export const DEFAULT_MAX_AUDIO_TRACKS = 2
+
+const laneCount = (values) =>
+  Math.max(1, (values.length ? Math.max(...values) : 0) + 1)
+
+export const buildRowModel = (
+  screenCount,
+  cues = [],
+  collapsed = {},
+  minimumLanes = {}
+) => {
+  const rows = []
+  const cueY = {}
+  let y = 0
+
+  const pushLaneRow = (meta, laneCues) => {
+    rows.push({ ...meta, y })
+    laneCues.forEach((c) => {
+      if (c?._id != null) cueY[c._id] = y
+    })
+    y += 1
+  }
+
+  for (let s = 1; s <= screenCount; s++) {
+    const group = `screen-${s}`
+    const screenCues = cues.filter(
+      (c) => c.cueType === "visual" && Number(c.screen) === s
+    )
+    const layers = screenCues.map((c) => Number(c.layer ?? 0))
+    const presentLayers = [...new Set(layers)]
+
+    const minimumLayerCount = Number(minimumLanes[group] ?? 1)
+    const requiredLayerCount = laneCount(layers)
+
+    if (collapsed[group]) {
+      const count = Math.max(presentLayers.length, minimumLayerCount)
+      pushLaneRow(
+        {
+          kind: "screen",
+          group,
+          screen: s,
+          collapsed: true,
+          count,
+          label: `Écran ${s}`,
+          groupStart: true,
+        },
+        screenCues
+      )
+    } else {
+      const count = Math.min(
+        DEFAULT_MAX_VISUAL_LAYERS,
+        Math.max(requiredLayerCount, minimumLayerCount)
+      )
+      for (let L = 0; L < count; L++) {
+        pushLaneRow(
+          {
+            kind: "layer",
+            group,
+            screen: s,
+            layer: L,
+            label: `L${L + 1}`,
+            laneTotal: count,
+            canRemoveLayer: L > 0,
+            groupStart: L === 0,
+            screenLabel: `Écran ${s}`,
+          },
+          screenCues.filter((c) => Number(c.layer ?? 0) === L)
+        )
+      }
+    }
+  }
+
+  const audioCues = cues.filter((c) => c.cueType === "audio")
+  const audioTracks = audioCues.map((c) => Number(c.layer ?? 0))
+  const presentTracks = [...new Set(audioTracks)]
+
+  const minimumAudioTrackCount = Number(minimumLanes.audio ?? 1)
+
+  if (collapsed.audio) {
+    pushLaneRow(
+      {
+        kind: "audio",
+        group: "audio",
+        screen: Number(screenCount) + 1,
+        collapsed: true,
+        count: Math.max(presentTracks.length, minimumAudioTrackCount),
+        label: "Audio",
+        groupStart: true,
+      },
+      audioCues
+    )
+  } else {
+    const count = Math.min(
+      DEFAULT_MAX_AUDIO_TRACKS,
+      Math.max(laneCount(audioTracks), minimumAudioTrackCount)
+    )
+    for (let T = 0; T < count; T++) {
+      pushLaneRow(
+        {
+          kind: "audio-track",
+          group: "audio",
+          screen: Number(screenCount) + 1,
+          layer: T,
+          label: `A${T + 1}`,
+          laneTotal: count,
+          groupStart: T === 0,
+        },
+        audioCues.filter((c) => Number(c.layer ?? 0) === T)
+      )
+    }
+  }
+
+  return { rows, cueY, rowCount: y }
+}
+
+export const getCueRow = (cue, cueY) =>
+  cueY[cue?._id] ?? Number(cue?.screen ?? 1) - 1
+
+export const laneAt = (rows, rowIndex) => rows[rowIndex] ?? null
+
+export const laneAcceptsCueType = (lane, cueType) => {
+  if (!lane) return false
+  const isAudioLane = lane.kind === "audio-track" || lane.kind === "audio"
+  return cueType === "audio" ? isAudioLane : !isAudioLane
+}
+
+export const dropTargetAt = (rows, rowIndex, cueType, screenCount) => {
+  const lane = laneAt(rows, rowIndex)
+  if (!laneAcceptsCueType(lane, cueType)) return null
+  if (cueType === "audio") {
+    return { screen: Number(screenCount) + 1, layer: lane.layer ?? 0 }
+  }
+  return { screen: lane.screen, layer: lane.layer ?? 0 }
+}
+
+export const planVisualLayerRemoval = (cues = [], screen, layer) => {
+  const targetScreen = Number(screen)
+  const targetLayer = Number(layer)
+
+  if (!Number.isInteger(targetLayer) || targetLayer <= 0) {
+    return { removedCueIds: [], shiftedCues: [] }
+  }
+
+  return cues.reduce(
+    (plan, cue) => {
+      const cueLayer = Number(cue.layer ?? 0)
+      const isTargetScreenVisual =
+        cue.cueType === "visual" && Number(cue.screen) === targetScreen
+
+      if (!isTargetScreenVisual) {
+        return plan
+      }
+
+      if (cueLayer === targetLayer) {
+        if (cue._id != null) {
+          plan.removedCueIds.push(cue._id)
+        }
+        return plan
+      }
+
+      if (cueLayer > targetLayer) {
+        plan.shiftedCues.push({ ...cue, layer: cueLayer - 1 })
+      }
+
+      return plan
+    },
+    { removedCueIds: [], shiftedCues: [] }
+  )
+}

--- a/src/client/components/utils/screenRowModel.js
+++ b/src/client/components/utils/screenRowModel.js
@@ -42,7 +42,7 @@ export const buildRowModel = (
           screen: s,
           collapsed: true,
           count,
-          label: `Écran ${s}`,
+          label: `Screen ${s}`,
           groupStart: true,
         },
         screenCues
@@ -63,7 +63,7 @@ export const buildRowModel = (
             laneTotal: count,
             canRemoveLayer: L > 0,
             groupStart: L === 0,
-            screenLabel: `Écran ${s}`,
+            screenLabel: `Screen ${s}`,
           },
           screenCues.filter((c) => Number(c.layer ?? 0) === L)
         )

--- a/src/client/redux/presentationReducer.js
+++ b/src/client/redux/presentationReducer.js
@@ -165,7 +165,8 @@ export const createCue = (id, formData) => async (dispatch) => {
     const newCue = updatedPresentation.cues.find(
       (cue) =>
         cue.index === Number(formData.get("index")) &&
-        cue.screen === Number(formData.get("screen"))
+        cue.screen === Number(formData.get("screen")) &&
+        Number(cue.layer ?? 0) === Number(formData.get("layer") ?? 0)
     )
     dispatch(addCue(newCue))
   } catch (error) {
@@ -199,7 +200,10 @@ export const updatePresentation =
         updatedCueData.file,
         updatedCueData.cueId || cueId,
         updatedCueData.color,
-        updatedCueData.loop
+        updatedCueData.loop,
+        updatedCueData.layer ?? 0,
+        updatedCueData.opacity ?? 1,
+        updatedCueData.continuePlayback ?? false
       )
       const updatedCue = await presentationService.updateCue(
         presentationId,
@@ -227,8 +231,10 @@ export const swapCues =
         secondCueId: secondUpdatedCue._id,
         firstIndex: firstUpdatedCue.index,
         firstScreen: firstUpdatedCue.screen,
+        firstLayer: firstUpdatedCue.layer ?? 0,
         secondIndex: secondUpdatedCue.index,
         secondScreen: secondUpdatedCue.screen,
+        secondLayer: secondUpdatedCue.layer ?? 0,
       }
 
       const { firstCue: updatedFirstCue, secondCue: updatedSecondCue } =

--- a/src/client/tests/unit/EditMode.test.jsx
+++ b/src/client/tests/unit/EditMode.test.jsx
@@ -1409,3 +1409,259 @@ describe("EditMode drag swapping", () => {
     })
   })
 })
+
+describe("EditMode layer and audio track management", () => {
+  const renderWithCues = (customCues, screenCount = 2) => {
+    useSelector.mockImplementation((selector) =>
+      selector({
+        presentation: {
+          cues: customCues,
+          name: "Test presentation",
+          screenCount,
+          indexCount: 3,
+        },
+      })
+    )
+    return render(
+      <EditMode
+        id="presentation-1"
+        cues={customCues}
+        isToolboxOpen={false}
+        setIsToolboxOpen={jest.fn()}
+        cueIndex={0}
+        isAudioMuted={false}
+        toggleAudioMute={jest.fn()}
+        indexCount={3}
+      />
+    )
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    useDispatch.mockReturnValue(mockDispatch)
+    mockDragScenario = null
+  })
+
+  it("adds a new empty layer to a screen", () => {
+    const cues = [
+      {
+        _id: "l1-cue",
+        index: 0,
+        screen: 1,
+        layer: 0,
+        name: "L1 cue",
+        color: "#ffffff",
+        cueType: "visual",
+        file: null,
+      },
+    ]
+
+    renderWithCues(cues)
+
+    expect(
+      screen.queryByLabelText("Remove layer from screen 1")
+    ).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText("Add layer to screen 1"))
+
+    expect(
+      screen.getByLabelText("Remove layer from screen 1")
+    ).toBeInTheDocument()
+  })
+
+  it("removes a visual layer, shifting cues above it down and showing a success toast", async () => {
+    const cues = [
+      {
+        _id: "l1-cue",
+        index: 0,
+        screen: 1,
+        layer: 0,
+        name: "L1 cue",
+        color: "#ffffff",
+        cueType: "visual",
+        file: null,
+      },
+      {
+        _id: "l2-cue",
+        index: 0,
+        screen: 1,
+        layer: 1,
+        name: "L2 cue",
+        color: "#ffffff",
+        cueType: "visual",
+        file: null,
+      },
+      {
+        _id: "l3-cue",
+        index: 0,
+        screen: 1,
+        layer: 2,
+        name: "L3 cue",
+        color: "#ffffff",
+        cueType: "visual",
+        file: null,
+      },
+      {
+        _id: "l4-cue",
+        index: 1,
+        screen: 1,
+        layer: 3,
+        name: "L4 cue",
+        color: "#ffffff",
+        cueType: "visual",
+        file: null,
+      },
+    ]
+
+    renderWithCues(cues)
+
+    fireEvent.click(screen.getAllByLabelText("Remove layer from screen 1")[0])
+
+    await waitFor(() => {
+      expect(removeCue).toHaveBeenCalledWith("presentation-1", "l2-cue")
+    })
+
+    await waitFor(() => {
+      expect(updatePresentation).toHaveBeenCalledWith(
+        "presentation-1",
+        expect.objectContaining({ cueName: "L3 cue", layer: 1 }),
+        "l3-cue"
+      )
+    })
+
+    await waitFor(() => {
+      expect(updatePresentation).toHaveBeenCalledWith(
+        "presentation-1",
+        expect.objectContaining({ cueName: "L4 cue", layer: 2 }),
+        "l4-cue"
+      )
+    })
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith({
+        title: "Layer removed",
+        description: "Layer 2 removed from screen 1",
+        status: "success",
+      })
+    })
+  })
+
+  it("shows an error and refetches the presentation when removing a layer fails", async () => {
+    const cues = [
+      {
+        _id: "l1-cue",
+        index: 0,
+        screen: 1,
+        layer: 0,
+        name: "L1 cue",
+        color: "#ffffff",
+        cueType: "visual",
+        file: null,
+      },
+      {
+        _id: "l2-cue",
+        index: 0,
+        screen: 1,
+        layer: 1,
+        name: "L2 cue",
+        color: "#ffffff",
+        cueType: "visual",
+        file: null,
+      },
+    ]
+
+    mockDispatch.mockImplementationOnce(() =>
+      Promise.reject(new Error("remove failed"))
+    )
+
+    renderWithCues(cues)
+
+    fireEvent.click(screen.getByLabelText("Remove layer from screen 1"))
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith({
+        title: "Error",
+        description: "remove failed",
+        status: "error",
+      })
+    })
+
+    expect(fetchPresentationInfo).toHaveBeenCalledWith("presentation-1")
+  })
+
+  it("adds a new empty audio track", () => {
+    renderWithCues([])
+
+    expect(screen.queryByText("A2")).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText("Add audio track"))
+
+    expect(screen.getByText("A2")).toBeInTheDocument()
+  })
+
+  it("stacks collapsed-preview cues by layer and falls back to layer 0 when a cue has no layer", () => {
+    const cues = [
+      {
+        _id: "l1-cue",
+        index: 0,
+        screen: 1,
+        name: "L1 cue",
+        color: "#111111",
+        cueType: "visual",
+        file: null,
+      },
+      {
+        _id: "l2-cue",
+        index: 0,
+        screen: 1,
+        layer: 2,
+        name: "L2 cue",
+        color: "#222222",
+        cueType: "visual",
+        file: null,
+      },
+      {
+        _id: "l3-cue",
+        index: 0,
+        screen: 1,
+        layer: 1,
+        name: "L3 cue",
+        color: "#333333",
+        cueType: "visual",
+        file: null,
+      },
+      {
+        _id: "l4-cue",
+        index: 0,
+        screen: 1,
+        layer: 3,
+        name: "L4 image cue",
+        cueType: "visual",
+        file: { url: "https://example.com/preview.jpg", type: "image/jpeg" },
+      },
+      {
+        _id: "l5-cue",
+        index: 0,
+        screen: 1,
+        layer: 4,
+        name: "L5 video cue",
+        cueType: "visual",
+        file: { url: "https://example.com/preview.mp4", type: "video/mp4" },
+      },
+    ]
+
+    renderWithCues(cues)
+
+    fireEvent.click(screen.getAllByLabelText("Collapse row group")[0])
+
+    const preview = screen.getByTestId("collapsed-preview-screen-1-0")
+    expect(preview).toBeInTheDocument()
+    expect(preview.textContent).toContain("L1 cue")
+    expect(
+      preview.querySelector('img[src="https://example.com/preview.jpg"]')
+    ).toBeTruthy()
+    expect(
+      preview.querySelector('video[src="https://example.com/preview.mp4"]')
+    ).toBeTruthy()
+  })
+})

--- a/src/client/tests/unit/EditMode.test.jsx
+++ b/src/client/tests/unit/EditMode.test.jsx
@@ -300,6 +300,56 @@ describe("EditMode drag swapping", () => {
     expect(updatePresentation).not.toHaveBeenCalled()
   })
 
+  it("hides cues from a collapsed screen group without remapping other screens", () => {
+    const layeredCues = [
+      {
+        _id: "screen-1-layer-1",
+        index: 0,
+        screen: 1,
+        layer: 0,
+        name: "Screen 1 L1",
+        color: "#ffffff",
+        cueType: "visual",
+        file: null,
+      },
+      {
+        _id: "screen-1-layer-2",
+        index: 0,
+        screen: 1,
+        layer: 1,
+        name: "Screen 1 L2",
+        color: "#111111",
+        cueType: "visual",
+        file: null,
+      },
+      {
+        _id: "screen-2-layer-1",
+        index: 0,
+        screen: 2,
+        layer: 0,
+        name: "Screen 2 L1",
+        color: "#222222",
+        cueType: "visual",
+        file: null,
+      },
+    ]
+
+    renderEditMode(layeredCues)
+
+    expect(screen.getByTestId("cue-Screen 1 L1")).toBeInTheDocument()
+    expect(screen.getByTestId("cue-Screen 1 L2")).toBeInTheDocument()
+    expect(screen.getByTestId("cue-Screen 2 L1")).toBeInTheDocument()
+
+    fireEvent.click(screen.getAllByLabelText("Collapse row group")[0])
+
+    expect(screen.queryByTestId("cue-Screen 1 L1")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("cue-Screen 1 L2")).not.toBeInTheDocument()
+    expect(
+      screen.getByTestId("collapsed-preview-screen-1-0")
+    ).toBeInTheDocument()
+    expect(screen.getByTestId("cue-Screen 2 L1")).toBeInTheDocument()
+  })
+
   it("does not swap when dropped on a continuation cell", () => {
     mockDragScenario = "visualSwapVisual"
 
@@ -567,12 +617,22 @@ describe("EditMode drag swapping", () => {
       clientY: 120,
     })
 
+    const dropEvent = createEvent.drop(dropArea)
+    Object.defineProperty(dropEvent, "dataTransfer", {
+      value: dataTransfer,
+      configurable: true,
+    })
+    Object.defineProperty(dropEvent, "clientX", {
+      value: 330,
+      configurable: true,
+    })
+    Object.defineProperty(dropEvent, "clientY", {
+      value: 120,
+      configurable: true,
+    })
+
     await act(async () => {
-      fireEvent.drop(dropArea, {
-        dataTransfer,
-        clientX: 330,
-        clientY: 120,
-      })
+      fireEvent(dropArea, dropEvent)
     })
 
     await waitFor(() => {

--- a/src/client/tests/unit/EditModeContainerAudio.test.jsx
+++ b/src/client/tests/unit/EditModeContainerAudio.test.jsx
@@ -72,6 +72,13 @@ jest.mock("../../components/presentation/PresentationPlaybackControls", () => {
         data-testid="mock-playback-controls"
         data-audio-src={props.audioSourceURL}
         data-audio-loop={String(props.audioLoop)}
+        data-audio-track-count={String(props.audioTracks?.length ?? 0)}
+        data-audio-track-srcs={(props.audioTracks || [])
+          .map((track) => track.src)
+          .join("|")}
+        data-audio-track-continuous={(props.audioTracks || [])
+          .map((track) => String(Boolean(track.continuePlayback)))
+          .join("|")}
       />
     )
   }
@@ -81,6 +88,7 @@ jest.mock("../../components/utils/ResizeElement", () => jest.fn())
 
 describe("EditModeContainer audio loop wiring", () => {
   const dispatchMock = jest.fn()
+  let loadSpy
 
   // Audio row is screenCount + 1, so with screenCount 2 the audio row is 3.
   const makeCues = (loop) => [
@@ -115,6 +123,9 @@ describe("EditModeContainer audio loop wiring", () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    loadSpy = jest
+      .spyOn(window.HTMLMediaElement.prototype, "load")
+      .mockImplementation(() => {})
     useDispatch.mockReturnValue(dispatchMock)
     useSelector.mockImplementation((selector) =>
       selector({
@@ -124,6 +135,10 @@ describe("EditModeContainer audio loop wiring", () => {
         },
       })
     )
+  })
+
+  afterEach(() => {
+    loadSpy.mockRestore()
   })
 
   test("passes audioLoop=true through to the playback controls when the cue loops", () => {
@@ -146,5 +161,45 @@ describe("EditModeContainer audio loop wiring", () => {
       "https://example.com/track.mp3"
     )
     expect(controls).toHaveAttribute("data-audio-loop", "false")
+  })
+
+  test("passes every active audio track through to the playback controls", () => {
+    const cues = [
+      {
+        _id: "cue-audio-a1",
+        index: 0,
+        screen: 3,
+        layer: 0,
+        name: "Music",
+        cueType: "audio",
+        file: { type: "audio/mpeg", url: "https://example.com/music.mp3" },
+        loop: true,
+        continuePlayback: true,
+      },
+      {
+        _id: "cue-audio-a2",
+        index: 0,
+        screen: 3,
+        layer: 1,
+        name: "SFX",
+        cueType: "audio",
+        file: { type: "audio/mpeg", url: "https://example.com/sfx.mp3" },
+        loop: false,
+        continuePlayback: false,
+      },
+    ]
+
+    render(<EditModeContainer {...baseProps} cues={cues} />)
+
+    const controls = screen.getByTestId("mock-playback-controls")
+    expect(controls).toHaveAttribute("data-audio-track-count", "2")
+    expect(controls).toHaveAttribute(
+      "data-audio-track-srcs",
+      "https://example.com/music.mp3|https://example.com/sfx.mp3"
+    )
+    expect(controls).toHaveAttribute(
+      "data-audio-track-continuous",
+      "true|false"
+    )
   })
 })

--- a/src/client/tests/unit/EditModeHeaders.test.jsx
+++ b/src/client/tests/unit/EditModeHeaders.test.jsx
@@ -1,0 +1,93 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { RowHeaders } from "../../components/presentation/EditModeHeaders"
+import { buildRowModel } from "../../components/utils/screenRowModel"
+
+describe("EditModeHeaders RowHeaders", () => {
+  const screenCount = 2
+  const cues = [{ _id: "c1", cueType: "visual", screen: 1, layer: 1, index: 0 }]
+  const rowModel = buildRowModel(screenCount, cues, {})
+
+  const renderRowHeaders = (overrides = {}) => {
+    const headerActionsRef = {
+      current: {
+        toggleAudioMute: jest.fn(),
+        increaseScreenCount: jest.fn(),
+        decreaseScreenCount: jest.fn(),
+      },
+    }
+    const props = {
+      rows: rowModel.rows,
+      collapsedGroups: {},
+      onToggleGroupCollapsed: jest.fn(),
+      onAddVisualLayer: jest.fn(),
+      onRemoveVisualLayer: jest.fn(),
+      onAddAudioTrack: jest.fn(),
+      maxVisualLayers: 3,
+      maxAudioTracks: 2,
+      gap: 4,
+      rowHeight: 60,
+      screenCount,
+      isAudioMuted: false,
+      screenIcon: "screen-icon.svg",
+      headerActionsRef,
+      ...overrides,
+    }
+
+    render(<RowHeaders {...props} />)
+    return { props, headerActionsRef }
+  }
+
+  test("toggles audio mute", () => {
+    const { headerActionsRef } = renderRowHeaders()
+
+    fireEvent.mouseDown(screen.getByLabelText("Mute/unmute audio"))
+
+    expect(headerActionsRef.current.toggleAudioMute).toHaveBeenCalledTimes(1)
+  })
+
+  test("removes a visual layer", () => {
+    const { props } = renderRowHeaders()
+
+    fireEvent.click(screen.getByLabelText("Remove layer from screen 1"))
+
+    expect(props.onRemoveVisualLayer).toHaveBeenCalledWith(1, 1)
+  })
+
+  test("adds a visual layer", () => {
+    const { props } = renderRowHeaders()
+
+    fireEvent.click(screen.getByLabelText("Add layer to screen 2"))
+
+    expect(props.onAddVisualLayer).toHaveBeenCalledWith(2)
+  })
+
+  test("increases the screen count", () => {
+    const { headerActionsRef } = renderRowHeaders()
+
+    fireEvent.click(screen.getByLabelText("Add screen"))
+
+    expect(headerActionsRef.current.increaseScreenCount).toHaveBeenCalledTimes(
+      1
+    )
+  })
+
+  test("decreases the screen count", () => {
+    const { headerActionsRef } = renderRowHeaders()
+
+    fireEvent.click(screen.getByLabelText("Remove screen"))
+
+    expect(headerActionsRef.current.decreaseScreenCount).toHaveBeenCalledTimes(
+      1
+    )
+  })
+
+  test("adds an audio track", () => {
+    const { props } = renderRowHeaders()
+
+    fireEvent.click(screen.getByLabelText("Add audio track"))
+
+    expect(props.onAddAudioTrack).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/client/tests/unit/EditModeHeaders.test.jsx
+++ b/src/client/tests/unit/EditModeHeaders.test.jsx
@@ -90,4 +90,138 @@ describe("EditModeHeaders RowHeaders", () => {
 
     expect(props.onAddAudioTrack).toHaveBeenCalledTimes(1)
   })
+
+  test("mutes/unmutes label reflects an already-muted state", () => {
+    renderRowHeaders({ isAudioMuted: true })
+
+    expect(screen.getByLabelText("Mute/unmute audio")).toHaveAttribute(
+      "title",
+      "Unmute audio"
+    )
+  })
+
+  test("shows the collapsed audio track count", () => {
+    renderRowHeaders({
+      rows: [
+        {
+          kind: "audio",
+          group: "audio-collapsed",
+          screen: 9,
+          collapsed: true,
+          groupStart: true,
+          y: 0,
+          count: 2,
+          label: "Audio",
+        },
+      ],
+    })
+
+    expect(screen.getByText("2 tracks")).toBeInTheDocument()
+  })
+
+  test("treats a layer row with no layer value as the base layer", () => {
+    renderRowHeaders({
+      rows: [
+        {
+          kind: "layer",
+          group: "screen-9",
+          screen: 9,
+          groupStart: true,
+          y: 0,
+          label: "L1",
+        },
+      ],
+      screenCount: 9,
+    })
+
+    expect(
+      screen.queryByLabelText("Remove layer from screen 9")
+    ).not.toBeInTheDocument()
+  })
+
+  test("disables removal for a layer row flagged as non-removable", () => {
+    renderRowHeaders({
+      rows: [
+        {
+          kind: "layer",
+          group: "screen-9",
+          screen: 9,
+          layer: 1,
+          groupStart: true,
+          y: 0,
+          label: "L2",
+          canRemoveLayer: false,
+        },
+      ],
+      screenCount: 9,
+    })
+
+    const removeButton = screen.getByLabelText("Remove layer from screen 9")
+    expect(removeButton).toHaveAttribute(
+      "title",
+      "Base layer cannot be removed"
+    )
+    expect(removeButton).toBeDisabled()
+  })
+
+  test("falls back to a default lane count for a layer row with no count metadata", () => {
+    renderRowHeaders({
+      rows: [
+        {
+          kind: "layer",
+          group: "screen-9",
+          screen: 9,
+          layer: 0,
+          groupStart: true,
+          y: 0,
+          label: "L1",
+        },
+      ],
+      screenCount: 9,
+    })
+
+    expect(screen.getByLabelText("Add layer to screen 9")).toBeInTheDocument()
+  })
+
+  test("falls back to a default lane count for an audio row with no count metadata", () => {
+    renderRowHeaders({
+      rows: [
+        {
+          kind: "audio-track",
+          group: "audio",
+          screen: 10,
+          layer: 0,
+          groupStart: true,
+          y: 0,
+          label: "A1",
+        },
+      ],
+    })
+
+    expect(screen.getByLabelText("Add audio track")).not.toBeDisabled()
+  })
+
+  test("evaluates the max screen count when a full last screen still needs an add-screen control", () => {
+    renderRowHeaders({
+      rows: [
+        {
+          kind: "layer",
+          group: "screen-12",
+          screen: 12,
+          layer: 0,
+          groupStart: true,
+          y: 0,
+          label: "L1",
+          count: 3,
+          laneTotal: 3,
+        },
+      ],
+      screenCount: 12,
+    })
+
+    expect(
+      screen.queryByLabelText("Add layer to screen 12")
+    ).not.toBeInTheDocument()
+    expect(screen.queryByLabelText("Add screen")).not.toBeInTheDocument()
+  })
 })

--- a/src/client/tests/unit/GridLayoutComponent.test.jsx
+++ b/src/client/tests/unit/GridLayoutComponent.test.jsx
@@ -594,4 +594,176 @@ describe("GridLayoutComponent", () => {
 
     consoleLogSpy.mockRestore()
   })
+
+  it("shrinks the continuation divider when there is no gap between cells", () => {
+    const cues = [
+      {
+        _id: "visual-1",
+        index: 0,
+        screen: 1,
+        name: "Visual cue 1",
+        cueType: "visual",
+        file: {
+          type: "image/png",
+          url: "https://example.com/1.png",
+          name: "1.png",
+        },
+      },
+      {
+        _id: "visual-2",
+        index: 1,
+        screen: 1,
+        name: "Visual cue 2",
+        cueType: "visual",
+        file: {
+          type: "image/png",
+          url: "https://example.com/2.png",
+          name: "2.png",
+        },
+      },
+    ]
+
+    renderGrid(
+      cues,
+      [
+        { i: "visual-1", x: 0, y: 0, w: 1, h: 1, static: false },
+        { i: "visual-2", x: 1, y: 0, w: 9, h: 1, static: false },
+      ],
+      { gap: 0 }
+    )
+
+    expect(
+      screen.getByTestId("cue-continuation-overlay-visual-2")
+    ).toBeInTheDocument()
+  })
+
+  it("renders a color background in the continuation preview for a color-only cue", () => {
+    const cues = [
+      {
+        _id: "visual-1",
+        index: 0,
+        screen: 1,
+        name: "Visual cue 1",
+        cueType: "visual",
+        file: {
+          type: "image/png",
+          url: "https://example.com/1.png",
+          name: "1.png",
+        },
+      },
+      {
+        _id: "visual-2",
+        index: 1,
+        screen: 1,
+        name: "Visual cue 2",
+        cueType: "visual",
+        file: null,
+      },
+    ]
+
+    renderGrid(cues, [
+      { i: "visual-1", x: 0, y: 0, w: 1, h: 1, static: false },
+      { i: "visual-2", x: 1, y: 0, w: 9, h: 1, static: false },
+    ])
+
+    const anchorOverlay = screen.getByTestId(
+      "cue-anchor-media-overlay-visual-2"
+    )
+    const continuationOverlay = screen.getByTestId(
+      "cue-continuation-overlay-visual-2"
+    )
+    expect(anchorOverlay.querySelector("img,video")).toBeNull()
+    expect(continuationOverlay.querySelector("img,video")).toBeNull()
+  })
+
+  it("falls back to a name-based media url for the continuation preview when the file has no url", () => {
+    const cues = [
+      {
+        _id: "visual-1",
+        index: 0,
+        screen: 1,
+        name: "Visual cue 1",
+        cueType: "visual",
+        file: {
+          type: "image/png",
+          url: "https://example.com/1.png",
+          name: "1.png",
+        },
+      },
+      {
+        _id: "visual-2",
+        index: 1,
+        screen: 1,
+        name: "Visual cue 2",
+        cueType: "visual",
+        file: { name: "no-url.png" },
+      },
+    ]
+
+    renderGrid(cues, [
+      { i: "visual-1", x: 0, y: 0, w: 1, h: 1, static: false },
+      { i: "visual-2", x: 1, y: 0, w: 9, h: 1, static: false },
+    ])
+
+    const anchorOverlay = screen.getByTestId(
+      "cue-anchor-media-overlay-visual-2"
+    )
+    expect(anchorOverlay.querySelector('img[src="/no-url.png"]')).toBeTruthy()
+  })
+
+  it("uses the provided interaction cursor while copying", () => {
+    const cues = [
+      {
+        _id: "visual-1",
+        index: 0,
+        screen: 1,
+        name: "Visual cue 1",
+        cueType: "visual",
+        file: {
+          type: "image/png",
+          url: "https://example.com/1.png",
+          name: "1.png",
+        },
+      },
+    ]
+
+    renderGrid(
+      cues,
+      [{ i: "visual-1", x: 0, y: 0, w: 1, h: 1, static: false }],
+      { isCopied: true, interactionCursor: "not-allowed" }
+    )
+
+    const contentBox = document.querySelector(
+      '[data-cue-content-id="visual-1"]'
+    )
+    expect(contentBox).toHaveStyle({ cursor: "not-allowed" })
+  })
+
+  it("defaults to a copy cursor while copying with no interaction cursor override", () => {
+    const cues = [
+      {
+        _id: "visual-1",
+        index: 0,
+        screen: 1,
+        name: "Visual cue 1",
+        cueType: "visual",
+        file: {
+          type: "image/png",
+          url: "https://example.com/1.png",
+          name: "1.png",
+        },
+      },
+    ]
+
+    renderGrid(
+      cues,
+      [{ i: "visual-1", x: 0, y: 0, w: 1, h: 1, static: false }],
+      { isCopied: true }
+    )
+
+    const contentBox = document.querySelector(
+      '[data-cue-content-id="visual-1"]'
+    )
+    expect(contentBox).toHaveStyle({ cursor: "copy" })
+  })
 })

--- a/src/client/tests/unit/GridLayoutComponent.test.jsx
+++ b/src/client/tests/unit/GridLayoutComponent.test.jsx
@@ -474,4 +474,124 @@ describe("GridLayoutComponent", () => {
       )
     })
   })
+
+  it("shows the continuous playback control as enabled when the cue already has it on", () => {
+    const cue = {
+      _id: "audio-2",
+      index: 0,
+      screen: 3,
+      name: "Audio cue 2",
+      color: "#ffffff",
+      cueType: "audio",
+      file: {
+        type: "audio/mpeg",
+        url: "https://example.com/audio.mp3",
+        name: "audio.mp3",
+      },
+      loop: false,
+      continuePlayback: true,
+    }
+
+    renderGrid(
+      [cue],
+      [{ i: "audio-2", x: 0, y: 2, w: 10, h: 1, static: false }]
+    )
+
+    fireEvent.click(screen.getByTestId("cue-menu-button-audio-2"))
+
+    expect(screen.getByLabelText("Continue audio Audio cue 2")).toHaveAttribute(
+      "title",
+      "Disable continuous playback"
+    )
+  })
+
+  it("handles continuous playback toggle action that disables it", async () => {
+    mockDispatch.mockResolvedValueOnce({
+      payload: {
+        continuePlayback: false,
+        name: "Audio cue",
+      },
+    })
+
+    const cue = {
+      _id: "audio-1",
+      index: 0,
+      screen: 3,
+      name: "Audio cue",
+      color: "#ffffff",
+      cueType: "audio",
+      file: {
+        type: "audio/mpeg",
+        url: "https://example.com/audio.mp3",
+        name: "audio.mp3",
+      },
+      loop: true,
+      continuePlayback: true,
+    }
+
+    renderGrid(
+      [cue],
+      [{ i: "audio-1", x: 0, y: 2, w: 10, h: 1, static: false }]
+    )
+
+    fireEvent.click(screen.getByTestId("cue-menu-button-audio-1"))
+    fireEvent.mouseDown(screen.getByLabelText("Continue audio Audio cue"))
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Continuous audio disabled",
+          description: "Audio cue will stop with the sequence",
+        })
+      )
+    })
+  })
+
+  it("logs an error if showing the continuous playback toast fails", async () => {
+    mockDispatch.mockResolvedValueOnce({
+      payload: {
+        continuePlayback: true,
+        name: "Audio cue",
+      },
+    })
+    mockShowToast.mockImplementationOnce(() => {
+      throw new Error("toast failed")
+    })
+    const consoleLogSpy = jest
+      .spyOn(console, "log")
+      .mockImplementation(() => {})
+
+    const cue = {
+      _id: "audio-1",
+      index: 0,
+      screen: 3,
+      name: "Audio cue",
+      color: "#ffffff",
+      cueType: "audio",
+      file: {
+        type: "audio/mpeg",
+        url: "https://example.com/audio.mp3",
+        name: "audio.mp3",
+      },
+      loop: true,
+      continuePlayback: false,
+    }
+
+    renderGrid(
+      [cue],
+      [{ i: "audio-1", x: 0, y: 2, w: 10, h: 1, static: false }]
+    )
+
+    fireEvent.click(screen.getByTestId("cue-menu-button-audio-1"))
+    fireEvent.mouseDown(screen.getByLabelText("Continue audio Audio cue"))
+
+    await waitFor(() => {
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "Error printing toast about continuous audio toggle: ",
+        expect.any(Error)
+      )
+    })
+
+    consoleLogSpy.mockRestore()
+  })
 })

--- a/src/client/tests/unit/GridLayoutComponent.test.jsx
+++ b/src/client/tests/unit/GridLayoutComponent.test.jsx
@@ -1,4 +1,3 @@
-
 /*
  * Grid layout component unit tests.
  * Covers cue rendering states, drag indicators, media/audio behavior, and cue menu actions
@@ -67,6 +66,19 @@ describe("GridLayoutComponent", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     useDispatch.mockReturnValue(mockDispatch)
+  })
+
+  it("renders background cells for empty rows", () => {
+    renderGrid([], [], { indexCount: 3, rowCount: 2 })
+
+    expect(screen.getByTestId("grid-empty-cells")).toBeInTheDocument()
+    expect(screen.getByTestId("grid-empty-cell-0-0")).toBeInTheDocument()
+    expect(screen.getByTestId("grid-empty-cell-1-2")).toBeInTheDocument()
+
+    const firstCallProps = mockGridLayout.mock.calls[0][0]
+    expect(firstCallProps.width).toBe(470)
+    expect(firstCallProps.maxRows).toBe(2)
+    expect(firstCallProps.style.minHeight).toBe("210px")
   })
 
   it("does not wire deprecated onDragStop behavior", () => {
@@ -414,6 +426,50 @@ describe("GridLayoutComponent", () => {
         expect.objectContaining({
           cueId: "audio-1",
           loop: true,
+        })
+      )
+    })
+  })
+
+  it("handles continuous playback toggle action for audio cue", async () => {
+    mockDispatch.mockResolvedValueOnce({
+      payload: {
+        continuePlayback: true,
+        name: "Audio cue",
+      },
+    })
+
+    const cue = {
+      _id: "audio-1",
+      index: 0,
+      screen: 3,
+      name: "Audio cue",
+      color: "#ffffff",
+      cueType: "audio",
+      file: {
+        type: "audio/mpeg",
+        url: "https://example.com/audio.mp3",
+        name: "audio.mp3",
+      },
+      loop: true,
+      continuePlayback: false,
+    }
+
+    renderGrid(
+      [cue],
+      [{ i: "audio-1", x: 0, y: 2, w: 10, h: 1, static: false }]
+    )
+
+    fireEvent.click(screen.getByTestId("cue-menu-button-audio-1"))
+    fireEvent.mouseDown(screen.getByLabelText("Continue audio Audio cue"))
+
+    await waitFor(() => {
+      expect(updatePresentation).toHaveBeenCalledWith(
+        "presentation-1",
+        expect.objectContaining({
+          cueId: "audio-1",
+          loop: true,
+          continuePlayback: true,
         })
       )
     })

--- a/src/client/tests/unit/PresentationPlaybackControls.test.jsx
+++ b/src/client/tests/unit/PresentationPlaybackControls.test.jsx
@@ -341,4 +341,40 @@ describe("PresentationPlaybackControls", () => {
       expect(pauseSpy).toHaveBeenCalledTimes(1)
     })
   })
+
+  test("falls back to a src-based key when an audio track has no id", () => {
+    const { container } = renderControls({
+      isAutoplaying: true,
+      audioTracks: [{ src: "https://example.com/no-id.mp3", loop: false }],
+    })
+
+    expect(
+      container.querySelector('audio[src="https://example.com/no-id.mp3"]')
+    ).toBeInTheDocument()
+  })
+
+  test("does not attempt to control an audio track that has no source", () => {
+    const { container } = renderControls({
+      isAutoplaying: true,
+      audioTracks: [{ id: "track-empty", src: "", loop: false }],
+    })
+
+    expect(container.querySelector("audio")).not.toBeInTheDocument()
+    expect(playSpy).not.toHaveBeenCalled()
+  })
+
+  test("does not throw when play() does not return a promise", async () => {
+    playSpy.mockImplementation(() => undefined)
+
+    renderControls({
+      isAutoplaying: true,
+      audioTracks: [
+        { id: "track-a1", src: "https://example.com/music.mp3", loop: true },
+      ],
+    })
+
+    await waitFor(() => {
+      expect(playSpy).toHaveBeenCalled()
+    })
+  })
 })

--- a/src/client/tests/unit/PresentationPlaybackControls.test.jsx
+++ b/src/client/tests/unit/PresentationPlaybackControls.test.jsx
@@ -4,7 +4,7 @@
  * autoplay start/stop behavior, and autoplay interval input handling.
  */
 import React from "react"
-import { render, screen, fireEvent } from "@testing-library/react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import PresentationPlaybackControls from "../../components/presentation/PresentationPlaybackControls"
 
@@ -27,6 +27,23 @@ const renderControls = (overrideProps = {}) => {
 }
 
 describe("PresentationPlaybackControls", () => {
+  let playSpy
+  let pauseSpy
+
+  beforeEach(() => {
+    playSpy = jest
+      .spyOn(window.HTMLMediaElement.prototype, "play")
+      .mockImplementation(() => Promise.resolve())
+    pauseSpy = jest
+      .spyOn(window.HTMLMediaElement.prototype, "pause")
+      .mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    playSpy.mockRestore()
+    pauseSpy.mockRestore()
+  })
+
   test("shows Frame 0 at cueIndex 0", () => {
     renderControls({ cueIndex: 0 })
 
@@ -132,5 +149,196 @@ describe("PresentationPlaybackControls", () => {
     })
 
     expect(container.querySelector("audio")).not.toHaveAttribute("loop")
+  })
+
+  test("does not start audio when an audio cue appears while autoplay is stopped", async () => {
+    renderControls({
+      audioSourceURL: "https://example.com/cue.mp3",
+      isAutoplaying: false,
+    })
+
+    await waitFor(() => {
+      expect(pauseSpy).toHaveBeenCalled()
+    })
+    expect(playSpy).not.toHaveBeenCalled()
+  })
+
+  test("starts and stops audio with autoplay state", async () => {
+    const { rerender, props } = renderControls({
+      audioSourceURL: "https://example.com/cue.mp3",
+      isAutoplaying: false,
+    })
+
+    expect(playSpy).not.toHaveBeenCalled()
+
+    rerender(
+      <PresentationPlaybackControls
+        {...props}
+        audioSourceURL="https://example.com/cue.mp3"
+        isAutoplaying={true}
+      />
+    )
+
+    await waitFor(() => {
+      expect(playSpy).toHaveBeenCalled()
+    })
+
+    rerender(
+      <PresentationPlaybackControls
+        {...props}
+        audioSourceURL="https://example.com/cue.mp3"
+        isAutoplaying={false}
+      />
+    )
+
+    await waitFor(() => {
+      expect(pauseSpy).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  test("plays every active audio track when autoplay starts", async () => {
+    const { container } = renderControls({
+      isAutoplaying: true,
+      audioTracks: [
+        {
+          id: "track-a1",
+          src: "https://example.com/music.mp3",
+          loop: true,
+        },
+        {
+          id: "track-a2",
+          src: "https://example.com/sfx.mp3",
+          loop: false,
+        },
+      ],
+    })
+
+    const audioElements = container.querySelectorAll("audio")
+    expect(audioElements).toHaveLength(2)
+    expect(audioElements[0]).toHaveAttribute(
+      "src",
+      "https://example.com/music.mp3"
+    )
+    expect(audioElements[0]).toHaveAttribute("loop")
+    expect(audioElements[1]).toHaveAttribute(
+      "src",
+      "https://example.com/sfx.mp3"
+    )
+    expect(audioElements[1]).not.toHaveAttribute("loop")
+
+    await waitFor(() => {
+      expect(playSpy).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  test("keeps a continuous audio track playing after autoplay reaches the end", async () => {
+    const { rerender, props } = renderControls({
+      isAutoplaying: true,
+      audioTracks: [
+        {
+          id: "track-a1",
+          src: "https://example.com/music.mp3",
+          loop: true,
+          continuePlayback: true,
+        },
+      ],
+    })
+
+    await waitFor(() => {
+      expect(playSpy).toHaveBeenCalledTimes(1)
+    })
+    expect(pauseSpy).not.toHaveBeenCalled()
+
+    rerender(
+      <PresentationPlaybackControls
+        {...props}
+        isAutoplaying={false}
+        allowContinuousAudio={true}
+        audioTracks={[
+          {
+            id: "track-a1",
+            src: "https://example.com/music.mp3",
+            loop: true,
+            continuePlayback: true,
+          },
+        ]}
+      />
+    )
+
+    expect(pauseSpy).not.toHaveBeenCalled()
+  })
+
+  test("keeps a looped audio track playing after autoplay reaches the end", async () => {
+    const { rerender, props } = renderControls({
+      isAutoplaying: true,
+      audioTracks: [
+        {
+          id: "track-a1",
+          src: "https://example.com/music.mp3",
+          loop: true,
+          continuePlayback: false,
+        },
+      ],
+    })
+
+    await waitFor(() => {
+      expect(playSpy).toHaveBeenCalledTimes(1)
+    })
+
+    rerender(
+      <PresentationPlaybackControls
+        {...props}
+        isAutoplaying={false}
+        allowContinuousAudio={true}
+        audioTracks={[
+          {
+            id: "track-a1",
+            src: "https://example.com/music.mp3",
+            loop: true,
+            continuePlayback: false,
+          },
+        ]}
+      />
+    )
+
+    expect(pauseSpy).not.toHaveBeenCalled()
+  })
+
+  test("stops a continuous audio track on manual autoplay stop", async () => {
+    const { rerender, props } = renderControls({
+      isAutoplaying: true,
+      audioTracks: [
+        {
+          id: "track-a1",
+          src: "https://example.com/music.mp3",
+          loop: true,
+          continuePlayback: true,
+        },
+      ],
+    })
+
+    await waitFor(() => {
+      expect(playSpy).toHaveBeenCalledTimes(1)
+    })
+
+    rerender(
+      <PresentationPlaybackControls
+        {...props}
+        isAutoplaying={false}
+        allowContinuousAudio={false}
+        audioTracks={[
+          {
+            id: "track-a1",
+            src: "https://example.com/music.mp3",
+            loop: true,
+            continuePlayback: true,
+          },
+        ]}
+      />
+    )
+
+    await waitFor(() => {
+      expect(pauseSpy).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/src/client/tests/unit/Screen.test.jsx
+++ b/src/client/tests/unit/Screen.test.jsx
@@ -815,4 +815,65 @@ describe("Screen", () => {
       ).toHaveLength(0)
     })
   })
+
+  test("renders a cue that has no id, name, index or screen", async () => {
+    const screenData = {
+      file: {
+        url: "http://example.com/minimal.jpg",
+        type: "image/jpg",
+        name: "minimal.jpg",
+      },
+    }
+
+    await act(async () => {
+      render(
+        <Screen
+          screenNumber={1}
+          screenData={screenData}
+          isVisible={true}
+          onClose={() => {}}
+        />
+      )
+    })
+
+    await waitFor(() => {
+      const popup = window.open.mock.results.at(-1).value
+      expect(
+        popup.document.body.querySelector(
+          'img[src="http://example.com/minimal.jpg"]'
+        )
+      ).toBeTruthy()
+    })
+  })
+
+  test("falls back to the cue name for its key when id is missing", async () => {
+    const screenData = {
+      file: {
+        url: "http://example.com/named-only.jpg",
+        type: "image/jpg",
+        name: "named-only.jpg",
+      },
+      name: "named-only-cue",
+    }
+
+    await act(async () => {
+      render(
+        <Screen
+          screenNumber={1}
+          screenData={screenData}
+          isVisible={true}
+          onClose={() => {}}
+        />
+      )
+    })
+
+    await waitFor(() => {
+      const popup = window.open.mock.results.at(-1).value
+      expect(
+        popup.document.body.querySelector(
+          'img[src="http://example.com/named-only.jpg"]'
+        )
+      ).toBeTruthy()
+    })
+  })
 })

--- a/src/client/tests/unit/Screen.test.jsx
+++ b/src/client/tests/unit/Screen.test.jsx
@@ -729,6 +729,61 @@ describe("Screen", () => {
     expect(popup.close).toHaveBeenCalled()
   })
 
+  test("shows the no-media fallback and keeps the previous cue while clearing to an empty cue", async () => {
+    const screenData = {
+      file: {
+        url: "http://example.com/clearing.jpg",
+        type: "image/jpg",
+        name: "clearing.jpg",
+      },
+      index: 1,
+      name: "clearing-cue",
+      screen: 1,
+      _id: "id-clearing",
+      loop: false,
+    }
+
+    const { rerender } = render(
+      <Screen
+        screenNumber={1}
+        screenData={screenData}
+        isVisible={true}
+        onClose={() => {}}
+      />
+    )
+
+    await waitFor(() => {
+      const popup = window.open.mock.results.at(-1).value
+      expect(
+        popup.document.body.querySelector(
+          'img[src="http://example.com/clearing.jpg"]'
+        )
+      ).toBeTruthy()
+    })
+
+    await act(async () => {
+      rerender(
+        <Screen
+          screenNumber={1}
+          screenData={null}
+          isVisible={true}
+          onClose={() => {}}
+        />
+      )
+    })
+
+    const popup = window.open.mock.results.at(-1).value
+    expect(
+      popup.document.body.querySelector('[data-testid="incoming-cue-layer"]')
+        .textContent
+    ).toContain("No media available for this cue.")
+    expect(
+      popup.document.body.querySelector(
+        'img[src="http://example.com/clearing.jpg"]'
+      )
+    ).toBeTruthy()
+  })
+
   test("renders the unsupported-media fallback when the file type is unknown", async () => {
     const screenData = {
       file: {

--- a/src/client/tests/unit/ScreensDisplay.test.jsx
+++ b/src/client/tests/unit/ScreensDisplay.test.jsx
@@ -179,6 +179,33 @@ describe("ScreensDisplay", () => {
     expect(colorDivs.length).toBeGreaterThan(0)
   })
 
+  test("falls back to the default background color when a color-only cue has no color", () => {
+    const cues = [
+      {
+        _id: "cue-no-color",
+        name: "No color cue",
+        index: 0,
+        screen: 1,
+        file: null,
+      },
+    ]
+
+    render(
+      <ScreensDisplay
+        screenCount={1}
+        cues={cues}
+        cueIndex={0}
+        indexCount={10}
+        screens={{ 1: false }}
+      />
+    )
+
+    const colorDivs = Array.from(document.querySelectorAll("div")).filter(
+      (div) => div.style.backgroundColor === "rgb(51, 51, 51)"
+    )
+    expect(colorDivs.length).toBeGreaterThan(0)
+  })
+
   test("stacks multiple cues on the same screen and frame ordered by layer", () => {
     const cues = [
       {
@@ -186,8 +213,16 @@ describe("ScreensDisplay", () => {
         name: "Base layer",
         index: 0,
         screen: 1,
-        layer: 0,
         color: "#000000",
+        file: null,
+      },
+      {
+        _id: "cue-layer-1",
+        name: "Middle layer",
+        index: 0,
+        screen: 1,
+        layer: 1,
+        color: "#444444",
         file: null,
       },
       {

--- a/src/client/tests/unit/ScreensDisplay.test.jsx
+++ b/src/client/tests/unit/ScreensDisplay.test.jsx
@@ -97,4 +97,123 @@ describe("ScreensDisplay", () => {
 
     expect(screen.getByRole("img", { name: "Image cue" })).toBeInTheDocument()
   })
+
+  test("renders video cue for active screen", () => {
+    const cues = [
+      {
+        _id: "cue-video",
+        name: "Video cue",
+        index: 0,
+        screen: 1,
+        file: { url: "https://example.com/video.mp4", type: "video/mp4" },
+      },
+    ]
+
+    render(
+      <ScreensDisplay
+        screenCount={1}
+        cues={cues}
+        cueIndex={0}
+        indexCount={10}
+        screens={{ 1: false }}
+      />
+    )
+
+    expect(
+      document.querySelector('video[src="https://example.com/video.mp4"]')
+    ).toBeInTheDocument()
+  })
+
+  test("shows unsupported content type message for unrecognized files", () => {
+    const cues = [
+      {
+        _id: "cue-doc",
+        name: "Doc cue",
+        index: 0,
+        screen: 1,
+        file: {
+          url: "https://example.com/document.pdf",
+          type: "application/pdf",
+        },
+      },
+    ]
+
+    render(
+      <ScreensDisplay
+        screenCount={1}
+        cues={cues}
+        cueIndex={0}
+        indexCount={10}
+        screens={{ 1: false }}
+      />
+    )
+
+    expect(screen.getByText("Unsupported content type")).toBeInTheDocument()
+  })
+
+  test("renders a plain color background for a color-only cue", () => {
+    const cues = [
+      {
+        _id: "cue-color",
+        name: "Color cue",
+        index: 0,
+        screen: 1,
+        color: "#ff00ff",
+        file: null,
+      },
+    ]
+
+    render(
+      <ScreensDisplay
+        screenCount={1}
+        cues={cues}
+        cueIndex={0}
+        indexCount={10}
+        screens={{ 1: false }}
+      />
+    )
+
+    const colorDivs = Array.from(document.querySelectorAll("div")).filter(
+      (div) => div.style.backgroundColor === "rgb(255, 0, 255)"
+    )
+    expect(colorDivs.length).toBeGreaterThan(0)
+  })
+
+  test("stacks multiple cues on the same screen and frame ordered by layer", () => {
+    const cues = [
+      {
+        _id: "cue-layer-0",
+        name: "Base layer",
+        index: 0,
+        screen: 1,
+        layer: 0,
+        color: "#000000",
+        file: null,
+      },
+      {
+        _id: "cue-layer-2",
+        name: "Top layer",
+        index: 0,
+        screen: 1,
+        layer: 2,
+        file: { url: "https://example.com/top.png", type: "image/png" },
+      },
+    ]
+
+    render(
+      <ScreensDisplay
+        screenCount={1}
+        cues={cues}
+        cueIndex={0}
+        indexCount={10}
+        screens={{ 1: false }}
+      />
+    )
+
+    expect(screen.getByRole("img", { name: "Top layer" })).toBeInTheDocument()
+    const colorDivs = Array.from(document.querySelectorAll("div")).filter(
+      (div) => div.style.backgroundColor === "rgb(0, 0, 0)"
+    )
+    expect(colorDivs.length).toBeGreaterThan(0)
+  })
 })

--- a/src/client/tests/unit/presentationReducer.test.js
+++ b/src/client/tests/unit/presentationReducer.test.js
@@ -604,7 +604,12 @@ describe("presentationReducer asynchronous actions", () => {
 
     store.dispatch(setPresentationInfo(initialState))
 
-    const updatedCueData = { cueName: "Updated Cue", index: 1, screen: 1 }
+    const updatedCueData = {
+      cueName: "Updated Cue",
+      index: 1,
+      screen: 1,
+      opacity: 0.42,
+    }
 
     presentationService.updateCue.mockResolvedValue({
       ...initialState.cues[0],
@@ -618,6 +623,8 @@ describe("presentationReducer asynchronous actions", () => {
       1,
       expect.any(FormData)
     )
+    const sentFormData = presentationService.updateCue.mock.calls[0][2]
+    expect(sentFormData.get("opacity")).toBe("0.42")
 
     expect(store.getState().presentation.cues).toContainEqual({
       ...initialState.cues[0],
@@ -978,8 +985,10 @@ describe("presentationReducer asynchronous actions", () => {
       secondCueId: secondUpdatedCue._id,
       firstIndex: firstUpdatedCue.index,
       firstScreen: firstUpdatedCue.screen,
+      firstLayer: 0,
       secondIndex: secondUpdatedCue.index,
       secondScreen: secondUpdatedCue.screen,
+      secondLayer: 0,
     })
 
     expect(store.getState().presentation.cues).toContainEqual(firstUpdatedCue)

--- a/src/client/tests/unit/screenRowModel.test.js
+++ b/src/client/tests/unit/screenRowModel.test.js
@@ -1,0 +1,89 @@
+import {
+  buildRowModel,
+  dropTargetAt,
+  planVisualLayerRemoval,
+} from "../../components/utils/screenRowModel"
+
+describe("screenRowModel", () => {
+  test("keeps L1 first and appends added visual layers below it", () => {
+    const rowModel = buildRowModel(1, [], {}, { "screen-1": 3 })
+
+    expect(rowModel.rows.map((row) => row.label)).toEqual([
+      "L1",
+      "L2",
+      "L3",
+      "A1",
+    ])
+    expect(rowModel.rows[0]).toMatchObject({
+      kind: "layer",
+      screen: 1,
+      layer: 0,
+      groupStart: true,
+    })
+    expect(rowModel.rows[1]).toMatchObject({
+      kind: "layer",
+      screen: 1,
+      layer: 1,
+      groupStart: false,
+      canRemoveLayer: true,
+    })
+    expect(rowModel.rows[0].canRemoveLayer).toBe(false)
+  })
+
+  test("plans layer removal by deleting target layer cues and shifting upper layers down", () => {
+    const cues = [
+      { _id: "cue-l1", cueType: "visual", screen: 1, layer: 0, index: 0 },
+      { _id: "cue-l2", cueType: "visual", screen: 1, layer: 1, index: 0 },
+      { _id: "cue-l3", cueType: "visual", screen: 1, layer: 2, index: 0 },
+      { _id: "cue-s2", cueType: "visual", screen: 2, layer: 2, index: 0 },
+      { _id: "cue-audio", cueType: "audio", screen: 3, layer: 1, index: 0 },
+    ]
+
+    expect(planVisualLayerRemoval(cues, 1, 1)).toEqual({
+      removedCueIds: ["cue-l2"],
+      shiftedCues: [
+        { _id: "cue-l3", cueType: "visual", screen: 1, layer: 1, index: 0 },
+      ],
+    })
+  })
+
+  test("marks non-base visual layers as removable even when occupied", () => {
+    const rowModel = buildRowModel(
+      1,
+      [{ _id: "cue-l2", cueType: "visual", screen: 1, layer: 1, index: 0 }],
+      {},
+      { "screen-1": 2 }
+    )
+
+    expect(rowModel.rows[0]).toMatchObject({
+      label: "L1",
+      canRemoveLayer: false,
+    })
+    expect(rowModel.rows[1]).toMatchObject({
+      label: "L2",
+      canRemoveLayer: true,
+    })
+  })
+
+  test("maps a drop on L2 to layer 1 for the same screen", () => {
+    const rowModel = buildRowModel(1, [], {}, { "screen-1": 2 })
+
+    expect(dropTargetAt(rowModel.rows, 1, "visual", 1)).toEqual({
+      screen: 1,
+      layer: 1,
+    })
+  })
+
+  test("maps audio tracks to the global audio screen row", () => {
+    const rowModel = buildRowModel(2, [], {}, { audio: 2 })
+
+    expect(dropTargetAt(rowModel.rows, 2, "audio", 2)).toEqual({
+      screen: 3,
+      layer: 0,
+    })
+    expect(dropTargetAt(rowModel.rows, 3, "audio", 2)).toEqual({
+      screen: 3,
+      layer: 1,
+    })
+  })
+})

--- a/src/client/tests/unit/screenRowModel.test.js
+++ b/src/client/tests/unit/screenRowModel.test.js
@@ -1,6 +1,7 @@
 import {
   buildRowModel,
   dropTargetAt,
+  getCueRow,
   planVisualLayerRemoval,
 } from "../../components/utils/screenRowModel"
 
@@ -84,6 +85,52 @@ describe("screenRowModel", () => {
     expect(dropTargetAt(rowModel.rows, 3, "audio", 2)).toEqual({
       screen: 3,
       layer: 1,
+    })
+  })
+
+  test("collapses the audio group into a single merged row", () => {
+    const cues = [
+      { _id: "a1", cueType: "audio", layer: 0, index: 0 },
+      { _id: "a2", cueType: "audio", layer: 1, index: 0 },
+    ]
+    const rowModel = buildRowModel(1, cues, { audio: true })
+
+    const audioRow = rowModel.rows.find((row) => row.kind === "audio")
+    expect(audioRow).toMatchObject({
+      group: "audio",
+      collapsed: true,
+      count: 2,
+      label: "Audio",
+      groupStart: true,
+    })
+    expect(rowModel.cueY["a1"]).toBe(audioRow.y)
+    expect(rowModel.cueY["a2"]).toBe(audioRow.y)
+  })
+
+  test("resolves a cue's row from the cueY map or falls back to its screen", () => {
+    const cueY = { "cue-1": 4 }
+
+    expect(getCueRow({ _id: "cue-1", screen: 2 }, cueY)).toBe(4)
+    expect(getCueRow({ _id: "missing", screen: 3 }, cueY)).toBe(2)
+    expect(getCueRow({ _id: "missing" }, cueY)).toBe(0)
+  })
+
+  test("returns an empty plan when the target layer is not a positive integer", () => {
+    const cues = [
+      { _id: "cue-l1", cueType: "visual", screen: 1, layer: 0, index: 0 },
+    ]
+
+    expect(planVisualLayerRemoval(cues, 1, 0)).toEqual({
+      removedCueIds: [],
+      shiftedCues: [],
+    })
+    expect(planVisualLayerRemoval(cues, 1, -1)).toEqual({
+      removedCueIds: [],
+      shiftedCues: [],
+    })
+    expect(planVisualLayerRemoval(cues, 1, 1.5)).toEqual({
+      removedCueIds: [],
+      shiftedCues: [],
     })
   })
 })

--- a/src/client/tests/unit/toolbox.test.js
+++ b/src/client/tests/unit/toolbox.test.js
@@ -81,9 +81,32 @@ describe("ToolBox Component", () => {
         ...cue,
         cueName: "Updated Name",
         name: "Updated Name",
+        opacity: 1,
       })
     })
     expect(mockOnClose).toHaveBeenCalledTimes(1)
+  })
+
+  it("saves cue opacity", async () => {
+    mockOnSave.mockResolvedValue(undefined)
+
+    render(
+      <Toolbox
+        isOpen
+        onClose={mockOnClose}
+        cue={{ ...cue, cueType: "visual", opacity: 0.6 }}
+        onSave={mockOnSave}
+      />
+    )
+
+    expect(screen.getByText("60%")).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Save" }))
+
+    await waitFor(() => {
+      expect(mockOnSave).toHaveBeenCalledWith(
+        expect.objectContaining({ opacity: 0.6 })
+      )
+    })
   })
 
   it("does not save when cue name is empty after trimming", () => {

--- a/src/server/models/presentation.js
+++ b/src/server/models/presentation.js
@@ -17,6 +17,7 @@ const {
   VALID_CUE_TYPES,
   getAudioRow,
   getCueTypeFromScreen,
+  getMaxLayers,
 } = require("../utils/cueType")
 
 // Normalizes and validates cues, ensuring they have the correct cueType and screen assignments
@@ -155,6 +156,23 @@ const presentationSchema = mongoose.Schema(
           type: { type: String, default: "image/jpeg" },
         },
         loop: { type: Boolean, default: false },
+        continuePlayback: { type: Boolean, default: false },
+        opacity: {
+          type: Number,
+          default: 1,
+          min: 0,
+          max: 1,
+        },
+        layer: {
+          type: Number,
+          default: 0,
+          min: 0,
+          set: (v) => (v === undefined || v === null ? v : Math.round(v)),
+          validate: {
+            validator: Number.isInteger,
+            message: "layer must be an integer",
+          },
+        },
       },
     ],
   },
@@ -218,6 +236,19 @@ presentationSchema.pre("save", function (next) {
           message: `Visual cue screen ${cue.screen} exceeds screenCount`,
           path: "cues.screen",
           value: cue.screen,
+        })
+      )
+    }
+
+    const layer = Number(cue.layer ?? 0)
+    const maxLayers = getMaxLayers(cue.cueType)
+    if (layer < 0 || layer >= maxLayers) {
+      validationError.addError(
+        "cues.layer",
+        new mongoose.Error.ValidatorError({
+          message: `Cue layer ${layer} out of range (0..${maxLayers - 1})`,
+          path: "cues.layer",
+          value: layer,
         })
       )
     }

--- a/src/server/routes/presentation.js
+++ b/src/server/routes/presentation.js
@@ -25,6 +25,7 @@ const {
 const {
   getAudioRow,
   getCueTypeFromScreen,
+  getMaxLayers,
   isAudioMimeType,
   isAllowedMimeType,
 } = require("../utils/cueType")
@@ -35,11 +36,32 @@ const storage = multer.memoryStorage()
 const upload = multer({ storage })
 
 const generateFileId = () => crypto.randomBytes(8).toString("hex")
-const hasPositionConflict = (cues, index, screen, excludedCueId = null) => {
+
+const parseCueOpacity = (rawOpacity, fallback = 1) => {
+  if (rawOpacity === undefined || rawOpacity === null || rawOpacity === "") {
+    return fallback
+  }
+
+  const opacity = Number(rawOpacity)
+  if (!Number.isFinite(opacity) || opacity < 0 || opacity > 1) {
+    return null
+  }
+
+  return opacity
+}
+
+const hasPositionConflict = (
+  cues,
+  index,
+  screen,
+  layer,
+  excludedCueId = null
+) => {
   return cues.some((cue) => {
     const samePosition =
       Number(cue.index) === Number(index) &&
-      Number(cue.screen) === Number(screen)
+      Number(cue.screen) === Number(screen) &&
+      Number(cue.layer ?? 0) === Number(layer ?? 0)
     if (!samePosition) {
       return false
     }
@@ -59,8 +81,10 @@ const hasSwapTargetConflict = (
   secondCueId,
   firstTargetIndex,
   firstTargetScreen,
+  firstTargetLayer,
   secondTargetIndex,
-  secondTargetScreen
+  secondTargetScreen,
+  secondTargetLayer
 ) => {
   return cues.some((cue) => {
     const cueId = cue._id.toString()
@@ -71,9 +95,11 @@ const hasSwapTargetConflict = (
 
     return (
       (Number(cue.index) === firstTargetIndex &&
-        Number(cue.screen) === firstTargetScreen) ||
+        Number(cue.screen) === firstTargetScreen &&
+        Number(cue.layer ?? 0) === firstTargetLayer) ||
       (Number(cue.index) === secondTargetIndex &&
-        Number(cue.screen) === secondTargetScreen)
+        Number(cue.screen) === secondTargetScreen &&
+        Number(cue.layer ?? 0) === secondTargetLayer)
     )
   })
 }
@@ -357,10 +383,19 @@ router.put(
       const index = Number(req.body.index)
       const screen = Number(req.body.screen)
       const loop = req.body.loop
+      const continuePlayback = req.body.continuePlayback
       const color = req.body.color || "#000000"
+      const layer = Number(req.body.layer) || 0
+      const opacity = parseCueOpacity(req.body.opacity, 1)
 
       if (!id || isNaN(index) || isNaN(screen)) {
         return res.status(400).json({ error: "Missing required fields" })
+      }
+
+      if (opacity === null) {
+        return res.status(400).json({
+          error: "Invalid opacity. Opacity must be a number between 0 and 1.",
+        })
       }
 
       if (
@@ -426,9 +461,16 @@ router.put(
           .json({ error: "Cue name must be between 1 and 100 characters long" })
       }
 
-      if (hasPositionConflict(presentation.cues, index, screen)) {
+      const maxLayers = getMaxLayers(cueType)
+      if (layer < 0 || layer >= maxLayers) {
         return res.status(400).json({
-          error: "A cue with the same index and screen already exists.",
+          error: `Invalid layer: ${layer}. Layer must be between 0 and ${maxLayers - 1}.`,
+        })
+      }
+
+      if (hasPositionConflict(presentation.cues, index, screen, layer)) {
+        return res.status(400).json({
+          error: "A cue with the same index, screen and layer already exists.",
         })
       }
 
@@ -451,6 +493,9 @@ router.put(
               file: file ? fileObject : null,
               color: color,
               loop: loop,
+              continuePlayback: cueType === "audio" ? continuePlayback : false,
+              layer: layer,
+              opacity: opacity,
             },
           },
         },
@@ -572,14 +617,18 @@ router.put(
         secondCueId,
         firstIndex,
         firstScreen,
+        firstLayer,
         secondIndex,
         secondScreen,
+        secondLayer,
       } = req.body
 
       const parsedFirstIndex = Number(firstIndex)
       const parsedFirstScreen = Number(firstScreen)
+      const parsedFirstLayer = Number(firstLayer ?? 0)
       const parsedSecondIndex = Number(secondIndex)
       const parsedSecondScreen = Number(secondScreen)
+      const parsedSecondLayer = Number(secondLayer ?? 0)
       const maxScreen = presentation.screenCount + 1
 
       // Validate request payload.
@@ -588,8 +637,10 @@ router.put(
         !secondCueId ||
         isNaN(parsedFirstIndex) ||
         isNaN(parsedFirstScreen) ||
+        isNaN(parsedFirstLayer) ||
         isNaN(parsedSecondIndex) ||
-        isNaN(parsedSecondScreen)
+        isNaN(parsedSecondScreen) ||
+        isNaN(parsedSecondLayer)
       ) {
         return res.status(400).json({ error: "Missing required swap fields" })
       }
@@ -597,12 +648,14 @@ router.put(
       if (
         !Number.isInteger(parsedFirstIndex) ||
         !Number.isInteger(parsedFirstScreen) ||
+        !Number.isInteger(parsedFirstLayer) ||
         !Number.isInteger(parsedSecondIndex) ||
-        !Number.isInteger(parsedSecondScreen)
+        !Number.isInteger(parsedSecondScreen) ||
+        !Number.isInteger(parsedSecondLayer)
       ) {
         return res
           .status(400)
-          .json({ error: "Swap coordinates must be integers" })
+          .json({ error: "Swap coordinates and layers must be integers" })
       }
 
       if (firstCueId === secondCueId) {
@@ -655,6 +708,17 @@ router.put(
           .json({ error: "Cue type does not match swap target screen" })
       }
 
+      const firstMaxLayers = getMaxLayers(firstTargetCueType)
+      const secondMaxLayers = getMaxLayers(secondTargetCueType)
+      if (
+        parsedFirstLayer < 0 ||
+        parsedFirstLayer >= firstMaxLayers ||
+        parsedSecondLayer < 0 ||
+        parsedSecondLayer >= secondMaxLayers
+      ) {
+        return res.status(400).json({ error: "Invalid swap target layer" })
+      }
+
       // Reject swaps that would collide with a third cue.
       if (
         hasSwapTargetConflict(
@@ -663,8 +727,10 @@ router.put(
           secondCueId,
           parsedFirstIndex,
           parsedFirstScreen,
+          parsedFirstLayer,
           parsedSecondIndex,
-          parsedSecondScreen
+          parsedSecondScreen,
+          parsedSecondLayer
         )
       ) {
         return res.status(400).json({
@@ -676,9 +742,11 @@ router.put(
       firstCue.index = parsedFirstIndex
       firstCue.screen = parsedFirstScreen
       firstCue.cueType = firstTargetCueType
+      firstCue.layer = parsedFirstLayer
       secondCue.index = parsedSecondIndex
       secondCue.screen = parsedSecondScreen
       secondCue.cueType = secondTargetCueType
+      secondCue.layer = parsedSecondLayer
 
       await presentation.save({ validateModifiedOnly: true })
 
@@ -726,14 +794,23 @@ router.put(
       const index = Number(req.body.index)
       const screen = Number(req.body.screen)
       const loop = req.body.loop
+      const continuePlayback = req.body.continuePlayback
+      const hasContinuePlayback = req.body.continuePlayback !== undefined
       // default fallback color is yellow, but it should never be used since color is a required field in the frontend
       const color = req.body.color || "#fded11"
+      const opacity = parseCueOpacity(req.body.opacity, undefined)
 
       const image = req.body.image
       const shouldClearFile = image === "null"
 
       if (!id || isNaN(index) || isNaN(screen)) {
         return res.status(400).json({ error: "Missing required fields" })
+      }
+
+      if (opacity === null) {
+        return res.status(400).json({
+          error: "Invalid opacity. Opacity must be a number between 0 and 1.",
+        })
       }
 
       if (
@@ -796,9 +873,20 @@ router.put(
           .json({ error: "Cue name must be between 1 and 100 characters long" })
       }
 
-      if (hasPositionConflict(presentation.cues, index, screen, cueId)) {
+      const layer =
+        req.body.layer !== undefined
+          ? Number(req.body.layer) || 0
+          : (cue.layer ?? 0)
+      const maxLayers = getMaxLayers(cueType)
+      if (layer < 0 || layer >= maxLayers) {
         return res.status(400).json({
-          error: "A cue with the same index and screen already exists.",
+          error: `Invalid layer: ${layer}. Layer must be between 0 and ${maxLayers - 1}.`,
+        })
+      }
+
+      if (hasPositionConflict(presentation.cues, index, screen, layer, cueId)) {
+        return res.status(400).json({
+          error: "A cue with the same index, screen and layer already exists.",
         })
       }
 
@@ -808,7 +896,15 @@ router.put(
       cue.cueType = cueType
       cue.name = trimmedCueName
       cue.loop = loop
+      cue.continuePlayback =
+        cueType === "audio"
+          ? hasContinuePlayback
+            ? continuePlayback
+            : (cue.continuePlayback ?? false)
+          : false
       cue.color = color
+      cue.layer = layer
+      cue.opacity = opacity === undefined ? (cue.opacity ?? 1) : opacity
 
       if (shouldClearFile) {
         cue.file = null

--- a/src/server/tests/presentation_api.test.js
+++ b/src/server/tests/presentation_api.test.js
@@ -251,6 +251,44 @@ describe("test presentation", () => {
       expect(createdCue.color).toBe("#ff69b4")
     })
 
+    test("creates cue with explicit opacity", async () => {
+      const response = await api
+        .put(`/api/presentation/${testPresentationId}`)
+        .set("Authorization", authHeader)
+        .field("index", 2)
+        .field("cueName", "Opacity Cue")
+        .field("screen", 2)
+        .field("opacity", "0.45")
+        .expect(200)
+
+      const createdCue = response.body.cues.find(
+        (cue) => cue.name === "Opacity Cue"
+      )
+      expect(createdCue).toBeDefined()
+      expect(createdCue.opacity).toBe(0.45)
+    })
+
+    test("creates audio cue with continuous playback", async () => {
+      const response = await api
+        .put(`/api/presentation/${testPresentationId}`)
+        .set("Authorization", authHeader)
+        .attach("image", mockAudioBuffer, {
+          filename: "mock_audio.mp3",
+          contentType: "audio/mpeg",
+        })
+        .field("index", 2)
+        .field("cueName", "Continuous Audio")
+        .field("screen", 5)
+        .field("continuePlayback", "true")
+        .expect(200)
+
+      const createdCue = response.body.cues.find(
+        (cue) => cue.name === "Continuous Audio"
+      )
+      expect(createdCue).toBeDefined()
+      expect(createdCue.continuePlayback).toBe(true)
+    })
+
     test("creates color-only cue with empty name", async () => {
       const response = await api
         .put(`/api/presentation/${testPresentationId}`)
@@ -352,6 +390,37 @@ describe("test presentation", () => {
         .expect(200)
 
       expect(response.body.color).toBe("#4b0082")
+    })
+
+    test("updates cue opacity when opacity is provided", async () => {
+      const response = await api
+        .put(`/api/presentation/${testPresentationId}/${testCueId}`)
+        .set("Authorization", authHeader)
+        .field("index", 1)
+        .field("cueName", "Updated Test Cue")
+        .field("screen", 2)
+        .field("opacity", "0.35")
+        .expect(200)
+
+      expect(response.body.opacity).toBe(0.35)
+    })
+
+    test("updates continuous playback when provided", async () => {
+      const createResponse = await createAudioCue(2, "Audio Cue", 5)
+      const audioCue = createResponse.body.cues.find(
+        (cue) => cue.name === "Audio Cue"
+      )
+
+      const response = await api
+        .put(`/api/presentation/${testPresentationId}/${audioCue._id}`)
+        .set("Authorization", authHeader)
+        .field("index", 2)
+        .field("cueName", "Updated Audio Cue")
+        .field("screen", 5)
+        .field("continuePlayback", "true")
+        .expect(200)
+
+      expect(response.body.continuePlayback).toBe(true)
     })
 
     test("updates color-only cue with empty name", async () => {
@@ -482,7 +551,9 @@ describe("test presentation", () => {
         })
         .expect(400)
 
-      expect(response.body.error).toBe("Swap coordinates must be integers")
+      expect(response.body.error).toBe(
+        "Swap coordinates and layers must be integers"
+      )
     })
 
     test("rejects swap when target position has third cue conflict", async () => {

--- a/src/server/tests/presentation_api.test.js
+++ b/src/server/tests/presentation_api.test.js
@@ -349,6 +349,74 @@ describe("test presentation", () => {
 
       expect(response.body.error).toBe("Missing required fields")
     })
+
+    test("throws error with invalid opacity", async () => {
+      const response = await api
+        .put(`/api/presentation/${testPresentationId}`)
+        .set("Authorization", authHeader)
+        .field("index", 1)
+        .field("cueName", "Bad Opacity Cue")
+        .field("screen", 2)
+        .field("opacity", "1.5")
+        .expect(400)
+
+      expect(response.body.error).toBe(
+        "Invalid opacity. Opacity must be a number between 0 and 1."
+      )
+    })
+
+    test("throws error with invalid layer", async () => {
+      const response = await api
+        .put(`/api/presentation/${testPresentationId}`)
+        .set("Authorization", authHeader)
+        .field("index", 1)
+        .field("cueName", "Bad Layer Cue")
+        .field("screen", 2)
+        .field("layer", "3")
+        .expect(400)
+
+      expect(response.body.error).toBe(
+        "Invalid layer: 3. Layer must be between 0 and 2."
+      )
+    })
+
+    test("throws error when a cue already exists at the same index, screen and layer", async () => {
+      await createCue(1, "First Cue", 2)
+
+      const response = await api
+        .put(`/api/presentation/${testPresentationId}`)
+        .set("Authorization", authHeader)
+        .field("index", 1)
+        .field("cueName", "Second Cue")
+        .field("screen", 2)
+        .field("layer", "0")
+        .field("color", "#ff69b4")
+        .expect(400)
+
+      expect(response.body.error).toBe(
+        "A cue with the same index, screen and layer already exists."
+      )
+    })
+
+    test("allows a cue on a different layer at the same index and screen", async () => {
+      await createCue(1, "First Cue", 2)
+
+      const response = await api
+        .put(`/api/presentation/${testPresentationId}`)
+        .set("Authorization", authHeader)
+        .field("index", 1)
+        .field("cueName", "Layered Cue")
+        .field("screen", 2)
+        .field("layer", "1")
+        .field("color", "#ff69b4")
+        .expect(200)
+
+      const createdCue = response.body.cues.find(
+        (cue) => cue.name === "Layered Cue"
+      )
+      expect(createdCue).toBeDefined()
+      expect(createdCue.layer).toBe(1)
+    })
   })
 
   describe("PUT /api/presentation/:id/:cueId", () => {
@@ -483,6 +551,68 @@ describe("test presentation", () => {
 
       expect(response.body.error).toBe("Missing required fields")
     })
+
+    test("throws error with invalid opacity", async () => {
+      const response = await api
+        .put(`/api/presentation/${testPresentationId}/${testCueId}`)
+        .set("Authorization", authHeader)
+        .field("index", 1)
+        .field("cueName", "Updated Test Cue")
+        .field("screen", 2)
+        .field("opacity", "-0.2")
+        .expect(400)
+
+      expect(response.body.error).toBe(
+        "Invalid opacity. Opacity must be a number between 0 and 1."
+      )
+    })
+
+    test("throws error with invalid layer", async () => {
+      const response = await api
+        .put(`/api/presentation/${testPresentationId}/${testCueId}`)
+        .set("Authorization", authHeader)
+        .field("index", 1)
+        .field("cueName", "Updated Test Cue")
+        .field("screen", 2)
+        .field("layer", "3")
+        .expect(400)
+
+      expect(response.body.error).toBe(
+        "Invalid layer: 3. Layer must be between 0 and 2."
+      )
+    })
+
+    test("throws error when moving a cue onto an already occupied index, screen and layer", async () => {
+      await createCue(2, "Other Cue", 2)
+
+      const response = await api
+        .put(`/api/presentation/${testPresentationId}/${testCueId}`)
+        .set("Authorization", authHeader)
+        .field("index", 2)
+        .field("cueName", "Updated Test Cue")
+        .field("screen", 2)
+        .field("layer", "0")
+        .expect(400)
+
+      expect(response.body.error).toBe(
+        "A cue with the same index, screen and layer already exists."
+      )
+    })
+
+    test("allows moving a cue onto a different layer at an occupied index and screen", async () => {
+      await createCue(2, "Other Cue", 2)
+
+      const response = await api
+        .put(`/api/presentation/${testPresentationId}/${testCueId}`)
+        .set("Authorization", authHeader)
+        .field("index", 2)
+        .field("cueName", "Updated Test Cue")
+        .field("screen", 2)
+        .field("layer", "1")
+        .expect(200)
+
+      expect(response.body.layer).toBe(1)
+    })
   })
 
   describe("PUT /api/presentation/:id/swapCues", () => {
@@ -535,6 +665,25 @@ describe("test presentation", () => {
       expect(updatedFirstCue.screen).toBe(1)
       expect(updatedSecondCue.index).toBe(0)
       expect(updatedSecondCue.screen).toBe(1)
+    })
+
+    test("rejects swap with an out-of-range target layer", async () => {
+      const response = await api
+        .put(`/api/presentation/${testPresentationId}/swapCues`)
+        .set("Authorization", authHeader)
+        .send({
+          firstCueId,
+          secondCueId,
+          firstIndex: 1,
+          firstScreen: 1,
+          firstLayer: 3,
+          secondIndex: 0,
+          secondScreen: 1,
+          secondLayer: 0,
+        })
+        .expect(400)
+
+      expect(response.body.error).toBe("Invalid swap target layer")
     })
 
     test("rejects decimal swap coordinates", async () => {
@@ -1351,6 +1500,88 @@ describe("MRU (Most Recently Used) sorting", () => {
     expect(user1Response.body.every((p) => p.user === user.id.toString())).toBe(
       true
     )
+  })
+})
+
+describe("Presentation model cue layer validation", () => {
+  let user
+
+  beforeEach(async () => {
+    await User.deleteMany({})
+    await Presentation.deleteMany({})
+
+    user = new User({
+      username: "layer-validation-user",
+      passwordHash: "test-password-hash",
+    })
+    await user.save()
+  })
+
+  test("rejects a visual cue with a layer out of range", async () => {
+    const presentation = new Presentation({
+      name: "Invalid Visual Layer Presentation",
+      user: user._id,
+      screenCount: 2,
+      cues: [
+        { cueType: "visual", index: 0, screen: 1, layer: 3, name: "Bad Layer" },
+      ],
+    })
+
+    let caughtError
+    try {
+      await presentation.save()
+    } catch (err) {
+      caughtError = err
+    }
+
+    expect(caughtError).toBeDefined()
+    expect(caughtError.errors["cues.layer"]).toBeDefined()
+  })
+
+  test("rejects an audio cue with a layer out of range", async () => {
+    const presentation = new Presentation({
+      name: "Invalid Audio Layer Presentation",
+      user: user._id,
+      screenCount: 2,
+      cues: [
+        {
+          cueType: "audio",
+          index: 0,
+          screen: 3,
+          layer: 2,
+          name: "Bad Audio Layer",
+        },
+      ],
+    })
+
+    let caughtError
+    try {
+      await presentation.save()
+    } catch (err) {
+      caughtError = err
+    }
+
+    expect(caughtError).toBeDefined()
+    expect(caughtError.errors["cues.layer"]).toBeDefined()
+  })
+
+  test("accepts a cue with a layer within range", async () => {
+    const presentation = new Presentation({
+      name: "Valid Layer Presentation",
+      user: user._id,
+      screenCount: 2,
+      cues: [
+        {
+          cueType: "visual",
+          index: 0,
+          screen: 1,
+          layer: 2,
+          name: "Good Layer",
+        },
+      ],
+    })
+
+    await expect(presentation.save()).resolves.toBeDefined()
   })
 })
 

--- a/src/server/utils/cueType.js
+++ b/src/server/utils/cueType.js
@@ -4,6 +4,11 @@
  */
 const VALID_CUE_TYPES = ["visual", "audio"]
 
+const MAX_VISUAL_LAYERS = 3
+const MAX_AUDIO_TRACKS = 2
+const getMaxLayers = (cueType) =>
+  cueType === "audio" ? MAX_AUDIO_TRACKS : MAX_VISUAL_LAYERS
+
 const VALID_VIDEO_MIME_TYPES = ["video/mp4", "video/3gpp"]
 const VALID_IMAGE_MIME_TYPES = [
   "image/jpeg",
@@ -64,6 +69,9 @@ const isAllowedMimeType = (mimeType = "") => {
 
 module.exports = {
   VALID_CUE_TYPES,
+  MAX_VISUAL_LAYERS,
+  MAX_AUDIO_TRACKS,
+  getMaxLayers,
   getAudioRow,
   isAudioScreen,
   getCueTypeFromScreen,


### PR DESCRIPTION
Add layered timeline support so users can stack visual cues per screen and use multiple global audio tracks in the editor/playback flow.

## Changes
- Add a row/layer model for screen layers and audio tracks.
- Support add/remove/collapse/expand behavior for screen layers and audio tracks.
- Update drag/drop, copy, replace, and cue movement to target `{ screen, layer }`.
- Add per-cue visual opacity.
- Add multi-track audio playback.

Closes #863.