### PR TITLE
chore: migrate container registry from Quay.io to GHCR

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,6 +9,8 @@ jobs:
   test:
     name: Unit tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -51,6 +53,8 @@ jobs:
     needs: test
     name: End-to-End tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -75,6 +79,9 @@ jobs:
   build:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout
@@ -99,16 +106,16 @@ jobs:
             --build-arg VITE_FIREBASE_PROJECT_ID=$VITE_FIREBASE_PROJECT_ID \
             --build-arg VITE_FIREBASE_APP_ID=$VITE_FIREBASE_APP_ID \
             -f docker/Dockerfile \
-            -t "quay.io/muvico_hy/muvico:${IMAGE_TAG}" \
-            -t quay.io/muvico_hy/muvico:staging .
+            -t "ghcr.io/muvico/muvico:${IMAGE_TAG}" \
+            -t ghcr.io/muvico/muvico:staging .
 
-      - name: Push image to Quay.io
-        id: push-to-quay
+      - name: Push image to GHCR
+        id: push-to-ghcr
         if: ${{ github.ref == 'refs/heads/main'}}
         env:
           IMAGE_TAG: ${{ steps.meta.outputs.image_tag }}
-          QUAY_IO_TOKEN: ${{ secrets.QUAY_IO_TOKEN }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo $QUAY_IO_TOKEN | docker login quay.io -u muvico_hy+robo --password-stdin
-          docker push "quay.io/muvico_hy/muvico:${IMAGE_TAG}"
-          docker push quay.io/muvico_hy/muvico:staging
+          echo $GHCR_TOKEN | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          docker push "ghcr.io/muvico/muvico:${IMAGE_TAG}"
+          docker push ghcr.io/muvico/muvico:staging

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -5,15 +5,18 @@ on:
     types: [published]
 
 jobs:
-  build-to-quay:
+  build-to-ghcr:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build, tag, and push image to Quay.io
+      - name: Build, tag, and push image to GHCR
         id: build-image
         env:
           VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
@@ -21,13 +24,13 @@ jobs:
           VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
         run: |
-          docker login quay.io -u muvico_hy+robo -p ${{ secrets.QUAY_IO_TOKEN }}
+          docker login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
           docker build \
             --build-arg VITE_FIREBASE_API_KEY=$VITE_FIREBASE_API_KEY \
             --build-arg VITE_FIREBASE_AUTH_DOMAIN=$VITE_FIREBASE_AUTH_DOMAIN \
             --build-arg VITE_FIREBASE_PROJECT_ID=$VITE_FIREBASE_PROJECT_ID \
             --build-arg VITE_FIREBASE_APP_ID=$VITE_FIREBASE_APP_ID \
             -f docker/Dockerfile \
-            -t 'quay.io/muvico_hy/muvico:${{ github.event.release.tag_name }}' .
-          docker push 'quay.io/muvico_hy/muvico:${{ github.event.release.tag_name }}'
-          echo "image=quay.io/muvico_hy/muvico:${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+            -t 'ghcr.io/muvico/muvico:${{ github.event.release.tag_name }}' .
+          docker push 'ghcr.io/muvico/muvico:${{ github.event.release.tag_name }}'
+          echo "image=ghcr.io/muvico/muvico:${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT

--- a/documentation/Definition of Done and conventions.md
+++ b/documentation/Definition of Done and conventions.md
@@ -18,7 +18,7 @@
 ### Continuous integration
 
 - _CI/CD_ pipe green
-  - This checks for testing (coverage included), building, pushing into quay-io and linting
+  - This checks for testing (coverage included), building, pushing into GHCR and linting
   - When issues are encountered, fixing them should be prioritized
 - Only working code should be expected in the _main_ branch
 - New code ought to be integrated via _pull requests_
@@ -45,12 +45,8 @@
   > The version in `package.json` should have the same version number.
 3. Set a title for the release in the format `MuViCo vX.Y.Z`, where `X.Y.Z` is the version of the release being made.
 4. Create release notes for the release and set it as the latest, then publish it.
-5. After the new image has been built, change the prod image tag to the newly published version in `manifests/prod-dep.yaml`.
-6. Apply the changes to Kubernetes with
-```bash
-kubectl --kubeconfig=muvico-cluster_kubeconfig.yaml apply -f manifests/prod-dep.yaml && \
-kubectl --kubeconfig=muvico-cluster_kubeconfig.yaml rollout restart deployment muvico-dep
-```
+5. After the new image has been built, change the prod image tag to the newly published version in the `gitops` repo, in `environments/prod/deployment.yaml` (`ghcr.io/muvico/muvico:vX.Y.Z`), and push that change.
+6. Argo CD (`muvico-prod` Application) picks up the change and syncs it to the cluster automatically. `manifests/` in this repo is a legacy reference kept in sync for documentation purposes only — `gitops` is the deployed source of truth.
 
 ### User story size estimates
 

--- a/documentation/architecture/cloud-deployment.md
+++ b/documentation/architecture/cloud-deployment.md
@@ -25,8 +25,8 @@ The application is designed for creating and performing multi-screen multimedia 
 - **[Upcloud Kubernetes](https://upcloud.com/docs/products/managed-kubernetes)**  
   Runs the MuViCo backend in a managed Kubernetes cluster. The deployment manifests live under `/manifests/` and are applied to the cluster using `kubectl`.
 
-- **[Quay.io](https://quay.io/)**  
-  Container registry used to store built images. The CI pipeline builds images from the repository and pushes them to Quay (tags include `staging` and release tags).
+- **[GitHub Container Registry (ghcr.io)](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)**  
+  Container registry used to store built images, at `ghcr.io/muvico/muvico`. The CI pipeline builds images from the repository and pushes them using the workflow's own `GITHUB_TOKEN` (tags include `staging` and release tags). The package is public, so no pull credentials are needed on the cluster.
 
 - **Docker**  
   The application is packaged as a Docker image using the project `Dockerfile`, which contains both the frontend build and the backend server.
@@ -134,11 +134,11 @@ MuViCo uses GitHub Actions to automate testing, building container images, and p
 
   - Runs linting, unit tests and end-to-end tests.
   - Builds a Docker image
-  - On main branch pushes the docker image is also pushed to Quay tagged with `staging`.
+  - On main branch pushes the docker image is also pushed to GHCR tagged with `staging`.
   - Uploads frontend and backend coverage reports to Codecov.
 
 - **`prod.yml`** runs when a GitHub Release is published:
-  - Builds a Docker image and pushes it to Quay tagged with the release name (e.g. `v1.2.3`).
+  - Builds a Docker image and pushes it to GHCR tagged with the release name (e.g. `v1.2.3`).
 
 ### Deploying to Upcloud Kubernetes
 

--- a/manifests/prod-dep.yaml
+++ b/manifests/prod-dep.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: muvico
-        image: quay.io/muvico_hy/muvico:staging
+        image: ghcr.io/muvico/muvico:staging
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 8000

--- a/manifests/staging-dep.yaml
+++ b/manifests/staging-dep.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: muvico-staging
-        image: quay.io/muvico_hy/muvico:staging
+        image: ghcr.io/muvico/muvico:staging
         imagePullPolicy: Always
         ports:
           - containerPort: 8000


### PR DESCRIPTION
Push/pull images via ghcr.io/muvico/muvico instead of quay.io/muvico_hy/muvico. CI now authenticates with the workflow's own GITHUB_TOKEN instead of the Quay robot account secret, removing an external credential to manage.

Closes #865.