### PR TITLE
feat: add refresh token flow, shorten access token to 1h

### DIFF
--- a/src/client/components/navbar/index.jsx
+++ b/src/client/components/navbar/index.jsx
@@ -34,10 +34,13 @@ import getToken from "../../auth"
 import { isTokenExpired } from "../../auth"
 import UserManualModal from "./UserManualModal"
 import { useCustomToast } from "../utils/toastUtils"
+import authService from "../../services/auth"
 import {
   SESSION_EXPIRED_MESSAGE,
   SESSION_EXPIRED_EVENT,
 } from "../../utils/axiosAuthInterceptor"
+
+const SILENT_REFRESH_INTERVAL_MS = 1000 * 60 * 20 // 20 minutes
 
 const NavBar = ({ user, setUser }) => {
   const navigate = useNavigate()
@@ -85,6 +88,7 @@ const NavBar = ({ user, setUser }) => {
   const navbarLogo = colorMode === "dark" ? hyLogo : bHyLogo
 
   const handleLogout = (navigate, setUser) => {
+    authService.logout() // best-effort
     window.localStorage.removeItem("user")
     window.localStorage.removeItem("driveAccessToken")
     setUser(null)
@@ -123,14 +127,45 @@ const NavBar = ({ user, setUser }) => {
     setIsManualOpen(true)
   }
 
-  // Check token expiration
+  // Token looks expired, but the refresh cookie may still be valid - try it before logging out.
   useEffect(() => {
     const token = getToken()
-    if (isTokenExpired(token)) {
-      handleLogout(navigate, setUser)
+    if (!isTokenExpired(token)) {
+      return
+    }
+
+    let cancelled = false
+    authService
+      .refreshAccessToken()
+      .then((refreshedUser) => {
+        if (!cancelled) setUser(refreshedUser)
+      })
+      .catch(() => {
+        if (!cancelled) handleLogout(navigate, setUser)
+      })
+
+    return () => {
+      cancelled = true
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []) //run only once
+
+  // Keep the access token fresh while logged in and the tab stays open.
+  useEffect(() => {
+    if (!user) {
+      return
+    }
+
+    const intervalId = setInterval(() => {
+      authService
+        .refreshAccessToken()
+        .then((refreshedUser) => setUser(refreshedUser))
+        .catch(() => {})
+    }, SILENT_REFRESH_INTERVAL_MS)
+
+    return () => clearInterval(intervalId)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user])
 
   // React to an expired/invalid session detected mid-session by the axios interceptor
   useEffect(() => {

--- a/src/client/services/auth.js
+++ b/src/client/services/auth.js
@@ -1,5 +1,5 @@
 /**
- * This module provides authentication services for the client application, including login, signup, password change, and user retrieval. 
+ * This module provides authentication services for the client application, including login, signup, password change, and user retrieval.
  * It uses axios for HTTP requests and localStorage for storing the logged-in user's information.
  */
 
@@ -7,14 +7,37 @@ import axios from "axios"
 import getToken from "../auth"
 
 const loginUrl = "/api/login"
+const refreshUrl = "/api/login/refresh"
+const logoutUrl = "/api/login/logout"
 const signupUrl = "/api/signup"
 const changePasswordUrl = "/api/users/change-password"
 
 const login = async (credentials) => {
-  const response = await axios.post(loginUrl, credentials)
+  const response = await axios.post(loginUrl, credentials, {
+    withCredentials: true,
+  })
   const user = response.data
   window.localStorage.setItem("user", JSON.stringify(user))
   return user
+}
+
+// Throws if there's no valid refresh token, which the caller treats as "really logged out".
+const refreshAccessToken = async () => {
+  const response = await axios.post(refreshUrl, {}, { withCredentials: true })
+
+  const currentUser = getLoggedUser()
+  const updatedUser = { ...currentUser, token: response.data.token }
+  window.localStorage.setItem("user", JSON.stringify(updatedUser))
+  return updatedUser
+}
+
+// Best-effort - local logout doesn't depend on this succeeding.
+const logout = async () => {
+  try {
+    await axios.post(logoutUrl, {}, { withCredentials: true })
+  } catch {
+    // ignore
+  }
 }
 
 const signup = async (credentials) => {
@@ -31,9 +54,9 @@ const checkUsernameAvailability = async (username) => {
 
 const getLoggedUser = () => {
   const loggedUserJSON = window.localStorage.getItem("user")
-    if (!loggedUserJSON) {
-      return null
-    }
+  if (!loggedUserJSON) {
+    return null
+  }
   try {
     return JSON.parse(loggedUserJSON)
   } catch {
@@ -57,4 +80,6 @@ export default {
   changepassword,
   getLoggedUser,
   checkUsernameAvailability,
+  refreshAccessToken,
+  logout,
 }

--- a/src/client/tests/unit/autologout.test.js
+++ b/src/client/tests/unit/autologout.test.js
@@ -12,9 +12,17 @@ import "@testing-library/jest-dom"
 import { useToast } from "@chakra-ui/react"
 import NavBar from "../../components/navbar/index"
 import { isTokenExpired } from "../../auth"
+import authService from "../../services/auth"
 import { SESSION_EXPIRED_EVENT } from "../../utils/axiosAuthInterceptor"
 
 jest.mock("../../auth")
+jest.mock("../../services/auth", () => ({
+  __esModule: true,
+  default: {
+    refreshAccessToken: jest.fn(),
+    logout: jest.fn().mockResolvedValue(undefined),
+  },
+}))
 jest.mock("react-router-dom", () => ({
   ...jest.requireActual("react-router-dom"),
   useNavigate: jest.fn(),
@@ -45,11 +53,18 @@ jest.mock("../../components/navbar/Login", () => {
 })
 
 describe("autologout", () => {
-  test("user is logged out when token expires", async () => {
+  beforeEach(() => {
+    authService.refreshAccessToken.mockReset()
+  })
+
+  test("user is logged out when token expires and the silent refresh also fails", async () => {
     const setUser = jest.fn()
     const navigate = jest.fn()
 
     isTokenExpired.mockReturnValue(true)
+    authService.refreshAccessToken.mockRejectedValue(
+      new Error("no valid refresh token")
+    )
     require("react-router-dom").useNavigate.mockReturnValue(navigate)
 
     render(
@@ -66,6 +81,35 @@ describe("autologout", () => {
       expect(setUser).toHaveBeenCalledWith(null)
       expect(navigate).toHaveBeenCalledWith("/")
     })
+  })
+
+  test("user stays logged in when the access token looks expired but the silent refresh succeeds", async () => {
+    // Covers the common real-world case: the access token (1h) expired while
+    // the browser was closed, but the httpOnly refresh cookie (7 days) is
+    // still valid, so the user shouldn't be bounced back to logged-out.
+    const setUser = jest.fn()
+    const navigate = jest.fn()
+    const refreshedUser = { username: "testuser", token: "new-access-token" }
+
+    isTokenExpired.mockReturnValue(true)
+    authService.refreshAccessToken.mockResolvedValue(refreshedUser)
+    require("react-router-dom").useNavigate.mockReturnValue(navigate)
+
+    render(
+      <MemoryRouter>
+        <NavBar
+          user={{ username: "testuser" }}
+          setUser={setUser}
+          navigate={navigate}
+        />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(setUser).toHaveBeenCalledWith(refreshedUser)
+    })
+    expect(setUser).not.toHaveBeenCalledWith(null)
+    expect(navigate).not.toHaveBeenCalledWith("/")
   })
 })
 

--- a/src/client/tests/unit/axiosAuthInterceptor.test.js
+++ b/src/client/tests/unit/axiosAuthInterceptor.test.js
@@ -2,14 +2,30 @@
  * Axios auth-error interceptor unit tests.
  * Verifies a 401 whose response body includes code: "SESSION_EXPIRED" (the
  * backend's own signal that the app's JWT itself failed verification)
- * dispatches "session-expired".
+ * first tries a silent refresh-and-retry, and only dispatches
+ * "session-expired" if that also fails (or there's nothing to retry).
  */
+import axios from "axios"
+import authService from "../../services/auth"
 import {
   handleResponseError,
   SESSION_EXPIRED_EVENT,
 } from "../../utils/axiosAuthInterceptor"
 
+jest.mock("axios")
+jest.mock("../../services/auth", () => ({
+  __esModule: true,
+  default: {
+    refreshAccessToken: jest.fn(),
+  },
+}))
+
 describe("axiosAuthInterceptor", () => {
+  beforeEach(() => {
+    axios.mockReset()
+    authService.refreshAccessToken.mockReset()
+  })
+
   test("dispatches session-expired when the response body includes code SESSION_EXPIRED", async () => {
     const listener = jest.fn()
     window.addEventListener(SESSION_EXPIRED_EVENT, listener)
@@ -69,6 +85,87 @@ describe("axiosAuthInterceptor", () => {
 
     await expect(handleResponseError(error)).rejects.toBe(error)
     expect(listener).not.toHaveBeenCalled()
+
+    window.removeEventListener(SESSION_EXPIRED_EVENT, listener)
+  })
+
+  test("silently refreshes and retries the original request instead of dispatching session-expired", async () => {
+    const listener = jest.fn()
+    window.addEventListener(SESSION_EXPIRED_EVENT, listener)
+
+    authService.refreshAccessToken.mockResolvedValue({ token: "new-token" })
+    const retriedResponse = { status: 200, data: { ok: true } }
+    axios.mockResolvedValue(retriedResponse)
+
+    const error = {
+      response: {
+        status: 401,
+        data: { error: "token expired", code: "SESSION_EXPIRED" },
+      },
+      config: {
+        url: "/api/home",
+        method: "get",
+        headers: { Authorization: "Bearer old-token" },
+      },
+    }
+
+    await expect(handleResponseError(error)).resolves.toBe(retriedResponse)
+    expect(axios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "/api/home",
+        headers: expect.objectContaining({
+          Authorization: "Bearer new-token",
+        }),
+      })
+    )
+    expect(listener).not.toHaveBeenCalled()
+
+    window.removeEventListener(SESSION_EXPIRED_EVENT, listener)
+  })
+
+  test("dispatches session-expired if the silent refresh itself fails", async () => {
+    const listener = jest.fn()
+    window.addEventListener(SESSION_EXPIRED_EVENT, listener)
+
+    authService.refreshAccessToken.mockRejectedValue(
+      new Error("no valid refresh token")
+    )
+
+    const error = {
+      response: {
+        status: 401,
+        data: { error: "token expired", code: "SESSION_EXPIRED" },
+      },
+      config: { url: "/api/home", method: "get", headers: {} },
+    }
+
+    await expect(handleResponseError(error)).rejects.toBe(error)
+    expect(axios).not.toHaveBeenCalled()
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    window.removeEventListener(SESSION_EXPIRED_EVENT, listener)
+  })
+
+  test("does not retry a request a second time (avoids an infinite loop)", async () => {
+    const listener = jest.fn()
+    window.addEventListener(SESSION_EXPIRED_EVENT, listener)
+
+    const error = {
+      response: {
+        status: 401,
+        data: { error: "token expired", code: "SESSION_EXPIRED" },
+      },
+      config: {
+        url: "/api/home",
+        method: "get",
+        headers: {},
+        retriedAfterRefresh: true,
+      },
+    }
+
+    await expect(handleResponseError(error)).rejects.toBe(error)
+    expect(authService.refreshAccessToken).not.toHaveBeenCalled()
+    expect(listener).toHaveBeenCalledTimes(1)
 
     window.removeEventListener(SESSION_EXPIRED_EVENT, listener)
   })

--- a/src/client/tests/unit/login.api.test.js
+++ b/src/client/tests/unit/login.api.test.js
@@ -1,12 +1,17 @@
 /*
- * Auth service API unit test.
- * Verifies login() sends credentials to /api/login and returns backend payload as-is.
+ * Auth service API unit tests.
+ * Verifies login() sends credentials to /api/login and returns backend payload as-is,
+ * plus the refresh/logout wrappers used by the silent-refresh flow.
  */
 const axios = require("axios")
-const authService = require("../../services/auth")
-const login = authService.default.login
+const authService = require("../../services/auth").default
 
 jest.mock("axios")
+
+beforeEach(() => {
+  window.localStorage.clear()
+  jest.clearAllMocks()
+})
 
 test("login api call behaves as expected", async () => {
   // Contract check: this wrapper should not transform request or response shape.
@@ -15,9 +20,45 @@ test("login api call behaves as expected", async () => {
 
   axios.post.mockResolvedValue({ data: response })
 
-  const result = await login(credentials)
+  const result = await authService.login(credentials)
   expect(result).toEqual(response)
   expect(axios.post).toHaveBeenCalledWith("/api/login", credentials, {
     withCredentials: true,
   })
+})
+
+test("refreshAccessToken merges the new token into the stored user", async () => {
+  window.localStorage.setItem(
+    "user",
+    JSON.stringify({ username: "John Doe", token: "old-token" })
+  )
+  axios.post.mockResolvedValue({ data: { token: "new-token" } })
+
+  const result = await authService.refreshAccessToken()
+
+  expect(axios.post).toHaveBeenCalledWith(
+    "/api/login/refresh",
+    {},
+    { withCredentials: true }
+  )
+  expect(result).toEqual({ username: "John Doe", token: "new-token" })
+  expect(JSON.parse(window.localStorage.getItem("user"))).toEqual(result)
+})
+
+test("refreshAccessToken propagates the error when there's no valid refresh token", async () => {
+  const error = new Error("Request failed with status code 401")
+  axios.post.mockRejectedValue(error)
+
+  await expect(authService.refreshAccessToken()).rejects.toThrow(error)
+})
+
+test("logout posts to the logout endpoint and never throws", async () => {
+  axios.post.mockRejectedValue(new Error("network error"))
+
+  await expect(authService.logout()).resolves.toBeUndefined()
+  expect(axios.post).toHaveBeenCalledWith(
+    "/api/login/logout",
+    {},
+    { withCredentials: true }
+  )
 })

--- a/src/client/tests/unit/login.api.test.js
+++ b/src/client/tests/unit/login.api.test.js
@@ -17,5 +17,7 @@ test("login api call behaves as expected", async () => {
 
   const result = await login(credentials)
   expect(result).toEqual(response)
-  expect(axios.post).toHaveBeenCalledWith("/api/login", credentials)
+  expect(axios.post).toHaveBeenCalledWith("/api/login", credentials, {
+    withCredentials: true,
+  })
 })

--- a/src/client/tests/unit/logout.test.js
+++ b/src/client/tests/unit/logout.test.js
@@ -2,43 +2,61 @@
  * Logout behavior unit tests for NavBar.
  * Verifies logout control rendering and user state reset when logging out.
  */
-import { render, screen, fireEvent } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
-import '@testing-library/jest-dom'
-import NavBar from '../../components/navbar/index'
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import "@testing-library/jest-dom"
+import NavBar from "../../components/navbar/index"
+import authService from "../../services/auth"
 
-jest.mock('../../components/utils/firebase', () => ({
-  apikey: 'testkey'
-  }))
+jest.mock("../../components/utils/firebase", () => ({
+  apikey: "testkey",
+}))
 
-describe('logout', () => {
-  test('render content', () => {
+// NavBar silently tries to refresh the access token on mount whenever it
+// looks expired (no real token exists in these tests' localStorage). Resolve
+// it so that background attempt doesn't also call setUser(null) and
+// interfere with the logout-button assertions below.
+jest.mock("../../services/auth", () => ({
+  __esModule: true,
+  default: {
+    refreshAccessToken: jest.fn().mockResolvedValue({ username: "testuser" }),
+    logout: jest.fn().mockResolvedValue(undefined),
+  },
+}))
+
+describe("logout", () => {
+  test("render content", () => {
     const setUser = jest.fn()
     render(
       <MemoryRouter>
-        <NavBar user={{ username: 'testuser' }} setUser={setUser} />
+        <NavBar user={{ username: "testuser" }} setUser={setUser} />
       </MemoryRouter>
     )
-    expect(screen.getByText('Logout')).toBeDefined()
+    expect(screen.getByText("Logout")).toBeDefined()
   })
 
-  test('handleLogout', () => {
-    // Core logout contract: active user is cleared from app state.
+  test("handleLogout", async () => {
+    // Core logout contract: active user is cleared from app state, and the
+    // server-side refresh token is invalidated (best-effort).
     const navigate = jest.fn()
     const setUser = jest.fn()
 
     const { getByText } = render(
       <MemoryRouter>
         <NavBar
-          user={{ username: 'testuser' }}
+          user={{ username: "testuser" }}
           setUser={setUser}
           navigate={navigate}
         />
       </MemoryRouter>
     )
-    const logoutButton = getByText('Logout')
+    const logoutButton = getByText("Logout")
 
     fireEvent.click(logoutButton)
-    expect(setUser).toHaveBeenCalledWith(null)
+
+    await waitFor(() => {
+      expect(setUser).toHaveBeenCalledWith(null)
+    })
+    expect(authService.logout).toHaveBeenCalled()
   })
 })

--- a/src/client/utils/axiosAuthInterceptor.js
+++ b/src/client/utils/axiosAuthInterceptor.js
@@ -1,12 +1,9 @@
 /*
- * Detects an expired/invalid app session from any axios response and
- * notifies the rest of the app via a "session-expired" window event,
- * without touching every individual service call site.
- *
- * The backend marks a 401 with code: "SESSION_EXPIRED" specifically when
- * the app's own JWT failed verification (see src/server/utils/middleware.js).
+ * On a 401 with code: "SESSION_EXPIRED", tries a silent refresh + retry
+ * before broadcasting "session-expired" (see src/server/utils/middleware.js).
  */
 import axios from "axios"
+import authService from "../services/auth"
 
 export const SESSION_EXPIRED_MESSAGE =
   "Your session has expired. Please log in again."
@@ -14,11 +11,44 @@ export const SESSION_EXPIRED_MESSAGE =
 // Used to broadcast a detected session expiry to the rest of the app
 export const SESSION_EXPIRED_EVENT = "session-expired"
 
-export const handleResponseError = (error) => {
-  if (error.response?.data?.code === "SESSION_EXPIRED") {
-    window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT))
+// Shares one in-flight refresh across requests that 401 at the same time.
+let refreshPromise = null
+
+const refreshOnce = () => {
+  if (!refreshPromise) {
+    refreshPromise = authService.refreshAccessToken().finally(() => {
+      refreshPromise = null
+    })
+  }
+  return refreshPromise
+}
+
+export const handleResponseError = async (error) => {
+  if (error.response?.data?.code !== "SESSION_EXPIRED") {
+    return Promise.reject(error)
   }
 
+  const originalRequest = error.config
+
+  // retriedAfterRefresh caps retries at one, avoiding an infinite loop.
+  if (originalRequest && !originalRequest.retriedAfterRefresh) {
+    originalRequest.retriedAfterRefresh = true
+
+    try {
+      const refreshedUser = await refreshOnce()
+      return axios({
+        ...originalRequest,
+        headers: {
+          ...originalRequest.headers,
+          Authorization: `Bearer ${refreshedUser.token}`,
+        },
+      })
+    } catch {
+      // refresh failed too - fall through to a real session expiry
+    }
+  }
+
+  window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT))
   return Promise.reject(error)
 }
 

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -33,6 +33,8 @@ const userSchema = mongoose.Schema({
   ],
   isAdmin: { type: Boolean, default: false },
   driveToken: { type: String, default: null },
+  refreshTokenHash: { type: String, default: null },
+  refreshTokenExpires: { type: Date, default: null },
 })
 
 userSchema.set("toJSON", {
@@ -41,6 +43,8 @@ userSchema.set("toJSON", {
     delete returnedObject._id
     delete returnedObject.__v
     delete returnedObject.passwordHash
+    delete returnedObject.refreshTokenHash
+    delete returnedObject.refreshTokenExpires
   },
 })
 

--- a/src/server/routes/login.js
+++ b/src/server/routes/login.js
@@ -1,6 +1,6 @@
 /**
- * this module defines the routes for user login and authentication, including both traditional username/password login and Firebase-based authentication. 
- * It uses JWT for token generation and includes error handling for invalid credentials. The routes interact with the User model to retrieve user data and manage authentication state. 
+ * this module defines the routes for user login and authentication, including both traditional username/password login and Firebase-based authentication.
+ * It uses JWT for token generation and includes error handling for invalid credentials. The routes interact with the User model to retrieve user data and manage authentication state.
  * The Firebase route also handles linking legacy accounts based on email prefixes to ensure a smooth transition for users authenticating with Google.
  */
 
@@ -11,8 +11,23 @@ const User = require("../models/user")
 const config = require("../utils/config")
 const verifyToken = require("../utils/verifyToken")
 const { generateUniqueUsername } = require("../utils/username")
+const {
+  REFRESH_TOKEN_COOKIE_NAME,
+  hashToken,
+  issueRefreshToken,
+  clearRefreshTokenCookie,
+} = require("../utils/refreshToken")
 
 const router = express.Router()
+
+// Kept short since this token authorizes every API call; /refresh below is
+// what keeps users logged in longer.
+const ACCESS_TOKEN_EXPIRES_IN_SECONDS = 60 * 60 // 1 hour
+
+const signAccessToken = (user) =>
+  jwt.sign({ username: user.username, id: user._id }, config.SECRET, {
+    expiresIn: ACCESS_TOKEN_EXPIRES_IN_SECONDS,
+  })
 
 router.post("/", async (req, res) => {
   const { username, password } = req.body
@@ -31,14 +46,8 @@ Checks if the entered password is correct for the given user.*
     })
   }
 
-  const userForToken = {
-    username: user.username,
-    id: user._id,
-  }
-
-  const token = jwt.sign(userForToken, config.SECRET, {
-    expiresIn: 60 * 60,
-  })
+  const token = signAccessToken(user)
+  await issueRefreshToken(user, res)
 
   return res.status(200).send({
     token,
@@ -89,14 +98,8 @@ router.post("/firebase", verifyToken, async (req, res) => {
 
     await user.save()
 
-    const userForToken = {
-      username: user.username,
-      id: user._id,
-    }
-
-    const token = jwt.sign(userForToken, config.SECRET, {
-      expiresIn: 60 * 60,
-    })
+    const token = signAccessToken(user)
+    await issueRefreshToken(user, res)
 
     return res.status(200).send({
       token,
@@ -109,6 +112,44 @@ router.post("/firebase", verifyToken, async (req, res) => {
   } catch (error) {
     res.status(500).json({ error: error.message })
   }
+})
+
+// Rotates the refresh token on every use so an old one can't be replayed.
+router.post("/refresh", async (req, res) => {
+  const rawToken = req.cookies?.[REFRESH_TOKEN_COOKIE_NAME]
+
+  if (!rawToken) {
+    return res.status(401).json({ error: "No refresh token" })
+  }
+
+  const user = await User.findOne({
+    refreshTokenHash: hashToken(rawToken),
+    refreshTokenExpires: { $gt: new Date() },
+  })
+
+  if (!user) {
+    clearRefreshTokenCookie(res)
+    return res.status(401).json({ error: "Invalid or expired refresh token" })
+  }
+
+  const token = signAccessToken(user)
+  await issueRefreshToken(user, res)
+
+  return res.status(200).json({ token })
+})
+
+router.post("/logout", async (req, res) => {
+  const rawToken = req.cookies?.[REFRESH_TOKEN_COOKIE_NAME]
+
+  if (rawToken) {
+    await User.findOneAndUpdate(
+      { refreshTokenHash: hashToken(rawToken) },
+      { refreshTokenHash: null, refreshTokenExpires: null }
+    )
+  }
+
+  clearRefreshTokenCookie(res)
+  return res.status(204).end()
 })
 
 module.exports = router

--- a/src/server/tests/login_api.test.js
+++ b/src/server/tests/login_api.test.js
@@ -4,10 +4,20 @@
  */
 const supertest = require("supertest")
 const mongoose = require("mongoose")
+const jwt = require("jsonwebtoken")
 const { generateHash } = require("../utils/auth.js")
+const { hashToken } = require("../utils/refreshToken")
 const User = require("../models/user")
 const app = require("../app")
 const verifyToken = require("../utils/verifyToken")
+
+// Pulls the raw refreshToken cookie value out of a supertest response's
+// Set-Cookie header, e.g. "refreshToken=abc123; Path=/api/login; ..." -> "abc123".
+const getRefreshCookieValue = (response) => {
+  const setCookie = response.headers["set-cookie"] || []
+  const cookie = setCookie.find((c) => c.startsWith("refreshToken="))
+  return cookie?.split(";")[0].split("=")[1]
+}
 
 const api = supertest(app)
 
@@ -318,6 +328,120 @@ describe("Login API", () => {
 
     // Restore the original implementation
     User.prototype.save.mockRestore()
+  })
+})
+
+describe("Refresh token flow", () => {
+  beforeEach(async () => {
+    await User.deleteMany({})
+
+    const passwordHash = await generateHash("testpassword")
+    const user = new User({ username: "testuser", passwordHash })
+
+    await user.save()
+  })
+
+  test("login sets an httpOnly refresh cookie scoped to /api/login", async () => {
+    const response = await api
+      .post("/api/login")
+      .send({ username: "testuser", password: "testpassword" })
+      .expect(200)
+
+    const setCookie = response.headers["set-cookie"] || []
+    const cookie = setCookie.find((c) => c.startsWith("refreshToken="))
+
+    expect(cookie).toBeDefined()
+    expect(cookie).toMatch(/HttpOnly/)
+    expect(cookie).toMatch(/Path=\/api\/login/)
+  })
+
+  test("exchanges a valid refresh cookie for a new access token", async () => {
+    const loginResponse = await api
+      .post("/api/login")
+      .send({ username: "testuser", password: "testpassword" })
+      .expect(200)
+
+    const refreshToken = getRefreshCookieValue(loginResponse)
+
+    const refreshResponse = await api
+      .post("/api/login/refresh")
+      .set("Cookie", [`refreshToken=${refreshToken}`])
+      .expect(200)
+
+    expect(refreshResponse.body.token).toBeDefined()
+    const payload = jwt.decode(refreshResponse.body.token)
+    expect(payload.username).toBe("testuser")
+  })
+
+  test("rotates the refresh token so the old value can't be reused", async () => {
+    const loginResponse = await api
+      .post("/api/login")
+      .send({ username: "testuser", password: "testpassword" })
+      .expect(200)
+
+    const originalRefreshToken = getRefreshCookieValue(loginResponse)
+
+    await api
+      .post("/api/login/refresh")
+      .set("Cookie", [`refreshToken=${originalRefreshToken}`])
+      .expect(200)
+
+    await api
+      .post("/api/login/refresh")
+      .set("Cookie", [`refreshToken=${originalRefreshToken}`])
+      .expect(401)
+  })
+
+  test("fails with 401 when no refresh cookie is sent", async () => {
+    const response = await api.post("/api/login/refresh").expect(401)
+    expect(response.body.error).toBe("No refresh token")
+  })
+
+  test("fails with 401 for an unknown refresh token", async () => {
+    const response = await api
+      .post("/api/login/refresh")
+      .set("Cookie", ["refreshToken=not-a-real-token"])
+      .expect(401)
+
+    expect(response.body.error).toBe("Invalid or expired refresh token")
+  })
+
+  test("fails with 401 for an expired refresh token", async () => {
+    const rawToken = "a".repeat(64)
+    await new User({
+      username: "expireduser",
+      passwordHash: await generateHash("testpassword"),
+      refreshTokenHash: hashToken(rawToken),
+      refreshTokenExpires: new Date(Date.now() - 1000),
+    }).save()
+
+    await api
+      .post("/api/login/refresh")
+      .set("Cookie", [`refreshToken=${rawToken}`])
+      .expect(401)
+  })
+
+  test("logout invalidates the refresh token so it can no longer be used", async () => {
+    const loginResponse = await api
+      .post("/api/login")
+      .send({ username: "testuser", password: "testpassword" })
+      .expect(200)
+
+    const refreshToken = getRefreshCookieValue(loginResponse)
+
+    await api
+      .post("/api/login/logout")
+      .set("Cookie", [`refreshToken=${refreshToken}`])
+      .expect(204)
+
+    await api
+      .post("/api/login/refresh")
+      .set("Cookie", [`refreshToken=${refreshToken}`])
+      .expect(401)
+  })
+
+  test("logout succeeds even without a refresh cookie", async () => {
+    await api.post("/api/login/logout").expect(204)
   })
 })
 

--- a/src/server/utils/refreshToken.js
+++ b/src/server/utils/refreshToken.js
@@ -1,0 +1,47 @@
+/*
+ * Refresh token utility: opaque random value, only its hash is stored in the
+ * DB, kept in an httpOnly cookie scoped to /api/login.
+ */
+const crypto = require("crypto")
+
+const REFRESH_TOKEN_COOKIE_NAME = "refreshToken"
+const REFRESH_TOKEN_COOKIE_PATH = "/api/login"
+const REFRESH_TOKEN_TTL_MS = 1000 * 60 * 60 * 24 * 7 // 7 days
+
+const hashToken = (token) =>
+  crypto.createHash("sha256").update(token).digest("hex")
+
+const cookieOptions = () => ({
+  httpOnly: true,
+  secure: process.env.NODE_ENV === "production",
+  sameSite: "lax",
+  path: REFRESH_TOKEN_COOKIE_PATH,
+  maxAge: REFRESH_TOKEN_TTL_MS,
+})
+
+// Only one refresh token is valid per user at a time.
+const issueRefreshToken = async (user, res) => {
+  const rawToken = crypto.randomBytes(32).toString("hex")
+
+  user.refreshTokenHash = hashToken(rawToken)
+  user.refreshTokenExpires = new Date(Date.now() + REFRESH_TOKEN_TTL_MS)
+  await user.save()
+
+  res.cookie(REFRESH_TOKEN_COOKIE_NAME, rawToken, cookieOptions())
+}
+
+const clearRefreshTokenCookie = (res) => {
+  res.clearCookie(REFRESH_TOKEN_COOKIE_NAME, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: REFRESH_TOKEN_COOKIE_PATH,
+  })
+}
+
+module.exports = {
+  REFRESH_TOKEN_COOKIE_NAME,
+  hashToken,
+  issueRefreshToken,
+  clearRefreshTokenCookie,
+}


### PR DESCRIPTION
Access token stays short-lived (authorizes every request), while a new httpOnly, rotating refresh token (7 days) silently renews it on mount, periodically, and on any 401 - so sessions survive closing the browser without weakening the access token itself.

Close #849 
