### PR TITLE
feat: add backend support for music score PDFs

### DIFF
--- a/src/server/models/presentation.js
+++ b/src/server/models/presentation.js
@@ -175,6 +175,94 @@ const presentationSchema = mongoose.Schema(
         },
       },
     ],
+    scores: [
+      {
+        title: {
+          type: String,
+          required: true,
+          minlength: 1,
+          maxlength: 150,
+        },
+        source: {
+          type: String,
+          required: true,
+          default: "upload",
+          enum: {
+            values: ["upload", "imslp"],
+            message: "source must be either upload or imslp",
+          },
+        },
+        sourceUrl: {
+          type: String,
+          maxlength: 1000,
+        },
+        imslpId: {
+          type: String,
+          maxlength: 80,
+        },
+        pageCount: {
+          type: Number,
+          min: 1,
+          set: (v) => (v === undefined || v === null ? v : Math.round(v)),
+          validate: {
+            validator: (v) => v === undefined || Number.isInteger(v),
+            message: "pageCount must be an integer",
+          },
+        },
+        file: {
+          id: String,
+          name: String,
+          url: String,
+          driveId: String,
+          size: { type: String, default: "0" },
+          type: { type: String, default: "application/pdf" },
+        },
+        markers: [
+          {
+            page: {
+              type: Number,
+              required: true,
+              min: 1,
+              set: (v) => (v === undefined || v === null ? v : Math.round(v)),
+              validate: {
+                validator: Number.isInteger,
+                message: "marker page must be an integer",
+              },
+            },
+            frameIndex: {
+              type: Number,
+              required: true,
+              min: 0,
+              set: (v) => (v === undefined || v === null ? v : Math.round(v)),
+              validate: {
+                validator: Number.isInteger,
+                message: "marker frameIndex must be an integer",
+              },
+            },
+            measureLabel: {
+              type: String,
+              default: "",
+              maxlength: 80,
+            },
+            note: {
+              type: String,
+              default: "",
+              maxlength: 300,
+            },
+            rect: {
+              x: { type: Number, min: 0, max: 1 },
+              y: { type: Number, min: 0, max: 1 },
+              width: { type: Number, min: 0, max: 1 },
+              height: { type: Number, min: 0, max: 1 },
+            },
+          },
+        ],
+        createdAt: {
+          type: Date,
+          default: Date.now,
+        },
+      },
+    ],
   },
   { timestamps: true }
 )
@@ -251,6 +339,36 @@ presentationSchema.pre("save", function (next) {
           value: layer,
         })
       )
+    }
+  }
+
+  for (const score of this.scores || []) {
+    for (const marker of score.markers || []) {
+      if (marker.frameIndex < 0 || marker.frameIndex >= this.indexCount) {
+        validationError.addError(
+          "scores.markers.frameIndex",
+          new mongoose.Error.ValidatorError({
+            message: `Score marker frameIndex ${marker.frameIndex} exceeds indexCount`,
+            path: "scores.markers.frameIndex",
+            value: marker.frameIndex,
+          })
+        )
+      }
+
+      if (
+        score.pageCount &&
+        marker.page &&
+        Number(marker.page) > Number(score.pageCount)
+      ) {
+        validationError.addError(
+          "scores.markers.page",
+          new mongoose.Error.ValidatorError({
+            message: `Score marker page ${marker.page} exceeds pageCount`,
+            path: "scores.markers.page",
+            value: marker.page,
+          })
+        )
+      }
     }
   }
 

--- a/src/server/routes/presentation.js
+++ b/src/server/routes/presentation.js
@@ -21,6 +21,8 @@ const {
   generateSignedUrlForS3,
   processS3Files,
   processDriveCueFiles,
+  processS3ScoreFiles,
+  processDriveScoreFiles,
 } = require("../utils/helper")
 const {
   getAudioRow,
@@ -34,8 +36,139 @@ const router = express.Router()
 
 const storage = multer.memoryStorage()
 const upload = multer({ storage })
+const PDF_MIME_TYPES = ["application/pdf", "application/x-pdf"]
+const MAX_SCORE_FILE_SIZE = 50 * 1024 * 1024
 
 const generateFileId = () => crypto.randomBytes(8).toString("hex")
+
+const parseOptionalPositiveInteger = (rawValue) => {
+  if (rawValue === undefined || rawValue === null || rawValue === "") {
+    return undefined
+  }
+
+  const value = Number(rawValue)
+  if (!Number.isInteger(value) || value < 1) {
+    return null
+  }
+
+  return value
+}
+
+const parseMarkerInteger = (rawValue) => {
+  const value = Number(rawValue)
+  return Number.isInteger(value) ? value : null
+}
+
+const isPdfFile = (file) => {
+  if (!file) {
+    return false
+  }
+
+  return (
+    PDF_MIME_TYPES.includes(file.mimetype) ||
+    file.originalname.toLowerCase().endsWith(".pdf")
+  )
+}
+
+const trimText = (value, fallback = "") =>
+  typeof value === "string" ? value.trim() : fallback
+
+const validateScoreTitle = (title) => {
+  const trimmedTitle = trimText(title)
+  if (trimmedTitle.length === 0 || trimmedTitle.length > 150) {
+    return null
+  }
+
+  return trimmedTitle
+}
+
+const parseUrl = (rawUrl) => {
+  const sourceUrl = trimText(rawUrl)
+  if (!sourceUrl) {
+    return null
+  }
+
+  try {
+    const url = new URL(sourceUrl)
+    if (!["http:", "https:"].includes(url.protocol)) {
+      return null
+    }
+
+    return url
+  } catch {
+    return null
+  }
+}
+
+const isImslpUrl = (url) =>
+  url.hostname === "imslp.org" || url.hostname.endsWith(".imslp.org")
+
+const parseMarkerRect = (rawRect) => {
+  if (rawRect === undefined || rawRect === null || rawRect === "") {
+    return undefined
+  }
+
+  const rect = typeof rawRect === "string" ? JSON.parse(rawRect) : rawRect
+  const keys = ["x", "y", "width", "height"]
+  const parsed = {}
+
+  for (const key of keys) {
+    if (rect[key] === undefined || rect[key] === null || rect[key] === "") {
+      continue
+    }
+
+    const value = Number(rect[key])
+    if (!Number.isFinite(value) || value < 0 || value > 1) {
+      return null
+    }
+
+    parsed[key] = value
+  }
+
+  return parsed
+}
+
+const processPresentationScoreFiles = async (presentation, user) => {
+  if (user.driveToken) {
+    presentation.scores = await processDriveScoreFiles(
+      presentation.scores || [],
+      user.driveToken
+    )
+  } else {
+    presentation.scores = await processS3ScoreFiles(
+      presentation.scores || [],
+      presentation._id
+    )
+  }
+
+  return presentation
+}
+
+const uploadScoreFile = async (presentationId, fileId, file, user) => {
+  const key = `${presentationId}/${fileId}`
+
+  if (user.driveToken) {
+    return uploadDriveFile(file.buffer, key, file.mimetype, user.driveToken)
+  }
+
+  await uploadFileS3(file.buffer, key, file.mimetype)
+  return null
+}
+
+const deleteScoreFile = async (presentationId, score, user) => {
+  if (!score.file) {
+    return
+  }
+
+  if (user.driveToken && score.file.driveId) {
+    await deleteDriveFile(score.file.driveId, user.driveToken)
+    return
+  }
+
+  if (score.file.id) {
+    await deleteFileS3(`${presentationId}/${score.file.id}`)
+  }
+}
 
 const parseCueOpacity = (rawOpacity, fallback = 1) => {
   if (rawOpacity === undefined || rawOpacity === null || rawOpacity === "") {
@@ -177,6 +310,7 @@ router.get(
           presentation._id
         )
       }
+      await processPresentationScoreFiles(presentation, user)
 
       res.json(presentation)
     } catch (error) {
@@ -198,6 +332,10 @@ router.delete(
 
       for (const cue of presentation.cues) {
         await deleteObject(presentation._id, cue._id, user.driveToken)
+      }
+
+      for (const score of presentation.scores || []) {
+        await deleteScoreFile(presentation._id, score, user)
       }
 
       await Presentation.findByIdAndDelete(presentation._id)
@@ -238,15 +376,27 @@ router.put(
 
       // If reducing index count, remove cues from indexes that will be removed
       let removedCuesCount = 0
+      let removedScoreMarkersCount = 0
       if (newIndexCount < presentation.indexCount) {
         const cuesToRemove = presentation.cues.filter(
           (cue) => Number(cue.index) >= newIndexCount
         )
         removedCuesCount = cuesToRemove.length
+        removedScoreMarkersCount = (presentation.scores || []).reduce(
+          (count, score) =>
+            count +
+            (score.markers || []).filter(
+              (marker) => Number(marker.frameIndex) >= newIndexCount
+            ).length,
+          0
+        )
 
         updateQuery.$pull = {
           cues: {
             _id: { $in: cuesToRemove.map((cue) => cue._id) },
+          },
+          "scores.$[].markers": {
+            frameIndex: { $gte: newIndexCount },
           },
         }
       }
@@ -260,6 +410,7 @@ router.put(
       res.json({
         indexCount: updatedPresentation.indexCount,
         removedCuesCount: removedCuesCount,
+        removedScoreMarkersCount: removedScoreMarkersCount,
       })
     } catch (err) {
       next(err)
@@ -359,6 +510,337 @@ router.put(
       res.json({ name: updated.name })
     } catch (err) {
       next(err)
+    }
+  }
+)
+
+router.get(
+  "/:id/scores",
+  userExtractor,
+  requirePresentationAccess,
+  async (req, res, next) => {
+    try {
+      const { user, presentation } = req
+      await processPresentationScoreFiles(presentation, user)
+      res.json(presentation.scores || [])
+    } catch (error) {
+      next(error)
+    }
+  }
+)
+
+router.post(
+  "/:id/scores/upload",
+  userExtractor,
+  requirePresentationAccess,
+  upload.single("score"),
+  async (req, res, next) => {
+    try {
+      const { file, presentation, user } = req
+      const fileId = generateFileId()
+      const pageCount = parseOptionalPositiveInteger(req.body.pageCount)
+
+      if (!file) {
+        return res.status(400).json({ error: "Score PDF file is required" })
+      }
+
+      if (!isPdfFile(file)) {
+        return res.status(400).json({ error: "Only PDF scores are allowed" })
+      }
+
+      if (file.size > MAX_SCORE_FILE_SIZE && !user.isAdmin) {
+        return res.status(400).json({ error: "File size exceeds 50 MB limit" })
+      }
+
+      if (pageCount === null) {
+        return res.status(400).json({
+          error: "pageCount must be a positive integer",
+        })
+      }
+
+      const title =
+        validateScoreTitle(req.body.title) ||
+        validateScoreTitle(file.originalname)
+
+      if (!title) {
+        return res
+          .status(400)
+          .json({ error: "Score title must be between 1 and 150 characters" })
+      }
+
+      const sourceUrl = trimText(req.body.sourceUrl)
+      const imslpId = trimText(req.body.imslpId)
+      const source = sourceUrl || imslpId ? "imslp" : "upload"
+
+      const score = {
+        title,
+        source,
+        ...(sourceUrl && { sourceUrl }),
+        ...(imslpId && { imslpId }),
+        ...(pageCount && { pageCount }),
+        file: {
+          id: fileId,
+          name: file.originalname,
+          url: "",
+          size: String(file.size),
+          type: file.mimetype || "application/pdf",
+        },
+      }
+
+      presentation.scores.push(score)
+      const createdScore = presentation.scores[presentation.scores.length - 1]
+
+      try {
+        const driveResponse = await uploadScoreFile(
+          presentation._id,
+          fileId,
+          file,
+          user
+        )
+
+        if (driveResponse?.id) {
+          createdScore.file.driveId = driveResponse.id
+        }
+      } catch (error) {
+        logger.error("Score upload error:", error)
+        return res.status(500).json({ error: "Score upload failed" })
+      }
+
+      await presentation.save({ validateModifiedOnly: true })
+
+      const [processedScore] = user.driveToken
+        ? await processDriveScoreFiles([createdScore], user.driveToken)
+        : await processS3ScoreFiles([createdScore], presentation._id)
+
+      res.status(201).json(processedScore)
+    } catch (error) {
+      next(error)
+    }
+  }
+)
+
+router.post(
+  "/:id/scores/import",
+  userExtractor,
+  requirePresentationAccess,
+  async (req, res, next) => {
+    try {
+      const { presentation } = req
+      const parsedUrl = parseUrl(req.body.sourceUrl)
+      const pageCount = parseOptionalPositiveInteger(req.body.pageCount)
+
+      if (!parsedUrl || !isImslpUrl(parsedUrl)) {
+        return res.status(400).json({
+          error: "A valid IMSLP URL is required",
+        })
+      }
+
+      if (pageCount === null) {
+        return res.status(400).json({
+          error: "pageCount must be a positive integer",
+        })
+      }
+
+      const title =
+        validateScoreTitle(req.body.title) ||
+        validateScoreTitle(
+          decodeURIComponent(parsedUrl.pathname.split("/").pop() || "")
+        )
+
+      if (!title) {
+        return res
+          .status(400)
+          .json({ error: "Score title must be between 1 and 150 characters" })
+      }
+
+      presentation.scores.push({
+        title,
+        source: "imslp",
+        sourceUrl: parsedUrl.toString(),
+        imslpId: trimText(req.body.imslpId),
+        ...(pageCount && { pageCount }),
+        file: {
+          name: title,
+          url: parsedUrl.toString(),
+          size: "0",
+          type: "application/pdf",
+        },
+      })
+
+      await presentation.save({ validateModifiedOnly: true })
+
+      res.status(201).json(presentation.scores[presentation.scores.length - 1])
+    } catch (error) {
+      next(error)
+    }
+  }
+)
+
+router.delete(
+  "/:id/scores/:scoreId",
+  userExtractor,
+  requirePresentationAccess,
+  async (req, res, next) => {
+    try {
+      const { presentation, user } = req
+      const { scoreId } = req.params
+      const score = presentation.scores.id(scoreId)
+
+      if (!score) {
+        return res.status(404).json({ error: "Score not found" })
+      }
+
+      await deleteScoreFile(presentation._id, score, user)
+      score.deleteOne()
+      await presentation.save({ validateModifiedOnly: true })
+
+      res.status(204).end()
+    } catch (error) {
+      next(error)
+    }
+  }
+)
+
+const buildMarkerFromBody = (body, presentation, score) => {
+  const page = parseMarkerInteger(body.page)
+  const frameIndex = parseMarkerInteger(body.frameIndex)
+
+  if (page === null || page < 1) {
+    return { error: "marker page must be a positive integer" }
+  }
+
+  if (
+    frameIndex === null ||
+    frameIndex < 0 ||
+    frameIndex >= presentation.indexCount
+  ) {
+    return {
+      error: `marker frameIndex must be between 0 and ${presentation.indexCount - 1}`,
+    }
+  }
+
+  if (score.pageCount && page > score.pageCount) {
+    return { error: `marker page must be between 1 and ${score.pageCount}` }
+  }
+
+  let rect
+  try {
+    rect = parseMarkerRect(body.rect)
+  } catch {
+    return { error: "marker rect must be valid JSON" }
+  }
+
+  if (rect === null) {
+    return { error: "marker rect values must be between 0 and 1" }
+  }
+
+  const measureLabel = trimText(body.measureLabel)
+  const note = trimText(body.note)
+
+  if (measureLabel.length > 80) {
+    return { error: "marker measureLabel must be at most 80 characters" }
+  }
+
+  if (note.length > 300) {
+    return { error: "marker note must be at most 300 characters" }
+  }
+
+  return {
+    marker: {
+      page,
+      frameIndex,
+      measureLabel,
+      note,
+      ...(rect && { rect }),
+    },
+  }
+}
+
+router.post(
+  "/:id/scores/:scoreId/markers",
+  userExtractor,
+  requirePresentationAccess,
+  async (req, res, next) => {
+    try {
+      const { presentation } = req
+      const score = presentation.scores.id(req.params.scoreId)
+
+      if (!score) {
+        return res.status(404).json({ error: "Score not found" })
+      }
+
+      const result = buildMarkerFromBody(req.body, presentation, score)
+      if (result.error) {
+        return res.status(400).json({ error: result.error })
+      }
+
+      score.markers.push(result.marker)
+      await presentation.save({ validateModifiedOnly: true })
+
+      res.status(201).json(score.markers[score.markers.length - 1])
+    } catch (error) {
+      next(error)
+    }
+  }
+)
+
+router.put(
+  "/:id/scores/:scoreId/markers/:markerId",
+  userExtractor,
+  requirePresentationAccess,
+  async (req, res, next) => {
+    try {
+      const { presentation } = req
+      const score = presentation.scores.id(req.params.scoreId)
+
+      if (!score) {
+        return res.status(404).json({ error: "Score not found" })
+      }
+
+      const marker = score.markers.id(req.params.markerId)
+      if (!marker) {
+        return res.status(404).json({ error: "Score marker not found" })
+      }
+
+      const result = buildMarkerFromBody(req.body, presentation, score)
+      if (result.error) {
+        return res.status(400).json({ error: result.error })
+      }
+
+      marker.set(result.marker)
+      await presentation.save({ validateModifiedOnly: true })
+
+      res.json(marker)
+    } catch (error) {
+      next(error)
+    }
+  }
+)
+
+router.delete(
+  "/:id/scores/:scoreId/markers/:markerId",
+  userExtractor,
+  requirePresentationAccess,
+  async (req, res, next) => {
+    try {
+      const { presentation } = req
+      const score = presentation.scores.id(req.params.scoreId)
+
+      if (!score) {
+        return res.status(404).json({ error: "Score not found" })
+      }
+
+      const marker = score.markers.id(req.params.markerId)
+      if (!marker) {
+        return res.status(404).json({ error: "Score marker not found" })
+      }
+
+      marker.deleteOne()
+      await presentation.save({ validateModifiedOnly: true })
+
+      res.status(204).end()
+    } catch (error) {
+      next(error)
     }
   }
 )

--- a/src/server/tests/presentation_api.test.js
+++ b/src/server/tests/presentation_api.test.js
@@ -139,6 +139,117 @@ describe("test presentation", () => {
         .expect("Content-Type", /application\/json/)
     })
   })
+
+  describe("Score documents", () => {
+    const imslpUrl =
+      "https://imslp.org/wiki/Special:ImagefromIndex/939945/apano-stin-triantafyllia.pdf"
+
+    const importScore = () =>
+      api
+        .post(`/api/presentation/${testPresentationId}/scores/import`)
+        .set("Authorization", authHeader)
+        .send({
+          title: "Apano stin Triantafyllia.pdf",
+          sourceUrl: imslpUrl,
+          imslpId: "IMSLP939945",
+          pageCount: 12,
+        })
+
+    test("imports IMSLP score metadata", async () => {
+      const response = await importScore().expect(201)
+
+      expect(response.body.title).toBe("Apano stin Triantafyllia.pdf")
+      expect(response.body.source).toBe("imslp")
+      expect(response.body.sourceUrl).toBe(imslpUrl)
+      expect(response.body.imslpId).toBe("IMSLP939945")
+      expect(response.body.pageCount).toBe(12)
+      expect(response.body.file.type).toBe("application/pdf")
+    })
+
+    test("rejects non-PDF score uploads", async () => {
+      const response = await api
+        .post(`/api/presentation/${testPresentationId}/scores/upload`)
+        .set("Authorization", authHeader)
+        .attach("score", mockImageBuffer, {
+          filename: "mock_image.png",
+          contentType: "image/png",
+        })
+        .field("title", "Not a score")
+        .expect(400)
+
+      expect(response.body.error).toBe("Only PDF scores are allowed")
+    })
+
+    test("adds, updates and deletes score markers", async () => {
+      const scoreResponse = await importScore().expect(201)
+      const scoreId = scoreResponse.body._id
+
+      const createMarkerResponse = await api
+        .post(
+          `/api/presentation/${testPresentationId}/scores/${scoreId}/markers`
+        )
+        .set("Authorization", authHeader)
+        .send({
+          page: 3,
+          frameIndex: 2,
+          measureLabel: "m. 12",
+          note: "Rehearsal B",
+          rect: { x: 0.1, y: 0.2, width: 0.6, height: 0.1 },
+        })
+        .expect(201)
+
+      expect(createMarkerResponse.body.page).toBe(3)
+      expect(createMarkerResponse.body.frameIndex).toBe(2)
+      expect(createMarkerResponse.body.measureLabel).toBe("m. 12")
+
+      const markerId = createMarkerResponse.body._id
+
+      const updateMarkerResponse = await api
+        .put(
+          `/api/presentation/${testPresentationId}/scores/${scoreId}/markers/${markerId}`
+        )
+        .set("Authorization", authHeader)
+        .send({
+          page: 4,
+          frameIndex: 3,
+          measureLabel: "m. 16",
+        })
+        .expect(200)
+
+      expect(updateMarkerResponse.body.page).toBe(4)
+      expect(updateMarkerResponse.body.frameIndex).toBe(3)
+      expect(updateMarkerResponse.body.measureLabel).toBe("m. 16")
+
+      await api
+        .delete(
+          `/api/presentation/${testPresentationId}/scores/${scoreId}/markers/${markerId}`
+        )
+        .set("Authorization", authHeader)
+        .expect(204)
+
+      const presentation = await Presentation.findById(testPresentationId)
+      const score = presentation.scores.id(scoreId)
+      expect(score.markers).toHaveLength(0)
+    })
+
+    test("rejects markers outside the timeline", async () => {
+      const scoreResponse = await importScore().expect(201)
+      const scoreId = scoreResponse.body._id
+
+      const response = await api
+        .post(
+          `/api/presentation/${testPresentationId}/scores/${scoreId}/markers`
+        )
+        .set("Authorization", authHeader)
+        .send({ page: 1, frameIndex: 10 })
+        .expect(400)
+
+      expect(response.body.error).toBe(
+        "marker frameIndex must be between 0 and 4"
+      )
+    })
+  })
+
   describe("DELETE", () => {
     test(" /api/presentation/:id", async () => {
       await api

--- a/src/server/utils/helper.js
+++ b/src/server/utils/helper.js
@@ -43,6 +43,28 @@ const processDriveCueFiles = async (cues, accessToken) => {
   return processedCues
 }
 
+const generateDriveFileUrl = async (file, accessToken) => {
+  if (!file?.driveId) {
+    return file
+  }
+
+  try {
+    const metadata = await getDriveFileMetadata(file.driveId, accessToken)
+    file.type = metadata.mimeType
+    file.size = metadata.size
+    const baseUrl =
+      process.env.NODE_ENV === "production"
+        ? "https://muvico.live"
+        : "http://localhost:3000"
+
+    file.url = `${baseUrl}/api/media/${file.driveId}?access_token=${accessToken}`
+  } catch (error) {
+    logger.error("Error fetching file metadata:", error)
+  }
+
+  return file
+}
+
 const generateSignedUrlForS3 = async (cue, presentationId) => {
   if (!cue.file?.id) {
     return cue
@@ -52,6 +74,17 @@ const generateSignedUrlForS3 = async (cue, presentationId) => {
   cue.file.url = await getObjectSignedUrl(key)
 
   return cue
+}
+
+const generateSignedScoreUrlForS3 = async (score, presentationId) => {
+  if (!score.file?.id) {
+    return score
+  }
+
+  const key = `${presentationId}/${score.file.id.toString()}`
+  score.file.url = await getObjectSignedUrl(key)
+
+  return score
 }
 
 const processS3Files = async (cues, presentationId) => {
@@ -75,8 +108,33 @@ const processS3Files = async (cues, presentationId) => {
   return processedCues
 }
 
+const processS3ScoreFiles = async (scores, presentationId) => {
+  return Promise.all(
+    scores.map(async (score) => {
+      if (!score.file?.id) {
+        return score
+      }
+
+      await generateSignedScoreUrlForS3(score, presentationId)
+      return score
+    })
+  )
+}
+
+const processDriveScoreFiles = async (scores, accessToken) => {
+  return Promise.all(
+    scores.map(async (score) => {
+      await generateDriveFileUrl(score.file, accessToken)
+      return score
+    })
+  )
+}
+
 module.exports = {
   processDriveCueFiles,
+  processDriveScoreFiles,
   generateSignedUrlForS3,
+  generateSignedScoreUrlForS3,
   processS3Files,
+  processS3ScoreFiles,
 }


### PR DESCRIPTION
Adds score PDF metadata, upload/import endpoints, and timeline marker APIs for future editor score viewing.

Closes #879.