### PR TITLE
fix(editor): update PDF preview not loading

### DIFF
--- a/__mocks__/urlMock.js
+++ b/__mocks__/urlMock.js
@@ -1,0 +1,1 @@
+module.exports = "mocked-url"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
           "<rootDir>/setup-jest.js"
         ],
         "moduleNameMapper": {
-          "\\.(css|less|scss|sass)$": "<rootDir>/__mocks__/styleMock.js"
+          "\\.(css|less|scss|sass)$": "<rootDir>/__mocks__/styleMock.js",
+          "\\?url$": "<rootDir>/__mocks__/urlMock.js"
         }
       },
       {

--- a/src/client/components/presentation/ScorePdfViewer.tsx
+++ b/src/client/components/presentation/ScorePdfViewer.tsx
@@ -1,3 +1,4 @@
+import workerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
   Box,
@@ -314,7 +315,7 @@ const ScorePdfViewer = ({
       try {
         const { GlobalWorkerOptions, getDocument } = await import("pdfjs-dist")
         if (cancelled) return
-        GlobalWorkerOptions.workerSrc = "/pdf.worker.min.mjs"
+        GlobalWorkerOptions.workerSrc = workerUrl
         loadingTask = getDocument({
           url,
           disableRange: true,


### PR DESCRIPTION
This pull request updates how the PDF.js worker is loaded in the `ScorePdfViewer` component to improve compatibility and bundling. The main change is switching from a hardcoded worker script path to using an imported worker URL, which is more robust and works better with modern build tools.