### PR TITLE
fix: repair legacy cue data and screen visibility state

### DIFF
--- a/e2e/gridlayout.spec.js
+++ b/e2e/gridlayout.spec.js
@@ -249,13 +249,6 @@ describe("GridLayout", () => {
     await expect(removeButton).toBeVisible()
     await removeButton.click()
 
-    await expect(
-      page.getByText(
-        "Screen 2 has existing elements. Deleting this screen will also delete all elements on this screen. Delete anyway?"
-      )
-    ).toBeVisible()
-    await page.getByRole("button", { name: "Yes" }).click()
-
     await expect(page.getByText("Screen removed").first()).toBeVisible()
     await expect(page.getByText("Screen removed").first()).not.toBeVisible({
       timeout: 5000,
@@ -294,7 +287,7 @@ describe("GridLayout", () => {
     await expect(page.getByText("Screen 2", { exact: true })).toBeVisible()
   })
 
-  test("new screen gets initial element", async ({ page }) => {
+  test("new screen has no initial element", async ({ page }) => {
     await page.getByText("testi").click()
 
     await revealScreenControls(page, 2)
@@ -302,12 +295,10 @@ describe("GridLayout", () => {
     await addButton.click()
     await expect(page.getByText("Screen 3", { exact: true })).toBeVisible()
 
-    const initialElementTestId = `cue-initial element for screen ${3}`
-    await page
-      .getByTestId(initialElementTestId)
-      .waitFor({ state: "visible", timeout: 20000 })
-
     await expect(page.getByText("Screen added").first()).toBeVisible()
+    await expect(
+      page.getByTestId(`cue-initial element for screen ${3}`)
+    ).not.toBeVisible()
   })
 
   test("screen management buttons only show on last screen", async ({

--- a/e2e/screen.spec.js
+++ b/e2e/screen.spec.js
@@ -58,6 +58,7 @@ describe("Screen", () => {
 
       await page.goto("http://localhost:3000/home")
       await page.getByText("title-test").click()
+      await addBlankCue(page, "test cue", "0", "2")
       //Goes to frame 4
       for (let i = 0; i < 4; i++) {
         await page.keyboard.press("ArrowRight")
@@ -133,6 +134,7 @@ describe("Screen", () => {
 
       await page.goto("http://localhost:3000/home")
       await page.getByText("title-test").click()
+      await addBlankCue(page, "test cue", "0", "2")
       // Goes to frame 4
       for (let i = 0; i < 4; i++) {
         await page.keyboard.press("ArrowRight")

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test-backend": "jest --coverage --selectProjects Backend",
     "coverage": "jest --coverage && xdg-open coverage/lcov-report/index.html",
     "build": "vite build",
+    "migrate:legacy-cues": "node src/server/scripts/migrateLegacyPresentationCues.js",
     "e2e": "playwright test --project=chromium --ui",
     "e2e-headless": "playwright test --project=chromium",
     "e2e:report": "playwright show-report",

--- a/src/client/components/presentation/EditModeContainer.tsx
+++ b/src/client/components/presentation/EditModeContainer.tsx
@@ -450,27 +450,18 @@ const EditModeContainer = ({
     [cues, indexCount]
   )
 
-  // Initialize screen visibility state based on cues and screen count
+  // Initialize screen visibility state for every screen number (1..screenCount)
   // - creates a visibility object with keys for each screen number and
   // values set to false (hidden) by default, then updates the state whenever cues or screen count changes
   useEffect(() => {
-    const screenNumberSet = new Set<number>()
-    ;(cues || [])
-      .filter((cue) => !isAudioRow(cue.screen, screenCount))
-      .forEach((cue) => {
-        screenNumberSet.add(Number(cue.screen))
-        // A spanning cue must be openable on every screen it spans, not
-        // just its own primary screen -- otherwise a screen with no cue of
-        // its own on any frame could never be opened to show its slice.
-        cue.spanScreens?.forEach((screenNumber) =>
-          screenNumberSet.add(Number(screenNumber))
-        )
-      })
-    const screenNumbers: number[] = [...screenNumberSet]
     const visibility: Record<string, boolean> = {}
-    screenNumbers.forEach((screenNumber) => {
+    for (
+      let screenNumber = 1;
+      screenNumber <= (screenCount ?? 0);
+      screenNumber += 1
+    ) {
       visibility[screenNumber] = false
-    })
+    }
     // Only add defaults for screen numbers we haven't seen yet - keep
     // existing screens' open/closed state untouched so that editing a cue
     // doesn't close every currently open presentation window

--- a/src/client/tests/unit/EditModeContainerScreens.test.jsx
+++ b/src/client/tests/unit/EditModeContainerScreens.test.jsx
@@ -239,12 +239,15 @@ describe("EditModeContainer screen visibility across cue edits", () => {
       "data-visible",
       "true"
     )
+    expect(screen.getByTestId("mock-screen-3")).toHaveAttribute(
+      "data-visible",
+      "true"
+    )
 
     editCue()
 
-    // Screens that were already open (1 and 2) stay open even though screen 2
-    // no longer has any cue assigned to it - only newly-seen screen numbers
-    // default to closed.
+    // Every declared screen (1..screenCount) is already open from "Toggle
+    // all screens", so moving a cue onto screen 3 doesn't change visibility.
     expect(screen.getByTestId("mock-screen-1")).toHaveAttribute(
       "data-visible",
       "true"
@@ -255,7 +258,7 @@ describe("EditModeContainer screen visibility across cue edits", () => {
     )
     expect(screen.getByTestId("mock-screen-3")).toHaveAttribute(
       "data-visible",
-      "false"
+      "true"
     )
   })
 })

--- a/src/server/models/presentation.js
+++ b/src/server/models/presentation.js
@@ -20,8 +20,39 @@ const {
   getMaxLayers,
 } = require("../utils/cueType")
 
-// Normalizes and validates cues, ensuring they have the correct cueType and screen assignments
-const normalizePresentationCues = (presentationObject) => {
+const normalizeCueLayer = (layer, cueType, repairInvalid) => {
+  if (layer === undefined || layer === null) {
+    return 0
+  }
+  const parsedLayer = Number(layer ?? 0)
+  const isValidLayer =
+    Number.isInteger(parsedLayer) &&
+    parsedLayer >= 0 &&
+    parsedLayer < getMaxLayers(cueType)
+
+  if (isValidLayer) {
+    return parsedLayer
+  }
+
+  return repairInvalid ? 0 : layer
+}
+
+const normalizeCueOpacity = (opacity, repairInvalid) => {
+  if (opacity === undefined || opacity === null) {
+    return 1
+  }
+  const parsedOpacity = Number(opacity ?? 1)
+  const isValidOpacity =
+    Number.isFinite(parsedOpacity) && parsedOpacity >= 0 && parsedOpacity <= 1
+
+  if (isValidOpacity) {
+    return parsedOpacity
+  }
+
+  return repairInvalid ? 1 : opacity
+}
+
+const normalizePresentationCues = (presentationObject, options = {}) => {
   const screenCount = Number(presentationObject.screenCount) || 1
   const cues = Array.isArray(presentationObject.cues)
     ? presentationObject.cues
@@ -38,6 +69,16 @@ const normalizePresentationCues = (presentationObject) => {
     return {
       ...normalizedCue,
       cueType,
+      layer: normalizeCueLayer(
+        normalizedCue.layer,
+        cueType,
+        options.repairInvalid === true
+      ),
+      opacity: normalizeCueOpacity(
+        normalizedCue.opacity,
+        options.repairInvalid === true
+      ),
+      continuePlayback: normalizedCue.continuePlayback ?? false,
       ...(cueType === "audio" ? { screen: getAudioRow(screenCount) } : {}),
     }
   })
@@ -419,7 +460,7 @@ presentationSchema.pre("save", function (next) {
 // Transform document when converting to JSON: format IDs and extract audio cues
 presentationSchema.set("toJSON", {
   transform: (document, returnedObject) => {
-    normalizePresentationCues(returnedObject)
+    normalizePresentationCues(returnedObject, { repairInvalid: true })
     returnedObject.audioCues = returnedObject.cues.filter(
       (cue) => cue.cueType === "audio"
     )

--- a/src/server/scripts/migrateLegacyPresentationCues.js
+++ b/src/server/scripts/migrateLegacyPresentationCues.js
@@ -1,0 +1,66 @@
+const mongoose = require("mongoose")
+const config = require("../utils/config")
+const {
+  normalizePresentation,
+  summarizeMigration,
+} = require("../utils/legacyPresentationMigration")
+
+const shouldApply = process.argv.includes("--apply")
+
+const main = async () => {
+  const uri = process.env.MONGODB_URI || config.MONGODB_URI
+  await mongoose.connect(uri)
+
+  const presentations = mongoose.connection.collection("presentations")
+  const documents = await presentations.find({}).toArray()
+  const results = documents.map(normalizePresentation)
+  const summary = summarizeMigration(results)
+
+  if (shouldApply && summary.duplicateSlots > 0) {
+    throw new Error(
+      "Refusing to apply migration while duplicate normalized slots exist"
+    )
+  }
+
+  if (shouldApply) {
+    const operations = results
+      .filter((result) => result.changed)
+      .map((result) => ({
+        updateOne: {
+          filter: { _id: result.presentation._id },
+          update: { $set: { cues: result.presentation.cues } },
+        },
+      }))
+
+    if (operations.length > 0) {
+      const writeResult = await presentations.bulkWrite(operations, {
+        ordered: false,
+      })
+      summary.modifiedCount = writeResult.modifiedCount
+      summary.matchedCount = writeResult.matchedCount
+    } else {
+      summary.modifiedCount = 0
+      summary.matchedCount = 0
+    }
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        mode: shouldApply ? "apply" : "dry-run",
+        ...summary,
+      },
+      null,
+      2
+    )
+  )
+}
+
+main()
+  .catch((error) => {
+    console.error(error.message)
+    process.exitCode = 1
+  })
+  .finally(async () => {
+    await mongoose.disconnect()
+  })

--- a/src/server/tests/legacyPresentationMigration.test.js
+++ b/src/server/tests/legacyPresentationMigration.test.js
@@ -1,0 +1,156 @@
+const {
+  normalizeCue,
+  normalizePresentation,
+  summarizeMigration,
+} = require("../utils/legacyPresentationMigration")
+
+describe("legacy presentation migration", () => {
+  test("adds missing layered timeline defaults to legacy visual cues", () => {
+    const result = normalizeCue({ index: 0, screen: 1, name: "Legacy" }, 3)
+
+    expect(result.cue).toEqual(
+      expect.objectContaining({
+        cueType: "visual",
+        screen: 1,
+        layer: 0,
+        opacity: 1,
+        continuePlayback: false,
+      })
+    )
+    expect(result.changes).toEqual([
+      "cueType",
+      "layer",
+      "opacity",
+      "continuePlayback",
+    ])
+  })
+
+  test("normalizes legacy audio cues to the synthetic audio row", () => {
+    const result = normalizeCue(
+      {
+        index: 0,
+        screen: 3,
+        cueType: "audio",
+        layer: 1,
+        opacity: 1,
+        continuePlayback: true,
+      },
+      4
+    )
+
+    expect(result.cue.screen).toBe(5)
+    expect(result.cue.layer).toBe(1)
+    expect(result.cue.continuePlayback).toBe(true)
+    expect(result.changes).toEqual(["screen"])
+  })
+
+  test("resets invalid layer and opacity values", () => {
+    const result = normalizeCue(
+      {
+        index: 0,
+        screen: 1,
+        cueType: "visual",
+        layer: 8,
+        opacity: 2,
+        continuePlayback: false,
+      },
+      2
+    )
+
+    expect(result.cue.layer).toBe(0)
+    expect(result.cue.opacity).toBe(1)
+    expect(result.changes).toEqual(["layer", "opacity"])
+  })
+
+  test("resets a non-integer layer even when it is within range", () => {
+    const result = normalizeCue(
+      {
+        index: 0,
+        screen: 1,
+        cueType: "visual",
+        layer: 1.5,
+        opacity: 1,
+        continuePlayback: false,
+      },
+      2
+    )
+
+    expect(result.cue.layer).toBe(0)
+    expect(result.changes).toEqual(["layer"])
+  })
+
+  test("keeps already-normalized cues unchanged", () => {
+    const result = normalizeCue(
+      {
+        index: 0,
+        screen: 1,
+        cueType: "visual",
+        layer: 0,
+        opacity: 0.5,
+        continuePlayback: false,
+      },
+      2
+    )
+
+    expect(result.changes).toEqual([])
+  })
+
+  test("normalizes a full presentation and reports duplicate slots", () => {
+    const presentation = {
+      _id: "presentation-1",
+      screenCount: 2,
+      cues: [
+        { index: 0, screen: 1, name: "A" },
+        { index: 0, screen: 1, name: "B" },
+      ],
+    }
+
+    const result = normalizePresentation(presentation)
+
+    expect(result.changed).toBe(true)
+    expect(result.changedFields).toEqual([
+      "continuePlayback",
+      "cueType",
+      "layer",
+      "opacity",
+    ])
+    expect(result.duplicateSlots).toBe(1)
+  })
+
+  test("summarizes migration results", () => {
+    const results = [
+      normalizePresentation({
+        _id: "presentation-1",
+        screenCount: 2,
+        cues: [{ index: 0, screen: 1 }],
+      }),
+      normalizePresentation({
+        _id: "presentation-2",
+        screenCount: 2,
+        cues: [
+          {
+            index: 0,
+            screen: 1,
+            cueType: "visual",
+            layer: 0,
+            opacity: 1,
+            continuePlayback: false,
+          },
+        ],
+      }),
+    ]
+
+    expect(summarizeMigration(results)).toEqual({
+      presentations: 2,
+      cues: 2,
+      changedPresentations: 1,
+      duplicateSlots: 0,
+      changedFields: {
+        continuePlayback: 1,
+        cueType: 1,
+        layer: 1,
+        opacity: 1,
+      },
+    })
+  })
+})

--- a/src/server/tests/presentation_api.test.js
+++ b/src/server/tests/presentation_api.test.js
@@ -155,6 +155,38 @@ describe("test presentation", () => {
         .expect(200)
         .expect("Content-Type", /application\/json/)
     })
+
+    test("legacy cues are returned with layered timeline defaults", async () => {
+      await Presentation.collection.updateOne(
+        { _id: testPresentationId },
+        {
+          $set: {
+            cues: [
+              {
+                _id: new mongoose.Types.ObjectId(),
+                index: 0,
+                screen: 1,
+                name: "Legacy cue",
+              },
+            ],
+          },
+        }
+      )
+
+      const response = await api
+        .get(`/api/presentation/${testPresentationId}`)
+        .set("Authorization", authHeader)
+        .expect(200)
+
+      expect(response.body.cues[0]).toEqual(
+        expect.objectContaining({
+          cueType: "visual",
+          layer: 0,
+          opacity: 1,
+          continuePlayback: false,
+        })
+      )
+    })
   })
 
   describe("Score documents", () => {

--- a/src/server/utils/legacyPresentationMigration.js
+++ b/src/server/utils/legacyPresentationMigration.js
@@ -1,0 +1,137 @@
+const { getAudioRow, getCueTypeFromScreen, getMaxLayers } = require("./cueType")
+
+const hasOwn = (object, key) =>
+  Object.prototype.hasOwnProperty.call(object, key)
+
+const isFiniteNumber = (value) => Number.isFinite(Number(value))
+const isValidLayerNumber = (value) => Number.isInteger(Number(value))
+
+const normalizeCue = (cue, screenCount) => {
+  const nextCue = { ...cue }
+  const changes = []
+
+  const cueType =
+    nextCue.cueType === "visual" || nextCue.cueType === "audio"
+      ? nextCue.cueType
+      : getCueTypeFromScreen(nextCue.screen, screenCount)
+
+  if (nextCue.cueType !== cueType) {
+    nextCue.cueType = cueType
+    changes.push("cueType")
+  }
+
+  if (
+    !hasOwn(nextCue, "layer") ||
+    nextCue.layer === null ||
+    !isValidLayerNumber(nextCue.layer)
+  ) {
+    nextCue.layer = 0
+    changes.push("layer")
+  }
+
+  const layer = Number(nextCue.layer)
+  if (layer < 0 || layer >= getMaxLayers(cueType)) {
+    nextCue.layer = 0
+    changes.push("layer")
+  }
+
+  if (
+    !hasOwn(nextCue, "opacity") ||
+    nextCue.opacity === null ||
+    !isFiniteNumber(nextCue.opacity) ||
+    Number(nextCue.opacity) < 0 ||
+    Number(nextCue.opacity) > 1
+  ) {
+    nextCue.opacity = 1
+    changes.push("opacity")
+  }
+
+  if (
+    !hasOwn(nextCue, "continuePlayback") ||
+    nextCue.continuePlayback === null
+  ) {
+    nextCue.continuePlayback = false
+    changes.push("continuePlayback")
+  }
+
+  if (
+    cueType === "audio" &&
+    Number(nextCue.screen) !== getAudioRow(screenCount)
+  ) {
+    nextCue.screen = getAudioRow(screenCount)
+    changes.push("screen")
+  }
+
+  return { cue: nextCue, changes }
+}
+
+const normalizedSlotKey = (cue, screenCount) => {
+  const cueType =
+    cue.cueType === "visual" || cue.cueType === "audio"
+      ? cue.cueType
+      : getCueTypeFromScreen(cue.screen, screenCount)
+  const screen =
+    cueType === "audio" ? getAudioRow(screenCount) : Number(cue.screen)
+  return [Number(cue.index), screen, Number(cue.layer ?? 0)].join(":")
+}
+
+const normalizePresentation = (presentation) => {
+  const screenCount = Number(presentation.screenCount) || 1
+  const cues = Array.isArray(presentation.cues) ? presentation.cues : []
+  const changedFields = new Set()
+  const slotCounts = new Map()
+
+  const normalizedCues = cues.map((cue) => {
+    const result = normalizeCue(cue, screenCount)
+    result.changes.forEach((field) => changedFields.add(field))
+    const key = normalizedSlotKey(result.cue, screenCount)
+    slotCounts.set(key, (slotCounts.get(key) || 0) + 1)
+    return result.cue
+  })
+
+  const duplicateSlots = [...slotCounts.values()].filter(
+    (count) => count > 1
+  ).length
+
+  return {
+    presentation: {
+      ...presentation,
+      cues: normalizedCues,
+    },
+    changed: changedFields.size > 0,
+    changedFields: [...changedFields].sort(),
+    duplicateSlots,
+  }
+}
+
+const summarizeMigration = (results) => {
+  return results.reduce(
+    (summary, result) => {
+      summary.presentations += 1
+      summary.cues += Array.isArray(result.presentation.cues)
+        ? result.presentation.cues.length
+        : 0
+      if (result.changed) {
+        summary.changedPresentations += 1
+      }
+      summary.duplicateSlots += result.duplicateSlots
+      for (const field of result.changedFields) {
+        summary.changedFields[field] = (summary.changedFields[field] || 0) + 1
+      }
+      return summary
+    },
+    {
+      presentations: 0,
+      cues: 0,
+      changedPresentations: 0,
+      duplicateSlots: 0,
+      changedFields: {},
+    }
+  )
+}
+
+module.exports = {
+  normalizeCue,
+  normalizePresentation,
+  summarizeMigration,
+}


### PR DESCRIPTION
Backfills missing layer/opacity defaults on legacy cues and fixes screen visibility state not being initialized for screens without cues.

Closes #893.