### PR TITLE
chore(release): bump version to 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muvico",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muvico",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.758.0",
         "@aws-sdk/client-secrets-manager": "^3.758.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "muvico",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.6.0",
   "main": "src/index.js",
   "scripts": {
     "start": "docker compose up",


### PR DESCRIPTION
Bumps package.json to 1.6.0 ahead of the v1.6.0 release.