### PR TITLE
feat(editor): rework the elements panel into one tab row with a media search

### DIFF
--- a/e2e/helper.js
+++ b/e2e/helper.js
@@ -84,10 +84,8 @@ const addBlankCue = async (page, name, index, screen) => {
   await dropArea.dispatchEvent("drop", { clientX, clientY, dataTransfer })
 }
 
-// Images, videos and audio share one pool and one input now; the tile shows
-// which kind an entry is, and the drop target still refuses audio on a visual
-// row. uploadAudioFile is kept as its own name so the audio specs still read
-// as being about audio.
+// One pool and one input for every kind. uploadAudioFile keeps its own name
+// so the audio specs still read as being about audio.
 const uploadMediaFile = async (page, files) => {
   await page.getByRole("tab", { name: "Media", exact: true }).click()
   await page.locator("#media-upload").setInputFiles(files)

--- a/e2e/helper.js
+++ b/e2e/helper.js
@@ -84,15 +84,16 @@ const addBlankCue = async (page, name, index, screen) => {
   await dropArea.dispatchEvent("drop", { clientX, clientY, dataTransfer })
 }
 
+// Images, videos and audio share one pool and one input now; the tile shows
+// which kind an entry is, and the drop target still refuses audio on a visual
+// row. uploadAudioFile is kept as its own name so the audio specs still read
+// as being about audio.
 const uploadMediaFile = async (page, files) => {
-  await page.getByRole("tab", { name: "Media" }).click()
+  await page.getByRole("tab", { name: "Media", exact: true }).click()
   await page.locator("#media-upload").setInputFiles(files)
 }
 
-const uploadAudioFile = async (page, files) => {
-  await page.getByRole("tab", { name: "Audio", exact: true }).click()
-  await page.locator("#sound-upload").setInputFiles(files)
-}
+const uploadAudioFile = uploadMediaFile
 
 const dragToGrid = async (page, source, index, screen) => {
   const dropArea = page.locator('[data-testid="drop-area"]')

--- a/src/client/components/presentation/CuesForm.tsx
+++ b/src/client/components/presentation/CuesForm.tsx
@@ -23,22 +23,16 @@ import {
   FormHelperText,
   Input,
   Button,
-  Heading,
-  Divider,
   Tooltip,
   Box,
   VStack,
   HStack,
   Text,
   SimpleGrid,
-  Image,
   IconButton,
   useColorModeValue,
-  Tabs,
-  TabList,
-  TabPanels,
-  Tab,
-  TabPanel,
+  InputGroup,
+  InputLeftElement,
   AlertDialog,
   AlertDialogBody,
   AlertDialogContent,
@@ -46,8 +40,7 @@ import {
   AlertDialogHeader,
   AlertDialogOverlay,
 } from "@chakra-ui/react"
-import { InfoOutlineIcon, DeleteIcon } from "@chakra-ui/icons"
-import { SpeakerIcon } from "../../lib/icons"
+import { InfoOutlineIcon, AddIcon, SearchIcon } from "@chakra-ui/icons"
 import { useState, useEffect, useRef } from "react"
 import type { ChangeEvent, FormEvent } from "react"
 import Error from "../utils/Error"
@@ -60,6 +53,7 @@ import {
   getAllowedMimeTypesForScreen,
 } from "../utils/fileTypeUtils"
 import mediaStore from "./mediaFileStore"
+import MediaPoolTile from "./MediaPoolTile"
 
 import type {
   Cue,
@@ -67,6 +61,12 @@ import type {
   CueUpdateInput,
   MediaLibraryItem,
 } from "../../types"
+
+// One input for every kind now that the audio pool was folded into the media
+// pool. Mirrors what the server accepts (isAllowedMimeType) rather than the
+// browser's own idea of "audio/*".
+const MEDIA_UPLOAD_ACCEPT =
+  "image/*,video/mp4,video/3gpp,audio/mpeg,audio/wav,audio/vnd.wave"
 
 // Create a transparent 1x1 pixel image to suppress the default browser drag ghost image
 const transparentDragImage = (() => {
@@ -130,6 +130,12 @@ interface CuesFormProps {
   mediaLibrary?: MediaLibraryItem[]
   onUploadMedia?: (file: File) => Promise<unknown>
   onDeleteMedia?: (mediaId: string) => Promise<unknown>
+  /**
+   * Which section to show. Controlled by EditorDock, which owns the single
+   * Colors / Media / Scores tab strip -- this component used to carry a second
+   * strip of its own underneath it.
+   */
+  activeTab?: "colors" | "media"
 }
 
 const CuesForm = ({
@@ -145,6 +151,7 @@ const CuesForm = ({
   mediaLibrary = [],
   onUploadMedia,
   onDeleteMedia,
+  activeTab = "media",
 }: CuesFormProps) => {
   // "" rather than null when empty: the dead form path compares `file !== ""`.
   const [file, setFile] = useState<File | "">("")
@@ -178,16 +185,18 @@ const CuesForm = ({
     "#ff007f",
   ]
 
-  // The pools are two views of the presentation's stored media library, split
-  // by MIME type. Entries live on the server, so they are still here after a
-  // reload -- unlike the previous in-memory File + blob: preview pool, which
-  // could not survive one.
-  const mediaFiles = mediaLibrary.filter(
-    (item) => !isAudioMimeType(item.type || "")
-  )
-  const soundFiles = mediaLibrary.filter((item) =>
-    isAudioMimeType(item.type || "")
-  )
+  // One pool for images, videos and audio alike: the tile shows what kind it
+  // is, and the drop target still refuses audio on a visual row. Entries live
+  // on the server, so they are all still here after a reload -- unlike the
+  // previous in-memory File + blob: preview pool, which could not survive one.
+  const [mediaSearch, setMediaSearch] = useState("")
+  const normalizedSearch = mediaSearch.trim().toLowerCase()
+  const visibleMedia = normalizedSearch
+    ? mediaLibrary.filter((item) =>
+        (item.name || "").toLowerCase().includes(normalizedSearch)
+      )
+    : mediaLibrary
+  const hasMedia = mediaLibrary.length > 0
   const [isUploading, setIsUploading] = useState(false)
   // Deleting a library entry deletes the stored object and every cue built from
   // it, so it goes through a confirmation rather than straight off the button.
@@ -195,21 +204,7 @@ const CuesForm = ({
     null
   )
   const mediaInputRef = useRef<HTMLInputElement | null>(null)
-  const soundInputRef = useRef<HTMLInputElement | null>(null)
   const cancelDeleteRef = useRef<HTMLButtonElement | null>(null)
-
-  const getInitialActiveTab = () => {
-    if (typeof window === "undefined") return "media"
-
-    const savedTab = window.localStorage.getItem("editModeMediaPoolActiveTab")
-    if (savedTab === "colors" || savedTab === "media" || savedTab === "audio") {
-      return savedTab
-    }
-
-    return "media"
-  }
-
-  const [activeTab, setActiveTab] = useState(getInitialActiveTab)
 
   const audioRow = getAudioRow(screenCount)
 
@@ -222,12 +217,6 @@ const CuesForm = ({
       setScreen(position.screen)
     }
   }, [position])
-
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem("editModeMediaPoolActiveTab", activeTab)
-    }
-  }, [activeTab])
 
   // Auto-calculate the next available index when adding a new cue
   useEffect(() => {
@@ -432,17 +421,12 @@ const CuesForm = ({
 
   const handleMediaUpload = async (event: ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(event.target.files ?? []).filter(
-      (file) => file.type.startsWith("image/") || file.type.startsWith("video/")
+      (file) =>
+        file.type.startsWith("image/") ||
+        file.type.startsWith("video/") ||
+        isAudioMimeType(file.type)
     )
     // Clearing lets the same file be picked again after a failed upload.
-    event.target.value = ""
-    await uploadToLibrary(files)
-  }
-
-  const handleSoundUpload = async (event: ChangeEvent<HTMLInputElement>) => {
-    const files = Array.from(event.target.files ?? []).filter((file) =>
-      isAudioMimeType(file.type)
-    )
     event.target.value = ""
     await uploadToLibrary(files)
   }
@@ -498,16 +482,13 @@ const CuesForm = ({
   const textColor = useColorModeValue("gray.800", "whiteAlpha.900")
   const mutedText = useColorModeValue("gray.600", "whiteAlpha.500")
 
-  const activeTabBg = surfaceBg
-  const activeTabColor = textColor
-  const inactiveTabBg = "transparent"
-  const inactiveTabColor = mutedText
-  const tabHoverBg = useColorModeValue("blackAlpha.50", "whiteAlpha.50")
+  const inputBorderColor = useColorModeValue("blackAlpha.300", "whiteAlpha.300")
+  const inputFocusColor = useColorModeValue("purple.500", "purple.300")
+  const scrollTrackBg = useColorModeValue("blackAlpha.50", "whiteAlpha.50")
+  const scrollThumbBg = useColorModeValue("blackAlpha.300", "whiteAlpha.300")
 
-  // Render the form with three tabs: Colors, Media, and Audio
-  // The colors tab allows creating colored elements by dragging them to the grid
-  // The media tab allows uploading and dragging images/videos to the grid
-  // The audio tab allows uploading and dragging audio files to the grid
+  // One section at a time, chosen by EditorDock's tab strip: colours to drag a
+  // solid onto the grid, or the media pool.
   return (
     <div className="cue-editor-form custom-scrollbar">
       <form
@@ -528,439 +509,243 @@ const CuesForm = ({
           minH={0}
           width="100%"
         >
-          <Box px={1} pb={3} flexShrink={0}>
-            <Heading size="sm" color={textColor}>
-              {cueData ? "Edit element" : "Add element"}
-            </Heading>
-          </Box>
-
-          <Tabs
-            index={["colors", "media", "audio"].indexOf(activeTab)}
-            onChange={(idx) => setActiveTab(["colors", "media", "audio"][idx])}
-            variant="enclosed"
-            size="sm"
-            display="flex"
-            flexDirection="column"
+          <Box
             flex="1 1 0"
             minHeight={0}
+            overflowY="auto"
+            bg={surfaceBg}
+            border="1px solid"
+            borderColor={borderColor}
+            borderRadius="md"
+            p={3}
+            sx={{
+              "&::-webkit-scrollbar": { width: "8px" },
+              "&::-webkit-scrollbar-track": {
+                bg: scrollTrackBg,
+                borderRadius: "4px",
+              },
+              "&::-webkit-scrollbar-thumb": {
+                bg: scrollThumbBg,
+                borderRadius: "4px",
+              },
+            }}
           >
-            <TabList flexShrink={0} borderColor={borderColor}>
-              {["Colors", "Media", "Audio"].map((tabLabel, idx) => {
-                const tabId = tabLabel.toLowerCase()
-                const isActive = activeTab === tabId
-                return (
-                  <Tab
-                    key={tabId}
-                    _selected={{
-                      color: activeTabColor,
-                      bg: activeTabBg,
-                      borderColor: borderColor,
-                      borderBottomColor: "transparent",
-                    }}
-                    color={inactiveTabColor}
-                    bg={inactiveTabBg}
-                    flex="1"
-                    borderTopRadius="md"
-                    borderBottomRadius="0"
-                    marginRight={idx < 2 ? "1px" : "0"}
-                    _hover={{
-                      bg: isActive ? activeTabBg : tabHoverBg,
-                      color: textColor,
-                    }}
-                    fontWeight={isActive ? "bold" : "normal"}
-                  >
-                    {tabLabel}
-                  </Tab>
-                )
-              })}
-            </TabList>
+            {activeTab === "colors" && (
+              <VStack spacing={3} align="stretch">
+                <FormHelperText color={mutedText} mt={0}>
+                  Select a color and drag it to the grid
+                </FormHelperText>
 
-            <TabPanels
-              flex="1 1 0"
-              minHeight={0}
-              overflowY="auto"
-              bg={surfaceBg}
-              border="1px solid"
-              borderColor={borderColor}
-              borderTop="none"
-              borderBottomRadius="md"
-              sx={{
-                "&::-webkit-scrollbar": { width: "8px" },
-                "&::-webkit-scrollbar-track": {
-                  bg: useColorModeValue("blackAlpha.50", "whiteAlpha.50"),
-                  borderRadius: "4px",
-                },
-                "&::-webkit-scrollbar-thumb": {
-                  bg: useColorModeValue("blackAlpha.300", "whiteAlpha.300"),
-                  borderRadius: "4px",
-                },
-              }}
-            >
-              <TabPanel p={3}>
-                <VStack spacing={3} align="stretch">
-                  <FormHelperText color={mutedText} mt={0}>
-                    Select a color and drag it to the grid
-                  </FormHelperText>
+                <ColorPickerWithPresets
+                  color={selectedColor}
+                  onChange={setSelectedColor}
+                  presetColors={presetColors}
+                />
+                <Input
+                  variant="flushed"
+                  data-testid="cue-name"
+                  id="cue-name"
+                  value={cueName}
+                  placeholder="Element name"
+                  color={textColor}
+                  borderColor={inputBorderColor}
+                  _focus={{ borderColor: inputFocusColor }}
+                  _placeholder={{ color: mutedText }}
+                  sx={{ caretColor: "currentColor" }}
+                  onChange={(e) => setCueName(e.target.value)}
+                  required
+                />
 
-                  <ColorPickerWithPresets
-                    color={selectedColor}
-                    onChange={setSelectedColor}
-                    presetColors={presetColors}
-                  />
-                  <Input
-                    variant="flushed"
-                    data-testid="cue-name"
-                    id="cue-name"
-                    value={cueName}
-                    placeholder="Element name"
-                    color={textColor}
-                    borderColor={useColorModeValue(
-                      "blackAlpha.300",
-                      "whiteAlpha.300"
-                    )}
-                    _focus={{
-                      borderColor: useColorModeValue(
-                        "purple.500",
-                        "purple.300"
-                      ),
-                    }}
-                    _placeholder={{ color: mutedText }}
-                    sx={{ caretColor: "currentColor" }}
-                    onChange={(e) => setCueName(e.target.value)}
-                    required
-                  />
+                <Box
+                  className="droppable-color-element"
+                  draggable={true}
+                  onDragStart={(e) => {
+                    suppressNativeDragGhost(e.dataTransfer)
+                    const normalizedCueName = cueName.trim()
+                    const dragData = {
+                      type: "newCueFromForm",
+                      cueName: normalizedCueName,
+                      color: selectedColor || "#e014ee",
+                      opacity: 1,
+                      elementType: "color",
+                    }
 
+                    mediaStore.setActiveDragData(dragData)
+
+                    e.dataTransfer.setData(
+                      "application/json",
+                      JSON.stringify(dragData)
+                    )
+                    e.dataTransfer.setData(
+                      "text/plain",
+                      JSON.stringify(dragData)
+                    )
+                  }}
+                  onDragEnd={() => mediaStore.clearActiveDragData()}
+                  p={3}
+                  mt={1}
+                  bg={selectedColor || "purple.500"}
+                  borderRadius="md"
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="center"
+                  cursor="grab"
+                  _active={{ cursor: "grabbing", transform: "scale(0.98)" }}
+                  _hover={{ opacity: 0.9 }}
+                  boxShadow="0 4px 12px rgba(0,0,0,0.2)"
+                  transition="all 0.1s"
+                >
                   <Box
-                    className="droppable-color-element"
-                    draggable={true}
-                    onDragStart={(e) => {
-                      suppressNativeDragGhost(e.dataTransfer)
-                      const normalizedCueName = cueName.trim()
-                      const dragData = {
-                        type: "newCueFromForm",
-                        cueName: normalizedCueName,
-                        color: selectedColor || "#e014ee",
-                        opacity: 1,
-                        elementType: "color",
-                      }
-
-                      mediaStore.setActiveDragData(dragData)
-
-                      e.dataTransfer.setData(
-                        "application/json",
-                        JSON.stringify(dragData)
-                      )
-                      e.dataTransfer.setData(
-                        "text/plain",
-                        JSON.stringify(dragData)
-                      )
-                    }}
-                    onDragEnd={() => mediaStore.clearActiveDragData()}
-                    p={3}
-                    mt={1}
-                    bg={selectedColor || "purple.500"}
-                    borderRadius="md"
-                    display="flex"
-                    alignItems="center"
-                    justifyContent="center"
-                    cursor="grab"
-                    _active={{ cursor: "grabbing", transform: "scale(0.98)" }}
-                    _hover={{ opacity: 0.9 }}
-                    boxShadow="0 4px 12px rgba(0,0,0,0.2)"
-                    transition="all 0.1s"
+                    mr={2}
+                    opacity={0.8}
+                    color={getContrastTextColor(selectedColor)}
                   >
-                    <Box
-                      mr={2}
-                      opacity={0.8}
-                      color={getContrastTextColor(selectedColor)}
+                    <svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      fill="currentColor"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        width="16"
-                        height="16"
-                        viewBox="0 0 16 16"
-                        fill="currentColor"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <circle cx="5" cy="3" r="1.5" />
-                        <circle cx="5" cy="8" r="1.5" />
-                        <circle cx="5" cy="13" r="1.5" />
-                        <circle cx="11" cy="3" r="1.5" />
-                        <circle cx="11" cy="8" r="1.5" />
-                        <circle cx="11" cy="13" r="1.5" />
-                      </svg>
-                    </Box>
-                    <Text
-                      color={getContrastTextColor(selectedColor)}
-                      fontWeight="bold"
-                      fontSize="sm"
-                    >
-                      Drag to grid
-                    </Text>
+                      <circle cx="5" cy="3" r="1.5" />
+                      <circle cx="5" cy="8" r="1.5" />
+                      <circle cx="5" cy="13" r="1.5" />
+                      <circle cx="11" cy="3" r="1.5" />
+                      <circle cx="11" cy="8" r="1.5" />
+                      <circle cx="11" cy="13" r="1.5" />
+                    </svg>
                   </Box>
-                </VStack>
-              </TabPanel>
-
-              <TabPanel p={3}>
-                <VStack spacing={4} align="stretch">
-                  <FormHelperText color={mutedText}>
-                    Upload images or videos and drag them to the grid
-                    <Tooltip
-                      label={
-                        <>
-                          <strong>Valid image types: </strong>.apng, .avif,
-                          .bmp, .cur, .gif, .ico, .jfif, .jpe, .jpeg, .jpg,
-                          .png, .svg and .webp
-                          <br />
-                          <strong>Valid video types: </strong> .mp4 and .3gp
-                        </>
-                      }
-                      placement="right-end"
-                      p={2}
-                      fontSize="sm"
-                    >
-                      <Button
-                        variant="ghost"
-                        size="xs"
-                        marginLeft={2}
-                        color={mutedText}
-                      >
-                        <InfoOutlineIcon />
-                      </Button>
-                    </Tooltip>
-                  </FormHelperText>
-
-                  <Input
-                    type="file"
-                    id="media-upload"
-                    ref={mediaInputRef}
-                    style={{ display: "none" }}
-                    onChange={handleMediaUpload}
-                    accept="image/*,video/mp4,video/3gpp"
-                    multiple
-                  />
-
-                  <Button
-                    onClick={() => mediaInputRef.current?.click()}
-                    colorScheme="purple"
-                    variant="outline"
-                    isLoading={isUploading}
-                    loadingText="Uploading"
+                  <Text
+                    color={getContrastTextColor(selectedColor)}
+                    fontWeight="bold"
+                    fontSize="sm"
                   >
-                    Upload Images/Videos
-                  </Button>
+                    Drag to grid
+                  </Text>
+                </Box>
+              </VStack>
+            )}
 
-                  {mediaFiles.length > 0 && (
-                    <>
-                      <Divider />
-                      <Text fontWeight="bold" color={textColor}>
-                        Media Pool ({mediaFiles.length})
-                      </Text>
-                      <SimpleGrid columns={2} spacing={3}>
-                        {mediaFiles.map((media) => (
-                          <Box
-                            key={media.id}
-                            draggable={true}
-                            onDragStart={(e) => {
-                              suppressNativeDragGhost(e.dataTransfer)
-                              // mediaId addresses the stored entry; the drop
-                              // handler sends it to the server, which reuses
-                              // that object instead of uploading anything.
-                              const dragData = {
-                                type: "newCueFromForm",
-                                cueName: media.name,
-                                elementType: "media",
-                                mediaId: media.id,
-                                mimeType: media.type,
-                                previewUrl: media.url,
-                              }
-                              mediaStore.setActiveDragData(dragData)
+            {activeTab === "media" && (
+              <VStack spacing={3} align="stretch">
+                <Input
+                  type="file"
+                  id="media-upload"
+                  ref={mediaInputRef}
+                  style={{ display: "none" }}
+                  onChange={handleMediaUpload}
+                  accept={MEDIA_UPLOAD_ACCEPT}
+                  multiple
+                />
 
-                              e.dataTransfer.setData(
-                                "application/json",
-                                JSON.stringify(dragData)
-                              )
-                              e.dataTransfer.setData(
-                                "text/plain",
-                                JSON.stringify(dragData)
-                              )
-                            }}
-                            onDragEnd={() => mediaStore.clearActiveDragData()}
-                            position="relative"
-                            border="2px solid"
-                            borderColor="purple.300"
-                            borderRadius="md"
-                            p={2}
-                            cursor="grab"
-                            _active={{ cursor: "grabbing" }}
-                            _hover={{
-                              borderColor: "purple.500",
-                              bg: "whiteAlpha.100",
-                            }}
-                          >
-                            <IconButton
-                              aria-label={`Remove ${media.name}`}
-                              icon={<DeleteIcon />}
-                              size="xs"
-                              colorScheme="red"
-                              position="absolute"
-                              top={1}
-                              right={1}
-                              onClick={() => setPendingDelete(media)}
-                              zIndex={1}
-                            />
-                            {media.type?.startsWith("image/") && (
-                              <Image
-                                src={media.url}
-                                alt={media.name}
-                                maxH="100px"
-                                objectFit="contain"
-                                w="100%"
-                              />
-                            )}
-                            {media.type?.startsWith("video/") && (
-                              <Box
-                                bg="whiteAlpha.200"
-                                p={4}
-                                textAlign="center"
-                                borderRadius="md"
-                              >
-                                <Text fontSize="2xl">🎥</Text>
-                              </Box>
-                            )}
-                            <Text
-                              fontSize="xs"
-                              mt={1}
-                              noOfLines={1}
-                              color={textColor}
-                            >
-                              {media.name}
-                            </Text>
-                          </Box>
-                        ))}
-                      </SimpleGrid>
-                    </>
-                  )}
-                </VStack>
-              </TabPanel>
+                {hasMedia && (
+                  <HStack spacing={2} align="center">
+                    <InputGroup size="sm">
+                      <InputLeftElement pointerEvents="none">
+                        <SearchIcon color={mutedText} />
+                      </InputLeftElement>
+                      <Input
+                        id="media-search"
+                        aria-label="Search media"
+                        placeholder="Search media"
+                        value={mediaSearch}
+                        onChange={(event) => setMediaSearch(event.target.value)}
+                        color={textColor}
+                        _placeholder={{ color: mutedText }}
+                        sx={{ caretColor: "currentColor" }}
+                      />
+                    </InputGroup>
 
-              <TabPanel p={3}>
-                <VStack spacing={4} align="stretch">
-                  <FormHelperText color={mutedText}>
-                    Upload audio files and drag them to the grid
-                    <Tooltip
-                      label={
-                        <>
-                          <strong>Valid audio types: </strong> .mp3 and .wav
-                        </>
-                      }
-                      placement="right-end"
-                      p={2}
-                      fontSize="sm"
-                    >
-                      <Button
-                        variant="ghost"
-                        size="xs"
-                        marginLeft={2}
-                        color={mutedText}
-                      >
-                        <InfoOutlineIcon />
-                      </Button>
+                    {/* Compact once there is something in the pool: the big
+                        button belongs to the empty state, where uploading is
+                        the only thing left to do. */}
+                    <Tooltip label="Upload media" placement="bottom-end">
+                      <IconButton
+                        aria-label="Upload media"
+                        icon={<AddIcon />}
+                        size="sm"
+                        colorScheme="purple"
+                        isLoading={isUploading}
+                        onClick={() => mediaInputRef.current?.click()}
+                      />
                     </Tooltip>
-                  </FormHelperText>
+                  </HStack>
+                )}
 
-                  <Input
-                    type="file"
-                    id="sound-upload"
-                    ref={soundInputRef}
-                    style={{ display: "none" }}
-                    onChange={handleSoundUpload}
-                    accept="audio/mpeg,audio/wav,audio/vnd.wave"
-                    multiple
-                  />
+                {!hasMedia && (
+                  <VStack spacing={4} align="stretch" py={4}>
+                    <FormHelperText color={mutedText} mt={0} textAlign="center">
+                      Upload images, videos or audio and drag them to the grid
+                      <Tooltip
+                        label={
+                          <>
+                            <strong>Valid image types: </strong>.apng, .avif,
+                            .bmp, .cur, .gif, .ico, .jfif, .jpe, .jpeg, .jpg,
+                            .png, .svg and .webp
+                            <br />
+                            <strong>Valid video types: </strong> .mp4 and .3gp
+                            <br />
+                            <strong>Valid audio types: </strong> .mp3 and .wav
+                          </>
+                        }
+                        placement="right-end"
+                        p={2}
+                        fontSize="sm"
+                      >
+                        <Button
+                          variant="ghost"
+                          size="xs"
+                          marginLeft={2}
+                          color={mutedText}
+                        >
+                          <InfoOutlineIcon />
+                        </Button>
+                      </Tooltip>
+                    </FormHelperText>
 
-                  <Button
-                    onClick={() => soundInputRef.current?.click()}
-                    colorScheme="purple"
-                    variant="outline"
-                    isLoading={isUploading}
-                    loadingText="Uploading"
-                  >
-                    Upload Audio Files
-                  </Button>
+                    <Button
+                      data-testid="media-upload-cta"
+                      size="lg"
+                      colorScheme="purple"
+                      leftIcon={<AddIcon />}
+                      isLoading={isUploading}
+                      loadingText="Uploading"
+                      onClick={() => mediaInputRef.current?.click()}
+                    >
+                      Upload media
+                    </Button>
+                  </VStack>
+                )}
 
-                  {soundFiles.length > 0 && (
-                    <>
-                      <Divider />
-                      <Text fontWeight="bold" color={textColor}>
-                        Sound Pool ({soundFiles.length})
-                      </Text>
-                      <VStack spacing={2} align="stretch">
-                        {soundFiles.map((sound) => (
-                          <Box
-                            key={sound.id}
-                            draggable={true}
-                            onDragStart={(e) => {
-                              suppressNativeDragGhost(e.dataTransfer)
-                              const dragData = {
-                                type: "newCueFromForm",
-                                cueName: sound.name,
-                                elementType: "sound",
-                                soundId: sound.id,
-                                mimeType: sound.type,
-                              }
-                              mediaStore.setActiveDragData(dragData)
+                {hasMedia && (
+                  <Text fontSize="xs" color={mutedText}>
+                    {normalizedSearch
+                      ? `Media Pool (${visibleMedia.length} of ${mediaLibrary.length})`
+                      : `Media Pool (${mediaLibrary.length})`}
+                  </Text>
+                )}
 
-                              e.dataTransfer.setData(
-                                "application/json",
-                                JSON.stringify(dragData)
-                              )
-                              e.dataTransfer.setData(
-                                "text/plain",
-                                JSON.stringify(dragData)
-                              )
-                            }}
-                            onDragEnd={() => mediaStore.clearActiveDragData()}
-                            display="flex"
-                            alignItems="center"
-                            justifyContent="space-between"
-                            border="2px solid"
-                            borderColor="purple.300"
-                            borderRadius="md"
-                            p={3}
-                            cursor="grab"
-                            _active={{ cursor: "grabbing" }}
-                            _hover={{
-                              borderColor: "purple.500",
-                              bg: "whiteAlpha.100",
-                            }}
-                          >
-                            <Box
-                              display="flex"
-                              alignItems="center"
-                              flex={1}
-                              color={textColor}
-                            >
-                              <SpeakerIcon boxSize="20px" mr={2} />
-                              <Text fontSize="sm" noOfLines={1}>
-                                {sound.name}
-                              </Text>
-                            </Box>
-                            <IconButton
-                              aria-label={`Remove ${sound.name}`}
-                              icon={<DeleteIcon />}
-                              size="sm"
-                              colorScheme="red"
-                              onClick={() => setPendingDelete(sound)}
-                            />
-                          </Box>
-                        ))}
-                      </VStack>
-                    </>
-                  )}
-                </VStack>
-              </TabPanel>
-            </TabPanels>
-          </Tabs>
+                {hasMedia && visibleMedia.length === 0 && (
+                  <Text fontSize="sm" color={mutedText} py={4}>
+                    No media matches &quot;{mediaSearch.trim()}&quot;.
+                  </Text>
+                )}
+
+                {visibleMedia.length > 0 && (
+                  <SimpleGrid columns={2} spacing={3}>
+                    {visibleMedia.map((item) => (
+                      <MediaPoolTile
+                        key={item.id}
+                        item={item}
+                        onDelete={setPendingDelete}
+                        suppressDragGhost={suppressNativeDragGhost}
+                      />
+                    ))}
+                  </SimpleGrid>
+                )}
+              </VStack>
+            )}
+          </Box>
 
           {error && <Error error={error} />}
         </FormControl>

--- a/src/client/components/presentation/CuesForm.tsx
+++ b/src/client/components/presentation/CuesForm.tsx
@@ -62,9 +62,7 @@ import type {
   MediaLibraryItem,
 } from "../../types"
 
-// One input for every kind now that the audio pool was folded into the media
-// pool. Mirrors what the server accepts (isAllowedMimeType) rather than the
-// browser's own idea of "audio/*".
+// One input for every kind. Mirrors the server's isAllowedMimeType.
 const MEDIA_UPLOAD_ACCEPT =
   "image/*,video/mp4,video/3gpp,audio/mpeg,audio/wav,audio/vnd.wave"
 
@@ -130,11 +128,7 @@ interface CuesFormProps {
   mediaLibrary?: MediaLibraryItem[]
   onUploadMedia?: (file: File) => Promise<unknown>
   onDeleteMedia?: (mediaId: string) => Promise<unknown>
-  /**
-   * Which section to show. Controlled by EditorDock, which owns the single
-   * Colors / Media / Scores tab strip -- this component used to carry a second
-   * strip of its own underneath it.
-   */
+  /** Which section to show. EditorDock owns the tab strip. */
   activeTab?: "colors" | "media"
 }
 
@@ -185,10 +179,7 @@ const CuesForm = ({
     "#ff007f",
   ]
 
-  // One pool for images, videos and audio alike: the tile shows what kind it
-  // is, and the drop target still refuses audio on a visual row. Entries live
-  // on the server, so they are all still here after a reload -- unlike the
-  // previous in-memory File + blob: preview pool, which could not survive one.
+  // One pool for every kind; entries live on the server, so a reload keeps them.
   const [mediaSearch, setMediaSearch] = useState("")
   const normalizedSearch = mediaSearch.trim().toLowerCase()
   const visibleMedia = normalizedSearch
@@ -399,8 +390,7 @@ const CuesForm = ({
     setError(null)
   }
 
-  // Uploading is a network call now, not a local push: the file is stored the
-  // moment it is picked, whether or not it is ever dragged onto the timeline.
+  // Uploading stores the file immediately, used on the timeline or not.
   const uploadToLibrary = async (files: File[]) => {
     if (!onUploadMedia || files.length === 0) {
       return
@@ -431,9 +421,7 @@ const CuesForm = ({
     await uploadToLibrary(files)
   }
 
-  // Cues built from a library entry share its stored object, so there is no
-  // way to keep them working once the entry is gone -- hence the count in the
-  // dialog below.
+  // Cues share the entry's stored object, so they cannot outlive it.
   const cuesUsingPendingDelete = pendingDelete
     ? cues.filter((cue) => cue.file?.id === pendingDelete.id).length
     : 0
@@ -487,8 +475,7 @@ const CuesForm = ({
   const scrollTrackBg = useColorModeValue("blackAlpha.50", "whiteAlpha.50")
   const scrollThumbBg = useColorModeValue("blackAlpha.300", "whiteAlpha.300")
 
-  // One section at a time, chosen by EditorDock's tab strip: colours to drag a
-  // solid onto the grid, or the media pool.
+  // One section at a time: colours to drag onto the grid, or the media pool.
   return (
     <div className="cue-editor-form custom-scrollbar">
       <form
@@ -656,9 +643,7 @@ const CuesForm = ({
                       />
                     </InputGroup>
 
-                    {/* Compact once there is something in the pool: the big
-                        button belongs to the empty state, where uploading is
-                        the only thing left to do. */}
+                    {/* The big button belongs to the empty state. */}
                     <Tooltip label="Upload media" placement="bottom-end">
                       <IconButton
                         aria-label="Upload media"

--- a/src/client/components/presentation/EditorDock.tsx
+++ b/src/client/components/presentation/EditorDock.tsx
@@ -2,13 +2,12 @@ import type React from "react"
 import { useCallback, useEffect, useRef, useState } from "react"
 import {
   Box,
-  Button,
-  ButtonGroup,
-  HStack,
+  Tab,
+  TabList,
+  Tabs,
   VStack,
   useColorModeValue,
 } from "@chakra-ui/react"
-import { AttachmentIcon, ViewIcon } from "@chakra-ui/icons"
 import CuesForm from "./CuesForm"
 import ScorePanel from "./ScorePanel"
 import { useAppDispatch, useAppSelector } from "../../redux/hooks"
@@ -16,12 +15,31 @@ import { removeMedia, uploadMedia } from "../../redux/presentationReducer"
 
 import type { Cue, CueUpdateInput, ScoreDocument } from "../../types"
 
-type DockTab = "elements" | "scores"
+type DockTab = "colors" | "media" | "scores"
+
+const DOCK_TABS: { id: DockTab; label: string }[] = [
+  { id: "colors", label: "Colors" },
+  { id: "media", label: "Media" },
+  { id: "scores", label: "Scores" },
+]
 
 const DOCK_WIDTH_KEY = "muvico.dockWidth"
+// Same key the media pool used for its own strip, which this one replaces. A
+// stored "audio" lands on Media, where audio now lives.
+const DOCK_TAB_KEY = "editModeMediaPoolActiveTab"
 const DOCK_MIN = 280
 const DOCK_MAX = 760
 const DOCK_DEFAULT = 380
+
+function readStoredTab(): DockTab {
+  try {
+    const saved = localStorage.getItem(DOCK_TAB_KEY)
+    if (DOCK_TABS.some((tab) => tab.id === saved)) {
+      return saved as DockTab
+    }
+  } catch {}
+  return "media"
+}
 
 function readStoredWidth(): number {
   try {
@@ -76,19 +94,28 @@ const EditorDock = ({
     [dispatch, presentationId]
   )
 
-  const [activeTab, setActiveTab] = useState<DockTab>("elements")
+  const [activeTab, setActiveTab] = useState<DockTab>(readStoredTab)
   const [dockWidth, setDockWidth] = useState<number>(readStoredWidth)
   const isDragging = useRef(false)
   const dragStartX = useRef(0)
   const dragStartWidth = useRef(0)
   const containerRef = useRef<HTMLDivElement | null>(null)
 
-  const tabBg = useColorModeValue("whiteAlpha.700", "blackAlpha.300")
-  const activeBg = useColorModeValue("purple.500", "purple.300")
-  const activeColor = useColorModeValue("white", "gray.900")
-  const inactiveColor = useColorModeValue("gray.900", "whiteAlpha.900")
+  const surfaceBg = useColorModeValue("gray.50", "#140f1a")
+  const borderColor = useColorModeValue("purple.200", "whiteAlpha.200")
+  const textColor = useColorModeValue("gray.800", "whiteAlpha.900")
+  const mutedText = useColorModeValue("gray.600", "whiteAlpha.500")
+  const tabHoverBg = useColorModeValue("blackAlpha.50", "whiteAlpha.50")
   const handleColor = useColorModeValue("purple.200", "purple.800")
   const handleHoverColor = useColorModeValue("purple.400", "purple.500")
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(DOCK_TAB_KEY, activeTab)
+    } catch {
+      // ignore
+    }
+  }, [activeTab])
 
   /* Persist width to localStorage */
   useEffect(() => {
@@ -179,26 +206,47 @@ const EditorDock = ({
         pl="5px"
       >
         {/* ── Tab switcher ─────────────────────────────────────────────── */}
-        <HStack justify="flex-end" align="center" px={2} pt={2}>
-          <ButtonGroup isAttached size="sm" bg={tabBg} borderRadius="8px">
-            <Button
-              leftIcon={<AttachmentIcon />}
-              bg={activeTab === "elements" ? activeBg : "transparent"}
-              color={activeTab === "elements" ? activeColor : inactiveColor}
-              onClick={() => setActiveTab("elements")}
-            >
-              Elements
-            </Button>
-            <Button
-              leftIcon={<ViewIcon />}
-              bg={activeTab === "scores" ? activeBg : "transparent"}
-              color={activeTab === "scores" ? activeColor : inactiveColor}
-              onClick={() => setActiveTab("scores")}
-            >
-              Scores
-            </Button>
-          </ButtonGroup>
-        </HStack>
+        {/* One strip for the whole dock. There used to be a second one inside
+            CuesForm, so the panel opened on two rows of tabs stacked on top of
+            each other. */}
+        <Tabs
+          index={DOCK_TABS.findIndex((tab) => tab.id === activeTab)}
+          onChange={(index) => setActiveTab(DOCK_TABS[index].id)}
+          variant="enclosed"
+          size="sm"
+          flexShrink={0}
+          pt={2}
+        >
+          <TabList borderColor={borderColor}>
+            {DOCK_TABS.map((tab, index) => {
+              const isActive = activeTab === tab.id
+              return (
+                <Tab
+                  key={tab.id}
+                  _selected={{
+                    color: textColor,
+                    bg: surfaceBg,
+                    borderColor: borderColor,
+                    borderBottomColor: "transparent",
+                  }}
+                  color={mutedText}
+                  bg="transparent"
+                  flex="1"
+                  borderTopRadius="md"
+                  borderBottomRadius="0"
+                  marginRight={index < DOCK_TABS.length - 1 ? "1px" : "0"}
+                  _hover={{
+                    bg: isActive ? surfaceBg : tabHoverBg,
+                    color: textColor,
+                  }}
+                  fontWeight={isActive ? "bold" : "normal"}
+                >
+                  {tab.label}
+                </Tab>
+              )
+            })}
+          </TabList>
+        </Tabs>
 
         {/* ── Tab content ──────────────────────────────────────────────── */}
         <Box
@@ -210,8 +258,11 @@ const EditorDock = ({
           overflow={activeTab === "scores" ? "hidden" : "auto"}
           p={activeTab === "scores" ? 2 : undefined}
         >
-          {activeTab === "elements" ? (
+          {activeTab === "scores" ? (
+            <ScorePanel presentationId={presentationId} scores={scores} />
+          ) : (
             <CuesForm
+              activeTab={activeTab}
               addCue={addCue}
               onClose={onClose}
               position={position}
@@ -225,8 +276,6 @@ const EditorDock = ({
               onUploadMedia={handleUploadMedia}
               onDeleteMedia={handleDeleteMedia}
             />
-          ) : (
-            <ScorePanel presentationId={presentationId} scores={scores} />
           )}
         </Box>
       </VStack>

--- a/src/client/components/presentation/EditorDock.tsx
+++ b/src/client/components/presentation/EditorDock.tsx
@@ -24,8 +24,7 @@ const DOCK_TABS: { id: DockTab; label: string }[] = [
 ]
 
 const DOCK_WIDTH_KEY = "muvico.dockWidth"
-// Same key the media pool used for its own strip, which this one replaces. A
-// stored "audio" lands on Media, where audio now lives.
+// A stored "audio" falls back to Media, where audio now lives.
 const DOCK_TAB_KEY = "editModeMediaPoolActiveTab"
 const DOCK_MIN = 280
 const DOCK_MAX = 760
@@ -80,8 +79,7 @@ const EditorDock = ({
   indexCount,
 }: EditorDockProps) => {
   const dispatch = useAppDispatch()
-  // The dock, not CuesForm, owns the store wiring: CuesForm is unit-tested
-  // rendered standalone, with no Provider around it.
+  // The dock owns the store wiring: CuesForm is tested without a Provider.
   const mediaLibrary = useAppSelector((state) => state.presentation.media)
 
   const handleUploadMedia = useCallback(
@@ -206,9 +204,7 @@ const EditorDock = ({
         pl="5px"
       >
         {/* ── Tab switcher ─────────────────────────────────────────────── */}
-        {/* One strip for the whole dock. There used to be a second one inside
-            CuesForm, so the panel opened on two rows of tabs stacked on top of
-            each other. */}
+        {/* One strip for the whole dock. */}
         <Tabs
           index={DOCK_TABS.findIndex((tab) => tab.id === activeTab)}
           onChange={(index) => setActiveTab(DOCK_TABS[index].id)}

--- a/src/client/components/presentation/MediaPoolTile.tsx
+++ b/src/client/components/presentation/MediaPoolTile.tsx
@@ -1,10 +1,4 @@
-/**
- * One draggable tile in the media pool.
- *
- * The three media kinds need genuinely different previews -- a still, a video
- * frame, a single icon -- so the whole tile lives here rather than as three
- * branches inside CuesForm's render.
- */
+/** One draggable tile in the media pool: still, video frame, or audio icon. */
 
 import {
   Box,
@@ -13,10 +7,11 @@ import {
   Text,
   useColorModeValue,
 } from "@chakra-ui/react"
-import { DeleteIcon } from "@chakra-ui/icons"
+import { DeleteIcon, WarningTwoIcon } from "@chakra-ui/icons"
 import { SpeakerIcon } from "../../lib/icons"
 import mediaStore from "./mediaFileStore"
 
+import { useState } from "react"
 import { dragDataForMedia, mediaKind } from "../utils/mediaKind"
 
 import type { MediaLibraryItem } from "../../types"
@@ -27,7 +22,8 @@ interface MediaPoolTileProps {
   suppressDragGhost: (dataTransfer: DataTransfer | null) => void
 }
 
-const PREVIEW_HEIGHT = "100px"
+// One height for every kind; previews crop rather than letterbox.
+const PREVIEW_HEIGHT = "68px"
 
 const MediaPoolTile = ({
   item,
@@ -37,7 +33,8 @@ const MediaPoolTile = ({
   const textColor = useColorModeValue("gray.800", "whiteAlpha.900")
   const mutedText = useColorModeValue("gray.600", "whiteAlpha.500")
   const placeholderBg = useColorModeValue("blackAlpha.50", "whiteAlpha.200")
-  const kind = mediaKind(item.type)
+  const kind = mediaKind(item)
+  const [isBroken, setIsBroken] = useState(false)
 
   return (
     <Box
@@ -72,21 +69,37 @@ const MediaPoolTile = ({
         zIndex={1}
       />
 
-      {kind === "image" && (
+      {kind === "image" && !isBroken && (
         <Image
           src={item.url}
           alt={item.name}
-          maxH={PREVIEW_HEIGHT}
-          objectFit="contain"
+          h={PREVIEW_HEIGHT}
+          objectFit="cover"
           w="100%"
+          borderRadius="md"
+          // An entry can outlive its stored object; show that, not a blank tile.
+          onError={() => setIsBroken(true)}
         />
       )}
 
-      {kind === "video" && (
+      {isBroken && (
+        <Box
+          h={PREVIEW_HEIGHT}
+          bg={placeholderBg}
+          borderRadius="md"
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          title="This file is no longer in storage"
+        >
+          <WarningTwoIcon boxSize="20px" color={mutedText} />
+        </Box>
+      )}
+
+      {kind === "video" && !isBroken && (
         <Box position="relative" borderRadius="md" overflow="hidden">
-          {/* The media fragment asks for a frame just past the start: at
-              exactly 0s some encodes hand back a black frame. `preload` is
-              metadata only, so this costs a range request, not the file. */}
+          {/* Past 0s, where some encodes are black. Metadata only: a range
+              request, not the whole file. */}
           <Box
             as="video"
             data-testid={`video-preview-${item.id}`}
@@ -96,8 +109,9 @@ const MediaPoolTile = ({
             preload="metadata"
             h={PREVIEW_HEIGHT}
             w="100%"
-            objectFit="contain"
-            // The tile owns the drag; a video element would swallow the press.
+            objectFit="cover"
+            onError={() => setIsBroken(true)}
+            // The tile owns the drag; the video would swallow the press.
             sx={{ pointerEvents: "none", backgroundColor: "black" }}
           />
           <Box
@@ -116,7 +130,7 @@ const MediaPoolTile = ({
         </Box>
       )}
 
-      {kind === "audio" && (
+      {kind === "audio" && !isBroken && (
         <Box
           h={PREVIEW_HEIGHT}
           bg={placeholderBg}
@@ -125,7 +139,7 @@ const MediaPoolTile = ({
           alignItems="center"
           justifyContent="center"
         >
-          <SpeakerIcon boxSize="32px" color={mutedText} />
+          <SpeakerIcon boxSize="22px" color={mutedText} />
         </Box>
       )}
 

--- a/src/client/components/presentation/MediaPoolTile.tsx
+++ b/src/client/components/presentation/MediaPoolTile.tsx
@@ -48,15 +48,19 @@ const MediaPoolTile = ({
         event.dataTransfer.setData("text/plain", JSON.stringify(dragData))
       }}
       onDragEnd={() => mediaStore.clearActiveDragData()}
+      role="group"
       position="relative"
       border="2px solid"
-      borderColor="purple.300"
+      borderColor="transparent"
       borderRadius="md"
       p={2}
       cursor="grab"
+      transition="border-color 0.15s, background 0.15s"
       _active={{ cursor: "grabbing" }}
-      _hover={{ borderColor: "purple.500", bg: "whiteAlpha.100" }}
+      _hover={{ borderColor: "purple.400", bg: "whiteAlpha.100" }}
+      _focusWithin={{ borderColor: "purple.400" }}
     >
+      {/* Hover-only, but still focusable so it stays reachable by keyboard. */}
       <IconButton
         aria-label={`Remove ${item.name}`}
         icon={<DeleteIcon />}
@@ -67,6 +71,10 @@ const MediaPoolTile = ({
         right={1}
         onClick={() => onDelete(item)}
         zIndex={1}
+        opacity={0}
+        transition="opacity 0.15s"
+        _groupHover={{ opacity: 1 }}
+        _focusVisible={{ opacity: 1 }}
       />
 
       {kind === "image" && !isBroken && (

--- a/src/client/components/presentation/MediaPoolTile.tsx
+++ b/src/client/components/presentation/MediaPoolTile.tsx
@@ -1,0 +1,139 @@
+/**
+ * One draggable tile in the media pool.
+ *
+ * The three media kinds need genuinely different previews -- a still, a video
+ * frame, a single icon -- so the whole tile lives here rather than as three
+ * branches inside CuesForm's render.
+ */
+
+import {
+  Box,
+  IconButton,
+  Image,
+  Text,
+  useColorModeValue,
+} from "@chakra-ui/react"
+import { DeleteIcon } from "@chakra-ui/icons"
+import { SpeakerIcon } from "../../lib/icons"
+import mediaStore from "./mediaFileStore"
+
+import { dragDataForMedia, mediaKind } from "../utils/mediaKind"
+
+import type { MediaLibraryItem } from "../../types"
+
+interface MediaPoolTileProps {
+  item: MediaLibraryItem
+  onDelete: (item: MediaLibraryItem) => void
+  suppressDragGhost: (dataTransfer: DataTransfer | null) => void
+}
+
+const PREVIEW_HEIGHT = "100px"
+
+const MediaPoolTile = ({
+  item,
+  onDelete,
+  suppressDragGhost,
+}: MediaPoolTileProps) => {
+  const textColor = useColorModeValue("gray.800", "whiteAlpha.900")
+  const mutedText = useColorModeValue("gray.600", "whiteAlpha.500")
+  const placeholderBg = useColorModeValue("blackAlpha.50", "whiteAlpha.200")
+  const kind = mediaKind(item.type)
+
+  return (
+    <Box
+      draggable={true}
+      onDragStart={(event) => {
+        suppressDragGhost(event.dataTransfer)
+        const dragData = dragDataForMedia(item)
+        mediaStore.setActiveDragData(dragData)
+
+        event.dataTransfer.setData("application/json", JSON.stringify(dragData))
+        event.dataTransfer.setData("text/plain", JSON.stringify(dragData))
+      }}
+      onDragEnd={() => mediaStore.clearActiveDragData()}
+      position="relative"
+      border="2px solid"
+      borderColor="purple.300"
+      borderRadius="md"
+      p={2}
+      cursor="grab"
+      _active={{ cursor: "grabbing" }}
+      _hover={{ borderColor: "purple.500", bg: "whiteAlpha.100" }}
+    >
+      <IconButton
+        aria-label={`Remove ${item.name}`}
+        icon={<DeleteIcon />}
+        size="xs"
+        colorScheme="red"
+        position="absolute"
+        top={1}
+        right={1}
+        onClick={() => onDelete(item)}
+        zIndex={1}
+      />
+
+      {kind === "image" && (
+        <Image
+          src={item.url}
+          alt={item.name}
+          maxH={PREVIEW_HEIGHT}
+          objectFit="contain"
+          w="100%"
+        />
+      )}
+
+      {kind === "video" && (
+        <Box position="relative" borderRadius="md" overflow="hidden">
+          {/* The media fragment asks for a frame just past the start: at
+              exactly 0s some encodes hand back a black frame. `preload` is
+              metadata only, so this costs a range request, not the file. */}
+          <Box
+            as="video"
+            data-testid={`video-preview-${item.id}`}
+            src={item.url ? `${item.url}#t=0.1` : undefined}
+            muted
+            playsInline
+            preload="metadata"
+            h={PREVIEW_HEIGHT}
+            w="100%"
+            objectFit="contain"
+            // The tile owns the drag; a video element would swallow the press.
+            sx={{ pointerEvents: "none", backgroundColor: "black" }}
+          />
+          <Box
+            position="absolute"
+            bottom={1}
+            left={1}
+            px={1.5}
+            borderRadius="sm"
+            bg="blackAlpha.700"
+            color="white"
+            fontSize="xs"
+            lineHeight="1.4"
+          >
+            ▶
+          </Box>
+        </Box>
+      )}
+
+      {kind === "audio" && (
+        <Box
+          h={PREVIEW_HEIGHT}
+          bg={placeholderBg}
+          borderRadius="md"
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <SpeakerIcon boxSize="32px" color={mutedText} />
+        </Box>
+      )}
+
+      <Text fontSize="xs" mt={1} noOfLines={1} color={textColor}>
+        {item.name}
+      </Text>
+    </Box>
+  )
+}
+
+export default MediaPoolTile

--- a/src/client/components/presentation/MediaPoolTile.tsx
+++ b/src/client/components/presentation/MediaPoolTile.tsx
@@ -35,6 +35,7 @@ const MediaPoolTile = ({
   const placeholderBg = useColorModeValue("blackAlpha.50", "whiteAlpha.200")
   const kind = mediaKind(item)
   const [isBroken, setIsBroken] = useState(false)
+  const [isHovered, setIsHovered] = useState(false)
 
   return (
     <Box
@@ -48,7 +49,8 @@ const MediaPoolTile = ({
         event.dataTransfer.setData("text/plain", JSON.stringify(dragData))
       }}
       onDragEnd={() => mediaStore.clearActiveDragData()}
-      role="group"
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
       position="relative"
       border="2px solid"
       borderColor="transparent"
@@ -58,24 +60,21 @@ const MediaPoolTile = ({
       transition="border-color 0.15s, background 0.15s"
       _active={{ cursor: "grabbing" }}
       _hover={{ borderColor: "purple.400", bg: "whiteAlpha.100" }}
-      _focusWithin={{ borderColor: "purple.400" }}
     >
-      {/* Hover-only, but still focusable so it stays reachable by keyboard. */}
-      <IconButton
-        aria-label={`Remove ${item.name}`}
-        icon={<DeleteIcon />}
-        size="xs"
-        colorScheme="red"
-        position="absolute"
-        top={1}
-        right={1}
-        onClick={() => onDelete(item)}
-        zIndex={1}
-        opacity={0}
-        transition="opacity 0.15s"
-        _groupHover={{ opacity: 1 }}
-        _focusVisible={{ opacity: 1 }}
-      />
+      {/* Only while this tile is hovered. */}
+      {isHovered && (
+        <IconButton
+          aria-label={`Remove ${item.name}`}
+          icon={<DeleteIcon />}
+          size="xs"
+          colorScheme="red"
+          position="absolute"
+          top={1}
+          right={1}
+          onClick={() => onDelete(item)}
+          zIndex={1}
+        />
+      )}
 
       {kind === "image" && !isBroken && (
         <Image

--- a/src/client/components/utils/mediaKind.ts
+++ b/src/client/components/utils/mediaKind.ts
@@ -1,39 +1,75 @@
 /**
- * How a media-library entry is previewed and dragged, derived from its MIME
- * type.
+ * How a media-library entry is previewed and dragged.
  *
- * The media and audio pools were merged into one grid, so the kind is no longer
- * implied by which list an item came from -- it has to be read off the type.
+ * Many stored entries claim `image/jpeg` when the file is really a video: the
+ * type was never recorded and the schema default filled in. So the filename
+ * decides whenever the stored type is missing or is that default.
  */
 
 import type { MediaLibraryItem, NewCueDragData } from "../../types"
 
 export type MediaKind = "image" | "video" | "audio"
 
-export const mediaKind = (mimeType?: string): MediaKind => {
+/** presentationSchema's default, indistinguishable from "not recorded". */
+const SCHEMA_DEFAULT_MIME = "image/jpeg"
+
+const EXTENSION_MIME: Record<string, string> = {
+  mp4: "video/mp4",
+  "3gp": "video/3gpp",
+  mp3: "audio/mpeg",
+  wav: "audio/wav",
+  gif: "image/gif",
+  png: "image/png",
+  webp: "image/webp",
+  svg: "image/svg+xml",
+  avif: "image/avif",
+  bmp: "image/bmp",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+}
+
+const mimeFromName = (name?: string): string | undefined => {
+  const extension = name?.split(".").pop()?.toLowerCase()
+  return extension ? EXTENSION_MIME[extension] : undefined
+}
+
+/** The stored type, unless it is unset or the default and the name knows better. */
+export const effectiveMimeType = (item: {
+  type?: string
+  name?: string
+}): string | undefined => {
+  if (item.type && item.type !== SCHEMA_DEFAULT_MIME) {
+    return item.type
+  }
+
+  return mimeFromName(item.name) ?? item.type
+}
+
+export const mediaKind = (item: {
+  type?: string
+  name?: string
+}): MediaKind => {
+  const mimeType = effectiveMimeType(item)
   if (mimeType?.startsWith("audio/")) return "audio"
   if (mimeType?.startsWith("video/")) return "video"
   return "image"
 }
 
-/**
- * Audio still travels as elementType "sound" with a soundId, and everything
- * else as "media" with a mediaId, so the drop handler's contract is unchanged.
- */
+/** Audio drags as "sound" with a soundId, everything else as "media". */
 export const dragDataForMedia = (item: MediaLibraryItem): NewCueDragData =>
-  mediaKind(item.type) === "audio"
+  mediaKind(item) === "audio"
     ? {
         type: "newCueFromForm",
         cueName: item.name,
         elementType: "sound",
         soundId: item.id,
-        mimeType: item.type,
+        mimeType: effectiveMimeType(item),
       }
     : {
         type: "newCueFromForm",
         cueName: item.name,
         elementType: "media",
         mediaId: item.id,
-        mimeType: item.type,
+        mimeType: effectiveMimeType(item),
         previewUrl: item.url,
       }

--- a/src/client/components/utils/mediaKind.ts
+++ b/src/client/components/utils/mediaKind.ts
@@ -1,0 +1,39 @@
+/**
+ * How a media-library entry is previewed and dragged, derived from its MIME
+ * type.
+ *
+ * The media and audio pools were merged into one grid, so the kind is no longer
+ * implied by which list an item came from -- it has to be read off the type.
+ */
+
+import type { MediaLibraryItem, NewCueDragData } from "../../types"
+
+export type MediaKind = "image" | "video" | "audio"
+
+export const mediaKind = (mimeType?: string): MediaKind => {
+  if (mimeType?.startsWith("audio/")) return "audio"
+  if (mimeType?.startsWith("video/")) return "video"
+  return "image"
+}
+
+/**
+ * Audio still travels as elementType "sound" with a soundId, and everything
+ * else as "media" with a mediaId, so the drop handler's contract is unchanged.
+ */
+export const dragDataForMedia = (item: MediaLibraryItem): NewCueDragData =>
+  mediaKind(item.type) === "audio"
+    ? {
+        type: "newCueFromForm",
+        cueName: item.name,
+        elementType: "sound",
+        soundId: item.id,
+        mimeType: item.type,
+      }
+    : {
+        type: "newCueFromForm",
+        cueName: item.name,
+        elementType: "media",
+        mediaId: item.id,
+        mimeType: item.type,
+        previewUrl: item.url,
+      }

--- a/src/client/tests/unit/EditorDock.test.tsx
+++ b/src/client/tests/unit/EditorDock.test.tsx
@@ -4,28 +4,29 @@ import { render, screen, fireEvent } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import EditorDock from "../../components/presentation/EditorDock"
 
-jest.mock("../../components/presentation/CuesForm", () => () => (
-  <div data-testid="cues-form">Elements</div>
-))
+jest.mock(
+  "../../components/presentation/CuesForm",
+  () =>
+    ({ activeTab }: { activeTab: string }) => (
+      <div data-testid="cues-form">{activeTab}</div>
+    )
+)
 jest.mock("../../components/presentation/ScorePanel", () => () => (
   <div data-testid="score-panel">Scores</div>
 ))
 
 // The dock reads the media library from the store and dispatches the upload
-// and delete thunks; this test only cares about tab switching, so stub the
-// hooks rather than standing up a Provider.
+// and delete thunks; these tests only cover the tab strip, so stub the hooks
+// rather than standing up a Provider.
 jest.mock("../../redux/hooks", () => ({
   useAppDispatch: () => jest.fn(),
   useAppSelector: (selector: (state: unknown) => unknown) =>
     selector({ presentation: { media: [] } }),
 }))
 
-const renderWithChakra = (component: React.ReactElement) =>
-  render(<ChakraProvider>{component}</ChakraProvider>)
-
-describe("EditorDock", () => {
-  test("toggles between Elements and Scores", () => {
-    renderWithChakra(
+const renderDock = () =>
+  render(
+    <ChakraProvider>
       <EditorDock
         presentationId="presentation-1"
         scores={[]}
@@ -34,16 +35,62 @@ describe("EditorDock", () => {
         screenCount={3}
         indexCount={5}
       />
+    </ChakraProvider>
+  )
+
+describe("EditorDock", () => {
+  beforeEach(() => {
+    window.localStorage.removeItem("editModeMediaPoolActiveTab")
+  })
+
+  test("offers Colors, Media and Scores on a single row", () => {
+    renderDock()
+
+    expect(screen.getAllByRole("tab")).toHaveLength(3)
+    expect(screen.getByRole("tab", { name: "Colors" })).toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: "Media" })).toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: "Scores" })).toBeInTheDocument()
+  })
+
+  test("opens on Media and drives the section CuesForm renders", () => {
+    renderDock()
+
+    expect(screen.getByTestId("cues-form")).toHaveTextContent("media")
+
+    fireEvent.click(screen.getByRole("tab", { name: "Colors" }))
+    expect(screen.getByTestId("cues-form")).toHaveTextContent("colors")
+  })
+
+  test("swaps CuesForm for the score panel on Scores", () => {
+    renderDock()
+
+    fireEvent.click(screen.getByRole("tab", { name: "Scores" }))
+    expect(screen.getByTestId("score-panel")).toBeInTheDocument()
+    expect(screen.queryByTestId("cues-form")).toBeNull()
+
+    fireEvent.click(screen.getByRole("tab", { name: "Media" }))
+    expect(screen.getByTestId("cues-form")).toBeInTheDocument()
+  })
+
+  test("remembers the selected tab", () => {
+    const { unmount } = renderDock()
+
+    fireEvent.click(screen.getByRole("tab", { name: "Colors" }))
+    expect(window.localStorage.getItem("editModeMediaPoolActiveTab")).toBe(
+      "colors"
     )
 
-    // Switch to Scores
-    const scoresTab = screen.getByRole("button", { name: /Scores/i })
-    fireEvent.click(scoresTab)
-    expect(screen.getByTestId("score-panel")).toBeInTheDocument()
+    unmount()
+    renderDock()
+    expect(screen.getByTestId("cues-form")).toHaveTextContent("colors")
+  })
 
-    // Switch back to Elements
-    const elementsTab = screen.getByRole("button", { name: /Elements/i })
-    fireEvent.click(elementsTab)
-    expect(screen.getByTestId("cues-form")).toBeInTheDocument()
+  test("falls back to Media for a tab that no longer exists", () => {
+    // "audio" was a tab of its own before the pools were merged.
+    window.localStorage.setItem("editModeMediaPoolActiveTab", "audio")
+
+    renderDock()
+
+    expect(screen.getByTestId("cues-form")).toHaveTextContent("media")
   })
 })

--- a/src/client/tests/unit/cues.test.js
+++ b/src/client/tests/unit/cues.test.js
@@ -173,6 +173,17 @@ describe("CuesForm", () => {
     expect(preview).toHaveAttribute("preload", "metadata")
   })
 
+  test("previews a legacy video whose stored type is the schema default", () => {
+    renderCuesForm({
+      mediaLibrary: [
+        // What a cue uploaded before the routes recorded `type` reads back as.
+        mediaItem({ id: "media-6", name: "vanha.mp4", type: "image/jpeg" }),
+      ],
+    })
+
+    expect(screen.getByTestId("video-preview-media-6").tagName).toBe("VIDEO")
+  })
+
   test("previews every audio entry with the same icon and no media request", () => {
     renderCuesForm({
       mediaLibrary: [

--- a/src/client/tests/unit/cues.test.js
+++ b/src/client/tests/unit/cues.test.js
@@ -67,96 +67,29 @@ describe("CuesForm", () => {
     URL.revokeObjectURL = jest.fn()
   })
 
-  test("uses media tab by default when no tab preference is stored", () => {
+  test("shows the media section by default, with no heading above it", () => {
     renderCuesForm()
 
-    expect(
-      screen.getByText("Upload images or videos and drag them to the grid")
-    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Upload media" })).toBeVisible()
+    // The tab strip and the "Add element" heading both moved out: EditorDock
+    // owns the one row of tabs, and the search bar took the heading's place.
+    expect(screen.queryByRole("tab")).toBeNull()
+    expect(screen.queryByText("Add element")).toBeNull()
   })
 
-  test("restores active tab from localStorage", () => {
-    window.localStorage.setItem("editModeMediaPoolActiveTab", "audio")
+  test("shows the colors section when told to", () => {
+    renderCuesForm({ activeTab: "colors" })
 
-    renderCuesForm()
-
-    expect(
-      screen.getByText("Upload audio files and drag them to the grid")
-    ).toBeInTheDocument()
-  })
-
-  test("ignores invalid stored tab values and falls back to media", () => {
-    window.localStorage.setItem("editModeMediaPoolActiveTab", "invalid")
-
-    renderCuesForm()
-
-    expect(
-      screen.getByText("Upload images or videos and drag them to the grid")
-    ).toBeInTheDocument()
-  })
-
-  test("renders add mode with tabs", () => {
-    renderCuesForm()
-
-    expect(screen.getByText("Add element")).toBeInTheDocument()
-    expect(screen.getByRole("tab", { name: "Colors" })).toBeInTheDocument()
-    expect(screen.getByRole("tab", { name: "Media" })).toBeInTheDocument()
-    expect(screen.getByRole("tab", { name: "Audio" })).toBeInTheDocument()
-    expect(
-      screen.getByText("Upload images or videos and drag them to the grid")
-    ).toBeInTheDocument()
-  })
-
-  test("renders edit mode title when cue data is provided", () => {
-    renderCuesForm({
-      cueData: {
-        _id: "cue-1",
-        name: "Existing cue",
-        index: 0,
-        screen: 1,
-        file: { name: "example.png", type: "image/png" },
-      },
-    })
-
-    expect(screen.getByText("Edit element")).toBeInTheDocument()
-  })
-
-  test("switches between tabs", () => {
-    renderCuesForm()
-
-    fireEvent.click(screen.getByRole("tab", { name: "Colors" }))
     expect(
       screen.getByText("Select a color and drag it to the grid")
     ).toBeInTheDocument()
     expect(screen.getByTestId("cue-name")).toBeInTheDocument()
-
-    fireEvent.click(screen.getByRole("tab", { name: "Audio" }))
-    expect(
-      screen.getByText("Upload audio files and drag them to the grid")
-    ).toBeInTheDocument()
-
-    fireEvent.click(screen.getByRole("tab", { name: "Media" }))
-    expect(
-      screen.getByText("Upload images or videos and drag them to the grid")
-    ).toBeInTheDocument()
-  })
-
-  test("persists selected tab to localStorage", () => {
-    renderCuesForm()
-
-    fireEvent.click(screen.getByRole("tab", { name: "Colors" }))
-    expect(window.localStorage.getItem("editModeMediaPoolActiveTab")).toBe(
-      "colors"
-    )
-
-    fireEvent.click(screen.getByRole("tab", { name: "Audio" }))
-    expect(window.localStorage.getItem("editModeMediaPoolActiveTab")).toBe(
-      "audio"
-    )
+    expect(screen.queryByLabelText("Search media")).toBeNull()
   })
 
   test("pre-fills cue name from cueData when editing", () => {
     renderCuesForm({
+      activeTab: "colors",
       cueData: {
         _id: "cue-1",
         name: "Existing cue",
@@ -165,8 +98,6 @@ describe("CuesForm", () => {
         file: { name: "example.png", type: "image/png" },
       },
     })
-
-    fireEvent.click(screen.getByRole("tab", { name: "Colors" }))
 
     expect(screen.getByTestId("cue-name")).toHaveValue("Existing cue")
   })
@@ -180,6 +111,80 @@ describe("CuesForm", () => {
       "src",
       "https://example.com/media-1"
     )
+  })
+
+  test("offers the big upload button only while the pool is empty", () => {
+    renderCuesForm()
+
+    expect(screen.getByTestId("media-upload-cta")).toBeVisible()
+    expect(screen.queryByLabelText("Search media")).toBeNull()
+  })
+
+  test("shrinks uploading to an icon beside the search bar once the pool fills", () => {
+    renderCuesForm({ mediaLibrary: [mediaItem()] })
+
+    expect(screen.queryByTestId("media-upload-cta")).toBeNull()
+    expect(screen.getByLabelText("Search media")).toBeVisible()
+    expect(screen.getByRole("button", { name: "Upload media" })).toBeVisible()
+  })
+
+  test("filters the pool by name as you type", () => {
+    renderCuesForm({
+      mediaLibrary: [
+        mediaItem(),
+        mediaItem({ id: "media-2", name: "backdrop.png" }),
+      ],
+    })
+
+    expect(screen.getByText("Media Pool (2)")).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText("Search media"), {
+      target: { value: "back" },
+    })
+
+    expect(screen.getByText("Media Pool (1 of 2)")).toBeInTheDocument()
+    expect(screen.getByText("backdrop.png")).toBeInTheDocument()
+    expect(screen.queryByText("photo.png")).toBeNull()
+  })
+
+  test("says so when nothing matches the search", () => {
+    renderCuesForm({ mediaLibrary: [mediaItem()] })
+
+    fireEvent.change(screen.getByLabelText("Search media"), {
+      target: { value: "nothing here" },
+    })
+
+    expect(
+      screen.getByText('No media matches "nothing here".')
+    ).toBeInTheDocument()
+  })
+
+  test("previews a video with a video element, not an icon", () => {
+    renderCuesForm({
+      mediaLibrary: [
+        mediaItem({ id: "media-3", name: "clip.mp4", type: "video/mp4" }),
+      ],
+    })
+
+    const preview = screen.getByTestId("video-preview-media-3")
+    expect(preview.tagName).toBe("VIDEO")
+    // The media fragment asks for a frame past 0s, where some encodes are black.
+    expect(preview).toHaveAttribute("src", "https://example.com/media-1#t=0.1")
+    expect(preview).toHaveAttribute("preload", "metadata")
+  })
+
+  test("previews every audio entry with the same icon and no media request", () => {
+    renderCuesForm({
+      mediaLibrary: [
+        mediaItem({ id: "media-4", name: "one.mp3", type: "audio/mpeg" }),
+        mediaItem({ id: "media-5", name: "two.wav", type: "audio/wav" }),
+      ],
+    })
+
+    expect(screen.getByText("one.mp3")).toBeInTheDocument()
+    expect(screen.getByText("two.wav")).toBeInTheDocument()
+    expect(screen.queryByTestId("video-preview-media-4")).toBeNull()
+    expect(document.querySelectorAll("img")).toHaveLength(0)
   })
 
   test("uploads picked media to the library instead of keeping it in memory", async () => {
@@ -289,7 +294,7 @@ describe("CuesForm", () => {
     expect(mediaStore.getFile("media-9")).toBeUndefined()
   })
 
-  test("splits the library by MIME type: audio entries land in the sound pool", async () => {
+  test("an audio entry sits in the same grid and drags as a sound", async () => {
     const { onDeleteMedia } = renderCuesForm({
       mediaLibrary: [
         mediaItem(),
@@ -297,12 +302,9 @@ describe("CuesForm", () => {
       ],
     })
 
-    // The image is in the media pool, not here.
-    expect(screen.getByText("Media Pool (1)")).toBeInTheDocument()
+    // Images, videos and audio share one grid now.
+    expect(screen.getByText("Media Pool (2)")).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole("tab", { name: "Audio" }))
-
-    expect(screen.getByText("Sound Pool (1)")).toBeInTheDocument()
     const soundItem = screen
       .getByText("sound.wav")
       .closest("[draggable='true']")
@@ -328,27 +330,25 @@ describe("CuesForm", () => {
     })
   })
 
-  test("filters invalid files from audio uploads", async () => {
+  test("accepts audio through the same input as images and videos", async () => {
     const { onUploadMedia } = renderCuesForm()
 
-    fireEvent.click(screen.getByRole("tab", { name: "Audio" }))
-
-    const soundInput = document.getElementById("sound-upload")
+    const soundInput = document.getElementById("media-upload")
     const audioFile = new File(["audio"], "sound.wav", { type: "audio/wav" })
     const imageFile = new File(["img"], "photo.png", { type: "image/png" })
 
     fireEvent.change(soundInput, { target: { files: [audioFile, imageFile] } })
 
     await waitFor(() => {
-      expect(onUploadMedia).toHaveBeenCalledTimes(1)
+      expect(onUploadMedia).toHaveBeenCalledTimes(2)
     })
     expect(onUploadMedia).toHaveBeenCalledWith(audioFile)
+    expect(onUploadMedia).toHaveBeenCalledWith(imageFile)
   })
 
   test("sets drag payload for color element", () => {
-    renderCuesForm()
+    renderCuesForm({ activeTab: "colors" })
 
-    fireEvent.click(screen.getByRole("tab", { name: "Colors" }))
     fireEvent.change(screen.getByTestId("cue-name"), {
       target: { value: "Warm color" },
     })
@@ -377,9 +377,9 @@ describe("CuesForm", () => {
   })
 
   test("submits add mode form and calls addCue with current values", () => {
-    const { addCue, onClose } = renderCuesForm()
+    const { addCue, onClose } = renderCuesForm({ activeTab: "colors" })
 
-    const form = screen.getByText("Add element").closest("form")
+    const form = screen.getByTestId("cue-name").closest("form")
     fireEvent.submit(form)
 
     expect(addCue).toHaveBeenCalledWith(
@@ -396,6 +396,7 @@ describe("CuesForm", () => {
     const updateCue = jest.fn().mockResolvedValue({})
     const onClose = jest.fn()
     renderCuesForm({
+      activeTab: "colors",
       updateCue,
       onClose,
       cueData: {
@@ -412,7 +413,7 @@ describe("CuesForm", () => {
       },
     })
 
-    const form = screen.getByText("Edit element").closest("form")
+    const form = screen.getByTestId("cue-name").closest("form")
     fireEvent.submit(form)
 
     await waitFor(() => {

--- a/src/client/tests/unit/cues.test.js
+++ b/src/client/tests/unit/cues.test.js
@@ -58,6 +58,14 @@ const createDataTransfer = () => ({
   setData: jest.fn(),
 })
 
+// The delete button only exists while the tile is hovered.
+const clickRemoveOn = (name) => {
+  const tile = screen.getByText(name).closest("[draggable='true']")
+  fireEvent.mouseEnter(tile)
+  fireEvent.click(within(tile).getByRole("button", { name: `Remove ${name}` }))
+  return tile
+}
+
 describe("CuesForm", () => {
   beforeEach(() => {
     mediaStore.clear()
@@ -231,8 +239,7 @@ describe("CuesForm", () => {
   test("removing a pool item asks for confirmation before deleting", async () => {
     const { onDeleteMedia } = renderCuesForm({ mediaLibrary: [mediaItem()] })
 
-    const fileCard = screen.getByText("photo.png").closest("[draggable='true']")
-    fireEvent.click(fileCard.querySelector("button"))
+    clickRemoveOn("photo.png")
 
     // The delete is permanent, so nothing happens until it is confirmed.
     expect(
@@ -250,8 +257,7 @@ describe("CuesForm", () => {
   test("cancelling the confirmation leaves the entry alone", async () => {
     const { onDeleteMedia } = renderCuesForm({ mediaLibrary: [mediaItem()] })
 
-    const fileCard = screen.getByText("photo.png").closest("[draggable='true']")
-    fireEvent.click(fileCard.querySelector("button"))
+    clickRemoveOn("photo.png")
 
     fireEvent.click(await screen.findByRole("button", { name: "Cancel" }))
 
@@ -271,8 +277,7 @@ describe("CuesForm", () => {
       ],
     })
 
-    const fileCard = screen.getByText("photo.png").closest("[draggable='true']")
-    fireEvent.click(fileCard.querySelector("button"))
+    clickRemoveOn("photo.png")
 
     expect(
       await screen.findByText(
@@ -332,8 +337,7 @@ describe("CuesForm", () => {
     expect(payload.elementType).toBe("sound")
     expect(payload.soundId).toBe("media-2")
 
-    const removeButtons = within(soundItem).getAllByRole("button")
-    fireEvent.click(removeButtons[0])
+    clickRemoveOn("sound.wav")
     fireEvent.click(await screen.findByRole("button", { name: "Delete" }))
 
     await waitFor(() => {

--- a/src/client/tests/unit/mediaKind.test.ts
+++ b/src/client/tests/unit/mediaKind.test.ts
@@ -1,0 +1,92 @@
+/*
+ * mediaKind unit tests.
+ * Covers deriving a media entry's kind from its stored type, the fallback to
+ * the filename when that type is missing or is the schema default, and the
+ * drag payload built from the result.
+ */
+import {
+  dragDataForMedia,
+  effectiveMimeType,
+  mediaKind,
+} from "../../components/utils/mediaKind"
+
+describe("effectiveMimeType", () => {
+  test("keeps a stored type that says something", () => {
+    expect(effectiveMimeType({ type: "video/mp4", name: "a.png" })).toBe(
+      "video/mp4"
+    )
+  })
+
+  test("falls back to the extension when no type was recorded", () => {
+    expect(effectiveMimeType({ name: "clip.mp4" })).toBe("video/mp4")
+  })
+
+  test("overrides the schema default, which is indistinguishable from unset", () => {
+    // Cues written before the upload routes recorded `type` all read back as
+    // image/jpeg, whatever was actually stored.
+    expect(effectiveMimeType({ type: "image/jpeg", name: "clip.mp4" })).toBe(
+      "video/mp4"
+    )
+  })
+
+  test("leaves a genuine jpeg alone", () => {
+    expect(effectiveMimeType({ type: "image/jpeg", name: "photo.jpg" })).toBe(
+      "image/jpeg"
+    )
+  })
+
+  test("keeps the default when the filename says nothing useful", () => {
+    expect(
+      effectiveMimeType({ type: "image/jpeg", name: "no-extension" })
+    ).toBe("image/jpeg")
+    expect(effectiveMimeType({ type: "image/jpeg", name: "a.xyz" })).toBe(
+      "image/jpeg"
+    )
+  })
+})
+
+describe("mediaKind", () => {
+  test("reads video, audio and image off the effective type", () => {
+    expect(mediaKind({ type: "video/mp4", name: "a" })).toBe("video")
+    expect(mediaKind({ type: "audio/wav", name: "a" })).toBe("audio")
+    expect(mediaKind({ type: "image/png", name: "a" })).toBe("image")
+  })
+
+  test("recognises a mislabelled legacy video by its filename", () => {
+    expect(mediaKind({ type: "image/jpeg", name: "vanha.mp4" })).toBe("video")
+    expect(mediaKind({ type: "image/jpeg", name: "theme.mp3" })).toBe("audio")
+  })
+
+  test("treats anything unrecognised as an image", () => {
+    expect(mediaKind({})).toBe("image")
+  })
+})
+
+describe("dragDataForMedia", () => {
+  test("sends audio as a sound, carrying the corrected type", () => {
+    const dragData = dragDataForMedia({
+      id: "media-1",
+      name: "theme.mp3",
+      type: "image/jpeg",
+    })
+
+    expect(dragData.elementType).toBe("sound")
+    expect(dragData.soundId).toBe("media-1")
+    expect(dragData.mimeType).toBe("audio/mpeg")
+    expect(dragData.mediaId).toBeUndefined()
+  })
+
+  test("sends everything else as media, with the preview url", () => {
+    const dragData = dragDataForMedia({
+      id: "media-2",
+      name: "clip.mp4",
+      type: "image/jpeg",
+      url: "https://example.com/media-2",
+    })
+
+    expect(dragData.elementType).toBe("media")
+    expect(dragData.mediaId).toBe("media-2")
+    expect(dragData.mimeType).toBe("video/mp4")
+    expect(dragData.previewUrl).toBe("https://example.com/media-2")
+  })
+})

--- a/src/server/routes/presentation.js
+++ b/src/server/routes/presentation.js
@@ -1336,6 +1336,9 @@ router.put(
             id: fileId,
             name: file?.originalname || `file-${fileId}`,
             url: "",
+            // Or the schema default applies, and an mp4 is stored as image/jpeg.
+            ...(file?.mimetype && { type: file.mimetype }),
+            ...(file?.size !== undefined && { size: String(file.size) }),
             ...(driveId && { driveId }),
           }
 
@@ -1892,6 +1895,8 @@ router.put(
               id: newFileId,
               name: file.originalname,
               url: `https://${BUCKET_NAME}.s3.amazonaws.com/${fileName}`,
+              type: file.mimetype,
+              size: String(file.size),
             }
             await generateSignedUrlForS3(cue, id)
           } catch (error) {


### PR DESCRIPTION
Follow-up to #899. The panel opened on two stacked rows of tabs, then spent the rest of its height on a heading, a paragraph of help and a full-width upload button before the first thumbnail — on a 280px dock, barely a row of media was visible.

## What changed

- **One tab row: Colors / Media / Scores.** `EditorDock` owns it and tells `CuesForm` which section to render, so the second strip inside `CuesForm` is gone along with its own tab state. The selection is still remembered; a stored `audio` falls back to Media.
- **The "Add element" heading is replaced by a search box** that filters the pool by name, locally, over the media already fetched. The count beside it reads `Media Pool (3 of 27)` while filtering.
- **The big upload button only appears when the pool is empty.** Otherwise uploading is an icon next to the search box, so it stays reachable without scrolling past it.
- **Audio folds into the media pool** instead of keeping a tab of its own. Which kind an entry is now comes off its MIME type rather than which list it sat in, so the drop handler's contract is untouched: audio still travels as `elementType: "sound"` and is still refused on a visual row.
- **MP4 previews are real frames.** They were a film emoji, so two clips looked identical. The tile renders the signed URL in a `<video>` asking for `#t=0.1` — some encodes start on a black frame — with `preload="metadata"`, so a tile costs a range request rather than the whole file.
- **Audio previews are one speaker icon,** deliberately identical for every entry, and cost no network at all.

The tile moved to its own `MediaPoolTile.tsx` and the kind/drag-payload logic to `utils/mediaKind.ts`, rather than growing three more branches inside a component already past 1000 lines.

## Verification

`npm test` — 911 passing across 72 suites, including new tests for the search filter, the empty-vs-filled upload button, the video element and the audio icon. `tsc --noEmit`, eslint and prettier clean.

`e2e/helper.js`: `uploadMediaFile` and `uploadAudioFile` both target the Media tab and `#media-upload` now, since there is one input for every kind. The audio specs are otherwise unchanged.

## Worth a look in review

- The video preview costs a metadata range request per visible tile. With 27 media that is 27 requests when the Media tab opens. If it shows up in practice, server-side thumbnails are the real fix — `thumbnailId`/`thumbnailDriveId` already exist in the schema from #901, still unused.
- The colours section still carries the unreachable create/edit form path documented at the top of `CuesForm.tsx`. Untouched here.