### PR TITLE
feat(show): add a dedicated show mode for live performance

### DIFF
--- a/documentation/userguide.md
+++ b/documentation/userguide.md
@@ -168,6 +168,18 @@ The Scores tab in the editor's side panel lets you attach a PDF score to the pre
 
 Markers are purely informational — they don't automatically advance the presentation. They're there so a performer can see, at a glance while reading their score, which frame the show should be on at that point.
 
+## Show mode
+
+Click **Show mode** from the editor to run the presentation in a dedicated full-screen workspace. The editor state, current frame, open display windows, audio playback, and score remain active when switching modes.
+
+- **Music stand**: Read the score in a two-page or scrolling layout, follow the marker for the current frame, and enable automatic page turns. The side rail shows live and next screen previews, frame cues, and active audio tracks.
+- **Control room**: Monitor every display, distinguish open and closed output windows, open a display directly, preview which screens will change on the next frame, and view the score in a compact panel.
+- **GO and Previous**: Advance or return one frame while keeping visual and audio cues synchronized.
+- **Auto**: Run frames automatically using the interval configured in the editor.
+- **Blackout**: Mask every output window without changing the current frame or stopping audio. The operator previews remain visible.
+- **Monitor**: Open either the score or the complete screen wall in a separate operator window.
+- **Exit**: Return to the same presentation in the editor.
+
 ## Profile page
 
 Navigate to the profile page from the navigation bar.

--- a/e2e/showmode.spec.js
+++ b/e2e/showmode.spec.js
@@ -1,0 +1,47 @@
+import { addPresentation, disableTutorials, loginWith } from "./helper"
+const { test, expect } = require("@playwright/test")
+
+const testuser = "showmodetestuser"
+const testPw = "test12345"
+
+test.beforeEach(async ({ page, request }) => {
+  await request.post("http://localhost:8000/api/testing/reset")
+  await request.post("http://localhost:8000/api/signup", {
+    data: {
+      username: testuser,
+      password: testPw,
+    },
+  })
+
+  await page.goto("http://localhost:3000/")
+  await disableTutorials(page)
+  await loginWith(page, testuser, testPw)
+})
+
+test("user can run a presentation from show mode", async ({
+  page,
+  context,
+}) => {
+  await addPresentation(page, "show-mode-test")
+  await page.getByRole("button", { name: "Show mode" }).click()
+
+  await expect(page).toHaveURL(/\/presentation\/[^/]+\/show$/)
+  await expect(page.getByText("SHOW", { exact: true })).toBeVisible()
+
+  await page.getByRole("button", { name: /Control room/ }).click()
+  const [popup] = await Promise.all([
+    context.waitForEvent("page"),
+    page.getByRole("button", { name: "Open display 1" }).click(),
+  ])
+
+  await page.getByRole("button", { name: "GO", exact: true }).click()
+  await expect(page.getByText("Frame 2 will change")).toBeVisible()
+
+  await page.getByRole("button", { name: "Blackout" }).click()
+  await expect(page.getByRole("button", { name: "Blackout on" })).toBeVisible()
+  await expect(popup.getByTestId("screen-blackout")).toBeVisible()
+
+  await page.getByRole("button", { name: "Exit" }).click()
+  await expect(page).toHaveURL(/\/presentation\/[^/]+$/)
+  await expect(page.getByRole("button", { name: "Show mode" })).toBeVisible()
+})

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -28,6 +28,7 @@ const App = () => {
 
   const location = useLocation()
   const isPresentation = location.pathname.startsWith("/presentation")
+  const isShowMode = /\/presentation\/[^/]+\/show\/?$/.test(location.pathname)
   const isHome = location.pathname.startsWith("/home")
   const isProfile = location.pathname.startsWith("/profile")
 
@@ -56,7 +57,7 @@ const App = () => {
         display="flex"
         flexDirection="column"
       >
-        <NavBar user={user} setUser={setUser} />
+        {!isShowMode && <NavBar user={user} setUser={setUser} />}
         <Container
           flex="1"
           // min-height 0 is what lets a flex child actually shrink and hand the
@@ -67,7 +68,9 @@ const App = () => {
           overflow={isPresentation ? "hidden" : undefined}
           pt={
             isPresentation
-              ? "var(--muvico-navbar-h, 4.5rem)"
+              ? isShowMode
+                ? 0
+                : "var(--muvico-navbar-h, 4.5rem)"
               : isHome
                 ? 24
                 : isProfile
@@ -91,7 +94,7 @@ const App = () => {
               }
             />
             <Route
-              path="/presentation/:id"
+              path="/presentation/:id/*"
               element={
                 user ? (
                   // userId and setUser used to be passed here too, but

--- a/src/client/components/presentation/CueAudioPlayers.jsx
+++ b/src/client/components/presentation/CueAudioPlayers.jsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useRef } from "react"
+
+const CueAudioPlayer = ({
+  src,
+  loop,
+  isAutoplaying,
+  continuePlayback,
+  allowContinuousAudio,
+}) => {
+  const audioRef = useRef(null)
+  const hasStartedRef = useRef(false)
+
+  useEffect(() => {
+    const audio = audioRef.current
+    if (!audio) return
+
+    if (!isAutoplaying || !src) {
+      if (
+        (loop || continuePlayback) &&
+        allowContinuousAudio &&
+        hasStartedRef.current
+      ) {
+        return
+      }
+      audio.pause()
+      return
+    }
+
+    const playPromise = audio.play()
+    hasStartedRef.current = true
+    if (playPromise?.catch) playPromise.catch(() => {})
+  }, [src, loop, isAutoplaying, continuePlayback, allowContinuousAudio])
+
+  if (!src) return null
+  return (
+    <audio ref={audioRef} loop={loop} src={src} preload="metadata" hidden />
+  )
+}
+
+const CueAudioPlayers = ({ tracks, isAutoplaying, allowContinuousAudio }) =>
+  tracks.map((track, trackIndex) => (
+    <CueAudioPlayer
+      key={track.id || `${track.src}-${trackIndex}`}
+      src={track.src}
+      loop={Boolean(track.loop)}
+      isAutoplaying={isAutoplaying}
+      continuePlayback={Boolean(track.continuePlayback)}
+      allowContinuousAudio={allowContinuousAudio}
+    />
+  ))
+
+export default CueAudioPlayers

--- a/src/client/components/presentation/EditModeContainer.tsx
+++ b/src/client/components/presentation/EditModeContainer.tsx
@@ -5,7 +5,8 @@
  * The component uses react-grid-layout for responsive layout and Chakra UI for styling.
  */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { Box, Button, FormLabel, HStack, Select } from "@chakra-ui/react"
+import { Box, Button, FormLabel, HStack, Icon, Select } from "@chakra-ui/react"
+import { FiPlay } from "react-icons/fi"
 import "react-grid-layout/css/styles.css"
 import { useAppDispatch, useAppSelector } from "../../redux/hooks"
 import { laneScreenFromKey } from "../utils/laneFocus"
@@ -18,6 +19,7 @@ import ClickablePopover from "../utils/ClickablePopover"
 import EditMode from "./EditMode"
 import EditorDock from "./EditorDock"
 import PresentationPlaybackControls from "./PresentationPlaybackControls"
+import CueAudioPlayers from "./CueAudioPlayers"
 import PresentationTitle from "./PresentationTitle"
 import StatusTooltip from "./StatusToolTip"
 import Screen from "./Screen"
@@ -27,6 +29,7 @@ import { getAudioRow, isType, isAudioRow } from "../utils/fileTypeUtils"
 import KeyboardHandler from "../utils/keyboardHandler"
 import makeResizable from "../utils/ResizeElement"
 import { ScreensDisplay } from "./ScreensDisplay"
+import ShowMode from "./ShowMode"
 import {
   buildCueVisualSpanMap,
   getCueVisualSpanFromMap,
@@ -60,6 +63,9 @@ interface EditModeContainerProps {
    */
   updateCue: (direction: "Next" | "Previous") => void
   isAudioMode?: boolean
+  isShowMode?: boolean
+  onEnterShow?: () => void
+  onExitShow?: () => void
 }
 
 interface AudioTrack {
@@ -97,6 +103,7 @@ interface EditorLayoutProps
   focusedScreen: number | null
   onFocusLane: (laneKey: string | null) => void
   onSelectFrame: (index: number) => void
+  onEnterShow: () => void
 }
 
 // Base component for different subcomponents of the editor
@@ -140,6 +147,7 @@ function EditorLayout(props: EditorLayoutProps) {
     focusedScreen,
     onFocusLane,
     onSelectFrame,
+    onEnterShow,
   } = props
 
   useEffect(() => {
@@ -232,13 +240,23 @@ function EditorLayout(props: EditorLayoutProps) {
             <PresentationTitle id={id} presentationName={presentationName} />
           </Box>
         </HStack>
-        <Button
-          className="edit-mode-btn edit-mode-btn-tutorial"
-          variant="muvico-secondary"
-          onClick={onOpenTutorial}
-        >
-          Tutorial
-        </Button>
+        <HStack spacing={2}>
+          <Button
+            className="edit-mode-btn edit-mode-btn-tutorial"
+            variant="muvico-secondary"
+            onClick={onOpenTutorial}
+          >
+            Tutorial
+          </Button>
+          <Button
+            className="edit-mode-btn"
+            variant="muvico-primary"
+            leftIcon={<Icon as={FiPlay} />}
+            onClick={onEnterShow}
+          >
+            Show mode
+          </Button>
+        </HStack>
       </Box>
       <div
         id="screen_preview"
@@ -290,6 +308,7 @@ function EditorLayout(props: EditorLayoutProps) {
           audioLoop={audioLoop}
           audioTracks={audioTracks as never[]}
           allowContinuousAudio={allowContinuousAudio}
+          renderAudioPlayers={false}
         />
         <Box className="editor-save-status">
           <StatusTooltip />
@@ -396,6 +415,9 @@ const EditModeContainer = ({
   cueData,
   updateCue,
   isAudioMode,
+  isShowMode = false,
+  onEnterShow = () => {},
+  onExitShow = () => {},
 }: EditModeContainerProps) => {
   const editModeBackground = "var(--muvico-canvas)"
   const panelBackground = "var(--muvico-surface)"
@@ -443,6 +465,7 @@ const EditModeContainer = ({
   const [autoplayEnded, setAutoplayEnded] = useState(false)
   const [autoplayInterval, setAutoplayInterval] = useState(5)
   const [isTutorialOpen, setIsTutorialOpen] = useState(false)
+  const [isBlackout, setIsBlackout] = useState(false)
   const autoplayTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const audioPreloadedUrlsRef = useRef(new Set())
   const cueIndexRef = useRef(cueIndex)
@@ -667,6 +690,10 @@ const EditModeContainer = ({
   }, [])
 
   useEffect(() => {
+    if (!isShowMode) setIsBlackout(false)
+  }, [isShowMode])
+
+  useEffect(() => {
     const previousBodyBackgroundColor = document.body.style.backgroundColor
     const previousBodyBackgroundImage = document.body.style.backgroundImage
 
@@ -684,45 +711,78 @@ const EditModeContainer = ({
 
   return (
     <>
-      <EditorLayout
-        id={id}
-        presentationName={presentationName}
-        screenCount={screenCount ?? 1}
-        scores={presentation.scores}
-        focusedLaneKey={focusedLaneKey}
-        focusedScreen={focusedScreen}
-        onFocusLane={setFocusedLaneKey}
-        onSelectFrame={setCueIndex}
-        cues={cues}
-        isToolboxOpen={isToolboxOpen}
-        setIsToolboxOpen={setIsToolboxOpen}
-        cueIndex={cueIndex}
-        isAudioMuted={isAudioMuted}
-        toggleAudioMute={toggleAudioMute}
-        indexCount={indexCount}
-        addCue={addCue}
-        onClose={onClose}
-        position={position}
-        cueData={cueData}
-        updateCue={updateCue}
-        isAudioMode={isAudioMode}
-        transitionType={transitionType}
-        onTransitionChange={onTransitionChange}
-        screens={screens}
-        toggleScreenVisibility={toggleScreenVisibility}
-        toggleAllScreens={toggleAllScreens}
-        autoplayInterval={autoplayInterval}
-        toggleAutoplay={toggleAutoplay}
+      {isShowMode ? (
+        <ShowMode
+          presentationName={presentationName}
+          screenCount={screenCount ?? 1}
+          scores={presentation.scores}
+          cueIndex={cueIndex}
+          indexCount={indexCount}
+          screens={screens}
+          audioTracks={currentAudioTracks}
+          autoplayInterval={autoplayInterval}
+          isAutoplaying={isAutoplaying}
+          isBlackout={isBlackout}
+          getActiveCuesForScreen={getActiveCuesForScreen}
+          onSetCueIndex={setCueIndex}
+          onPrevious={() => updateCue("Previous")}
+          onNext={() => updateCue("Next")}
+          onToggleAutoplay={toggleAutoplay}
+          onToggleBlackout={() => setIsBlackout((active) => !active)}
+          onToggleScreen={toggleScreenVisibility}
+          onExit={() => {
+            setIsBlackout(false)
+            onExitShow()
+          }}
+        />
+      ) : (
+        <EditorLayout
+          id={id}
+          presentationName={presentationName}
+          screenCount={screenCount ?? 1}
+          scores={presentation.scores}
+          focusedLaneKey={focusedLaneKey}
+          focusedScreen={focusedScreen}
+          onFocusLane={setFocusedLaneKey}
+          onSelectFrame={setCueIndex}
+          onEnterShow={onEnterShow}
+          cues={cues}
+          isToolboxOpen={isToolboxOpen}
+          setIsToolboxOpen={setIsToolboxOpen}
+          cueIndex={cueIndex}
+          isAudioMuted={isAudioMuted}
+          toggleAudioMute={toggleAudioMute}
+          indexCount={indexCount}
+          addCue={addCue}
+          onClose={onClose}
+          position={position}
+          cueData={cueData}
+          updateCue={updateCue}
+          isAudioMode={isAudioMode}
+          transitionType={transitionType}
+          onTransitionChange={onTransitionChange}
+          screens={screens}
+          toggleScreenVisibility={toggleScreenVisibility}
+          toggleAllScreens={toggleAllScreens}
+          autoplayInterval={autoplayInterval}
+          toggleAutoplay={toggleAutoplay}
+          isAutoplaying={isAutoplaying}
+          toggleAutoplayInterval={toggleAutoplayInterval}
+          onOpenTutorial={handleOpenTutorial}
+          audioSourceURL={currentAudioSrc}
+          audioLoop={currentAudioLoop}
+          audioTracks={currentAudioTracks}
+          allowContinuousAudio={autoplayEnded}
+          editModeBackground={editModeBackground}
+          panelBackground={panelBackground}
+          panelBorderColor={panelBorderColor}
+        />
+      )}
+
+      <CueAudioPlayers
+        tracks={currentAudioTracks}
         isAutoplaying={isAutoplaying}
-        toggleAutoplayInterval={toggleAutoplayInterval}
-        onOpenTutorial={handleOpenTutorial}
-        audioSourceURL={currentAudioSrc}
-        audioLoop={currentAudioLoop}
-        audioTracks={currentAudioTracks}
         allowContinuousAudio={autoplayEnded}
-        editModeBackground={editModeBackground}
-        panelBackground={panelBackground}
-        panelBorderColor={panelBorderColor}
       />
 
       <TutorialGuide
@@ -749,6 +809,7 @@ const EditModeContainer = ({
             transitionType={transitionType}
             screenWidths={screenWidths}
             onWidthChange={handleScreenWidthChange}
+            isBlackout={isBlackout}
           />
         )
       })}

--- a/src/client/components/presentation/PresentationPlaybackControls.jsx
+++ b/src/client/components/presentation/PresentationPlaybackControls.jsx
@@ -9,7 +9,7 @@
  * - Autoplay instructions popover
  * - Audio player (if audio source URL is provided)
  */
-import React, { useEffect, useRef } from "react"
+import React from "react"
 import ClickablePopover from "../utils/ClickablePopover"
 
 import {
@@ -29,6 +29,7 @@ import { ArrowBackIcon, ArrowForwardIcon } from "@chakra-ui/icons"
 import pausebutton from "../../public/icons/pausebutton.svg"
 import playbutton from "../../public/icons/playbutton.svg"
 import { SpeakerIcon } from "../../lib/icons"
+import CueAudioPlayers from "./CueAudioPlayers"
 
 // autoplay controls component used in both presentation navigation and autoplay
 const AutoplayControls = ({ toggleAutoplay, isAutoplaying }) => {
@@ -128,46 +129,6 @@ const CueNavigationNext = ({ cueIndex, updateCue, indexCount }) => (
   />
 )
 
-const CueAudioPlayer = ({
-  src,
-  loop,
-  isAutoplaying,
-  continuePlayback,
-  allowContinuousAudio,
-}) => {
-  const audioRef = useRef(null)
-  const hasStartedRef = useRef(false)
-
-  useEffect(() => {
-    const audio = audioRef.current
-    if (!audio) return
-
-    if (!isAutoplaying || !src) {
-      if (
-        (loop || continuePlayback) &&
-        allowContinuousAudio &&
-        hasStartedRef.current
-      ) {
-        return
-      }
-      audio.pause()
-      return
-    }
-
-    const playPromise = audio.play()
-    hasStartedRef.current = true
-    if (playPromise?.catch) {
-      playPromise.catch(() => {})
-    }
-  }, [src, loop, isAutoplaying, continuePlayback, allowContinuousAudio])
-
-  if (!src) return null
-
-  return (
-    <audio ref={audioRef} loop={loop} src={src} preload="metadata" hidden />
-  )
-}
-
 const getTrackLabel = (track, index) => {
   if (track.name) return track.name
   const sourceName = String(track.src || "")
@@ -225,6 +186,7 @@ const PresentationPlaybackControls = ({
   audioLoop = false,
   audioTracks = [],
   allowContinuousAudio = false,
+  renderAudioPlayers = true,
 }) => {
   const resolvedAudioTracks =
     audioTracks.length > 0
@@ -285,16 +247,13 @@ const PresentationPlaybackControls = ({
         tracks={resolvedAudioTracks.filter((track) => track.src)}
         isAutoplaying={isAutoplaying}
       />
-      {resolvedAudioTracks.map((track, trackIndex) => (
-        <CueAudioPlayer
-          key={track.id || `${track.src}-${trackIndex}`}
-          src={track.src}
-          loop={Boolean(track.loop)}
+      {renderAudioPlayers && (
+        <CueAudioPlayers
+          tracks={resolvedAudioTracks}
           isAutoplaying={isAutoplaying}
-          continuePlayback={Boolean(track.continuePlayback)}
           allowContinuousAudio={allowContinuousAudio}
         />
-      ))}
+      )}
     </Box>
   )
 }

--- a/src/client/components/presentation/ScoreMarkerOverlay.tsx
+++ b/src/client/components/presentation/ScoreMarkerOverlay.tsx
@@ -22,6 +22,62 @@ export interface ScoreMarkerOverlayProps {
   highlightedMarkerId?: string | null
 }
 
+interface ScoreMarkerPinProps {
+  marker: ScoreMarker
+  isHighlighted?: boolean
+  isActive?: boolean
+  onSelect?: (marker: ScoreMarker) => void
+}
+
+export const ScoreMarkerPin = ({
+  marker,
+  isHighlighted = false,
+  isActive = false,
+  onSelect,
+}: ScoreMarkerPinProps) => (
+  <Box
+    position="absolute"
+    left={`${marker.rect!.x * 100}%`}
+    top={`${marker.rect!.y * 100}%`}
+    transform="translate(-50%, -50%)"
+    pointerEvents={onSelect ? "auto" : "none"}
+    cursor={onSelect ? "pointer" : "default"}
+    zIndex={isHighlighted || isActive ? 3 : 1}
+    title={`Frame ${marker.frameIndex}${onSelect ? " — click to edit" : ""}`}
+    data-marker-id={marker._id}
+    data-testid="score-marker-pin"
+    data-active={isActive}
+    onClick={
+      onSelect
+        ? (event) => {
+            event.stopPropagation()
+            onSelect(marker)
+          }
+        : undefined
+    }
+  >
+    <Box
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      width="22px"
+      height="22px"
+      borderRadius="full"
+      bg={isActive ? "red.500" : "purple.500"}
+      border="2px solid white"
+      boxShadow="0 1px 4px rgba(0,0,0,0.4)"
+      _hover={onSelect ? { bg: "red.500" } : undefined}
+      sx={
+        isHighlighted ? { animation: `${markerPing} 1s ease-out 3` } : undefined
+      }
+    >
+      <Text fontSize="10px" fontWeight={700} color="white">
+        {marker.frameIndex}
+      </Text>
+    </Box>
+  </Box>
+)
+
 const ScoreMarkerOverlay = ({
   markers,
   isPlacing,
@@ -49,49 +105,14 @@ const ScoreMarkerOverlay = ({
     >
       {markers
         .filter((marker) => marker.rect)
-        .map((marker) => {
-          const isHighlighted = marker._id === highlightedMarkerId
-          return (
-            <Box
-              key={marker._id}
-              position="absolute"
-              left={`${marker.rect!.x * 100}%`}
-              top={`${marker.rect!.y * 100}%`}
-              transform="translate(-50%, -50%)"
-              pointerEvents="auto"
-              cursor="pointer"
-              zIndex={isHighlighted ? 3 : 1}
-              title={`Frame ${marker.frameIndex} — click to edit`}
-              data-marker-id={marker._id}
-              onClick={(event) => {
-                event.stopPropagation()
-                onSelectMarker(marker)
-              }}
-            >
-              <Box
-                display="flex"
-                alignItems="center"
-                justifyContent="center"
-                width="22px"
-                height="22px"
-                borderRadius="full"
-                bg="purple.500"
-                border="2px solid white"
-                boxShadow="0 1px 4px rgba(0,0,0,0.4)"
-                _hover={{ bg: "red.500" }}
-                sx={
-                  isHighlighted
-                    ? { animation: `${markerPing} 1s ease-out 3` }
-                    : undefined
-                }
-              >
-                <Text fontSize="10px" fontWeight={700} color="white">
-                  {marker.frameIndex}
-                </Text>
-              </Box>
-            </Box>
-          )
-        })}
+        .map((marker) => (
+          <ScoreMarkerPin
+            key={marker._id}
+            marker={marker}
+            isHighlighted={marker._id === highlightedMarkerId}
+            onSelect={onSelectMarker}
+          />
+        ))}
     </Box>
   )
 }

--- a/src/client/components/presentation/ScorePdfViewer.tsx
+++ b/src/client/components/presentation/ScorePdfViewer.tsx
@@ -123,19 +123,29 @@ const PdfCanvas = ({
         if (cancelled) return
         const vp = page.getViewport({ scale })
         const dpr = window.devicePixelRatio || 1
-        const ctx = canvas.getContext("2d")
+        const buffer = document.createElement("canvas")
+        buffer.width = Math.floor(vp.width * dpr)
+        buffer.height = Math.floor(vp.height * dpr)
+        const ctx = buffer.getContext("2d")
         if (!ctx) return
-        canvas.width = Math.floor(vp.width * dpr)
-        canvas.height = Math.floor(vp.height * dpr)
-        canvas.style.width = `${Math.floor(vp.width)}px`
-        canvas.style.height = `${Math.floor(vp.height)}px`
-        ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+
+        const transform = dpr !== 1 ? [dpr, 0, 0, dpr, 0, 0] : undefined
+
         renderTask = page.render({
           canvasContext: ctx,
           viewport: vp,
+          transform,
           background,
         })
         await renderTask.promise
+        if (cancelled) return
+        const visibleContext = canvas.getContext("2d")
+        if (!visibleContext) return
+        canvas.width = buffer.width
+        canvas.height = buffer.height
+        canvas.style.width = `${Math.floor(vp.width)}px`
+        canvas.style.height = `${Math.floor(vp.height)}px`
+        visibleContext.drawImage(buffer, 0, 0)
       } catch {
         /* cancelled or error — silently ignore */
       } finally {
@@ -296,10 +306,13 @@ const ThumbnailCanvas = ({
         canvas.height = Math.floor(vp.height * dpr)
         canvas.style.width = `${THUMB_WIDTH}px`
         canvas.style.height = `${Math.floor(vp.height)}px`
-        ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+
+        const transform = dpr !== 1 ? [dpr, 0, 0, dpr, 0, 0] : undefined
+
         await page.render({
           canvasContext: ctx,
           viewport: vp,
+          transform,
           background: "#ffffff",
         }).promise
       } catch {
@@ -949,12 +962,10 @@ const ScorePdfViewer = ({
           minW={0}
           minH={0}
           bg={surfaceBg}
-          overflowX="hidden"
+          overflowX="auto"
           overflowY="auto"
           p={4}
-          display="flex"
-          alignItems="flex-start"
-          justifyContent="center"
+          textAlign="center"
         >
           {isLoading ? (
             <VStack mt={8}>

--- a/src/client/components/presentation/Screen.jsx
+++ b/src/client/components/presentation/Screen.jsx
@@ -174,6 +174,7 @@ const ScreenContent = ({
   showText,
   transitionType,
   screenWidths,
+  isBlackout,
 }) => {
   const { enter: enterAnim, exit: exitAnim } = getAnims(transitionType)
   const animStyle = (kf) => (kf ? `${kf} 500ms ease-in-out forwards` : "none")
@@ -257,6 +258,15 @@ const ScreenContent = ({
       >
         {renderCueStack(currentScreenData, screenNumber, screenWidths)}
       </Box>
+      {isBlackout && (
+        <Box
+          data-testid="screen-blackout"
+          position="absolute"
+          inset="0"
+          zIndex={1000}
+          bg="black"
+        />
+      )}
     </Box>
   )
 }
@@ -269,6 +279,7 @@ const Screen = ({
   transitionType,
   screenWidths,
   onWidthChange,
+  isBlackout = false,
 }) => {
   const windowRef = useRef(null)
   const [isWindowReady, setIsWindowReady] = useState(false)
@@ -295,6 +306,10 @@ const Screen = ({
           `Screen ${screenNumber}`,
           "width=800,height=600"
         )
+        if (!newWindow) {
+          onClose(screenNumber)
+          return
+        }
         windowRef.current = newWindow
         setIsWindowReady(true)
 
@@ -349,6 +364,21 @@ const Screen = ({
       }
     }
   }, [isVisible, screenNumber, onClose])
+
+  useEffect(() => {
+    if (!isVisible) return undefined
+    const interval = window.setInterval(() => {
+      if (windowRef.current?.closed) {
+        windowRef.current = null
+        setIsWindowReady(false)
+        setEmotionCache(null)
+        setCurrentScreenData(null)
+        setPreviousScreenData(null)
+        onClose(screenNumber)
+      }
+    }, 750)
+    return () => window.clearInterval(interval)
+  }, [isVisible, onClose, screenNumber])
 
   useEffect(() => {
     if (windowRef.current && !emotionCache) {
@@ -444,10 +474,7 @@ const Screen = ({
   }, [])
 
   // Only render the portal when the window is ready
-  return windowRef.current &&
-    isWindowReady &&
-    emotionCache &&
-    (currentScreenData || previousScreenData)
+  return windowRef.current && isWindowReady && emotionCache
     ? ReactDOM.createPortal(
         //inject Emotion styles to portal (e.g. fadeOut, fadeIn effects)
         <CacheProvider value={emotionCache}>
@@ -458,6 +485,7 @@ const Screen = ({
             showText={showText}
             transitionType={transitionType}
             screenWidths={screenWidths}
+            isBlackout={isBlackout}
           />
         </CacheProvider>,
         windowRef.current.document.body // render to new window's document.body

--- a/src/client/components/presentation/ScreensDisplay.tsx
+++ b/src/client/components/presentation/ScreensDisplay.tsx
@@ -16,7 +16,7 @@ import {
   buildCueVisualSpanMap,
   getCueVisualSpanFromMap,
 } from "../utils/cueVisualSpanUtils"
-import { isType } from "../utils/fileTypeUtils"
+import { isImageFile, isVideoFile } from "../utils/fileTypeUtils"
 import { normalizeCueOpacity } from "../utils/cueOpacityUtils"
 import { computeScreenSpanLayout } from "../utils/screenSpanLayout"
 
@@ -205,21 +205,6 @@ export const ScreensDisplay = ({
       return acc
     }, {})
   }, [cues])
-
-  const getCleanUrl = (file?: CueFileMeta | null): string => {
-    const url = file?.url || ""
-    return String(url).split("?")[0].split("#")[0]
-  }
-
-  const isImageFile = (file?: CueFileMeta | null): boolean => {
-    if (isType.image(file)) return true
-    return /\.(jpg|jpeg|png|gif|webp|bmp|svg)$/i.test(getCleanUrl(file)) // check common image file extensions
-  }
-
-  const isVideoFile = (file?: CueFileMeta | null): boolean => {
-    if (isType.video(file)) return true
-    return /\.(mp4|webm|ogg|mov|m4v)$/i.test(getCleanUrl(file)) // check common video file extensions
-  }
 
   const getCurrentCueStackForScreen = (screenNumber: number): Cue[] => {
     const cuesOnScreen = screenSortedCuesByScreen[Number(screenNumber)] || []

--- a/src/client/components/presentation/ShowMode.tsx
+++ b/src/client/components/presentation/ShowMode.tsx
@@ -1,0 +1,529 @@
+import {
+  Box,
+  Button,
+  HStack,
+  Icon,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  Text,
+} from "@chakra-ui/react"
+import {
+  FiBookOpen,
+  FiChevronDown,
+  FiGrid,
+  FiMonitor,
+  FiSkipBack,
+} from "react-icons/fi"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import type { Dispatch, SetStateAction } from "react"
+import type { Cue, ScoreDocument } from "../../types"
+import KeyboardHandler from "../utils/keyboardHandler"
+import ShowMonitorWindow from "./ShowMonitorWindow"
+import ShowScoreViewer from "./ShowScoreViewer"
+import ShowScreenPreview from "./ShowScreenPreview"
+
+type ShowView = "music" | "control"
+type MonitorView = "score" | "wall" | null
+type PageMode = "two" | "scroll"
+
+interface AudioTrack {
+  id: string
+  name: string
+  layer: number
+  loop: boolean
+  continuePlayback: boolean
+}
+
+interface ShowModeProps {
+  presentationName: string
+  screenCount: number
+  scores: ScoreDocument[]
+  cueIndex: number
+  indexCount: number
+  screens: Record<string, boolean>
+  audioTracks: AudioTrack[]
+  autoplayInterval: number
+  isAutoplaying: boolean
+  isBlackout: boolean
+  getActiveCuesForScreen: (screenNumber: number, index: number) => Cue[]
+  onSetCueIndex: Dispatch<SetStateAction<number>>
+  onPrevious: () => void
+  onNext: () => void
+  onToggleAutoplay: () => void
+  onToggleBlackout: () => void
+  onToggleScreen: (screenNumber: number) => void
+  onExit: () => void
+}
+
+const formatDuration = (seconds: number) => {
+  const hours = Math.floor(seconds / 3600)
+  const minutes = Math.floor((seconds % 3600) / 60)
+  const remaining = seconds % 60
+  return [hours, minutes, remaining]
+    .map((part) => String(part).padStart(2, "0"))
+    .join(":")
+}
+
+const cueStackKey = (cues: Cue[]) =>
+  cues
+    .map(
+      (cue) =>
+        `${cue._id}:${cue.index}:${cue.layer}:${cue.opacity}:${cue.file?.url ?? cue.color}`
+    )
+    .join("|")
+
+const ShowCueList = ({
+  cueIndex,
+  indexCount,
+  scores,
+  onSelect,
+}: {
+  cueIndex: number
+  indexCount: number
+  scores: ScoreDocument[]
+  onSelect: (index: number) => void
+}) => {
+  const markedFrames = new Set(
+    scores.flatMap((score) => score.markers.map((marker) => marker.frameIndex))
+  )
+
+  return (
+    <Box className="show-cue-list" role="list" aria-label="Cue list">
+      {Array.from({ length: indexCount }, (_, index) => {
+        const state =
+          index === cueIndex
+            ? "live"
+            : index === Math.min(cueIndex + 1, indexCount - 1)
+              ? "next"
+              : "idle"
+        return (
+          <Button
+            key={index}
+            className="show-cue-chip"
+            data-state={state}
+            aria-label={`Go to frame ${index}`}
+            onClick={() => onSelect(index)}
+          >
+            {index}
+            {markedFrames.has(index) && <Box className="show-cue-marker-dot" />}
+          </Button>
+        )
+      })}
+    </Box>
+  )
+}
+
+const ShowAudioStrip = ({ tracks }: { tracks: AudioTrack[] }) => (
+  <Box className="show-audio-strip" aria-label="Active audio tracks">
+    <Text className="show-section-label">Audio</Text>
+    {tracks.length ? (
+      tracks.map((track) => (
+        <Box key={track.id} className="show-audio-track">
+          <Box className="show-audio-meter">
+            <Box />
+            <Box />
+            <Box />
+            <Box />
+          </Box>
+          <Text title={track.name}>{track.name}</Text>
+          <Text as="span">A{track.layer + 1}</Text>
+          {track.loop && <Text as="span">Loop</Text>}
+        </Box>
+      ))
+    ) : (
+      <Text className="show-muted">No active audio</Text>
+    )}
+  </Box>
+)
+
+const ShowScreenWall = ({
+  screenCount,
+  screens,
+  cueIndex,
+  getActiveCuesForScreen,
+  onToggleScreen,
+}: Pick<
+  ShowModeProps,
+  | "screenCount"
+  | "screens"
+  | "cueIndex"
+  | "getActiveCuesForScreen"
+  | "onToggleScreen"
+>) => (
+  <Box className="show-screen-wall">
+    {Array.from({ length: screenCount }, (_, index) => {
+      const screenNumber = index + 1
+      return (
+        <ShowScreenPreview
+          key={screenNumber}
+          screenNumber={screenNumber}
+          cues={getActiveCuesForScreen(screenNumber, cueIndex)}
+          isOnline={Boolean(screens[screenNumber])}
+          onOpen={() => onToggleScreen(screenNumber)}
+        />
+      )
+    })}
+  </Box>
+)
+
+const ShowTransport = ({
+  cueIndex,
+  indexCount,
+  nextChanges,
+  scores,
+  isAutoplaying,
+  isBlackout,
+  autoplayInterval,
+  onPrevious,
+  onNext,
+  onSelect,
+  onToggleAutoplay,
+  onToggleBlackout,
+  large,
+}: {
+  cueIndex: number
+  indexCount: number
+  nextChanges: number[]
+  scores: ScoreDocument[]
+  isAutoplaying: boolean
+  isBlackout: boolean
+  autoplayInterval: number
+  onPrevious: () => void
+  onNext: () => void
+  onSelect: (index: number) => void
+  onToggleAutoplay: () => void
+  onToggleBlackout: () => void
+  large?: boolean
+}) => (
+  <Box className={`show-transport ${large ? "show-transport-large" : ""}`}>
+    <Button
+      className="show-previous"
+      aria-label="Previous frame"
+      isDisabled={cueIndex <= 0}
+      onClick={onPrevious}
+    >
+      <Icon as={FiSkipBack} />
+    </Button>
+    <Button
+      className="show-go"
+      isDisabled={cueIndex >= indexCount - 1}
+      onClick={onNext}
+    >
+      GO
+      {large && cueIndex < indexCount - 1 && (
+        <Text as="span">Frame {cueIndex + 1}</Text>
+      )}
+    </Button>
+    {!large && (
+      <Box className="show-next-change">
+        <Text>Frame {Math.min(cueIndex + 1, indexCount - 1)} will change</Text>
+        <Text>
+          {nextChanges.length
+            ? nextChanges.map((screen) => `Display ${screen}`).join(" · ")
+            : "No display changes"}
+        </Text>
+      </Box>
+    )}
+    <ShowCueList
+      cueIndex={cueIndex}
+      indexCount={indexCount}
+      scores={scores}
+      onSelect={onSelect}
+    />
+    <Button
+      className="show-auto"
+      data-active={isAutoplaying}
+      onClick={onToggleAutoplay}
+    >
+      Auto {isAutoplaying ? "on" : "off"} · {autoplayInterval}s
+    </Button>
+    <Button
+      className="show-blackout"
+      data-active={isBlackout}
+      onClick={onToggleBlackout}
+    >
+      Blackout{isBlackout ? " on" : ""}
+    </Button>
+  </Box>
+)
+
+const ShowMode = ({
+  presentationName,
+  screenCount,
+  scores,
+  cueIndex,
+  indexCount,
+  screens,
+  audioTracks,
+  autoplayInterval,
+  isAutoplaying,
+  isBlackout,
+  getActiveCuesForScreen,
+  onSetCueIndex,
+  onPrevious,
+  onNext,
+  onToggleAutoplay,
+  onToggleBlackout,
+  onToggleScreen,
+  onExit,
+}: ShowModeProps) => {
+  const [view, setView] = useState<ShowView>("music")
+  const [pageMode, setPageMode] = useState<PageMode>("two")
+  const [autoPageTurn, setAutoPageTurn] = useState(true)
+  const [monitorView, setMonitorView] = useState<MonitorView>(null)
+  const [elapsed, setElapsed] = useState(0)
+  const [clock, setClock] = useState(() => new Date())
+  const selectedScore = scores[0] ?? null
+  const onlineCount = Object.values(screens).filter(Boolean).length
+  const nextIndex = Math.min(cueIndex + 1, Math.max(indexCount - 1, 0))
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      setElapsed((value) => value + 1)
+      setClock(new Date())
+    }, 1000)
+    return () => window.clearInterval(timer)
+  }, [])
+
+  const nextChanges = useMemo(
+    () =>
+      Array.from({ length: screenCount }, (_, index) => index + 1).filter(
+        (screenNumber) =>
+          cueStackKey(getActiveCuesForScreen(screenNumber, cueIndex)) !==
+          cueStackKey(getActiveCuesForScreen(screenNumber, nextIndex))
+      ),
+    [cueIndex, getActiveCuesForScreen, nextIndex, screenCount]
+  )
+
+  const closeMonitor = useCallback(() => setMonitorView(null), [])
+
+  return (
+    <Box className="show-mode-shell">
+      <KeyboardHandler
+        onNext={onNext}
+        onPrevious={onPrevious}
+        onTogglePlay={onToggleAutoplay}
+      />
+      <Box className="show-topbar">
+        <Box className="show-badge">
+          <Box />
+          SHOW
+        </Box>
+        <Text className="show-title">{presentationName}</Text>
+        <Box className="show-divider" />
+        <Box className="show-clock-group">
+          <Text>Elapsed</Text>
+          <Text style={{ fontVariantNumeric: "tabular-nums" }}>
+            {formatDuration(elapsed)}
+          </Text>
+        </Box>
+        <Text
+          className="show-wall-clock"
+          style={{ fontVariantNumeric: "tabular-nums" }}
+        >
+          {clock.toLocaleTimeString([], {
+            hour: "2-digit",
+            minute: "2-digit",
+            second: "2-digit",
+          })}
+        </Text>
+        <Box flex="1" />
+        <Box className="show-segmented show-view-switch">
+          <Button
+            data-active={view === "music"}
+            onClick={() => setView("music")}
+          >
+            <Icon as={FiBookOpen} /> Music stand
+          </Button>
+          <Button
+            data-active={view === "control"}
+            onClick={() => setView("control")}
+          >
+            <Icon as={FiGrid} /> Control room
+          </Button>
+        </Box>
+        <Menu>
+          <MenuButton
+            as={Button}
+            className="show-monitor-button"
+            data-active={Boolean(monitorView)}
+            leftIcon={<Icon as={FiMonitor} />}
+            rightIcon={<Icon as={FiChevronDown} />}
+          >
+            {monitorView ? "Monitor live" : "Monitor"}
+          </MenuButton>
+          <MenuList className="show-monitor-menu">
+            <MenuItem onClick={() => setMonitorView("score")}>
+              Score only
+            </MenuItem>
+            <MenuItem onClick={() => setMonitorView("wall")}>
+              Screen wall
+            </MenuItem>
+            {monitorView && (
+              <MenuItem onClick={closeMonitor}>Close monitor</MenuItem>
+            )}
+          </MenuList>
+        </Menu>
+        <Box className="show-display-status">
+          <Box
+            className={`show-online-dot ${onlineCount ? "is-online" : ""}`}
+          />
+          <Text>
+            {onlineCount} / {screenCount} displays online
+          </Text>
+        </Box>
+        {isBlackout && (
+          <Box className="show-blackout-status">Output blackout</Box>
+        )}
+        <Button className="show-exit" onClick={onExit}>
+          Exit
+        </Button>
+      </Box>
+
+      {view === "music" ? (
+        <Box className="show-main show-main-music">
+          <Box className="show-music-primary">
+            <ShowScoreViewer
+              score={selectedScore}
+              cueIndex={cueIndex}
+              pageMode={pageMode}
+              autoPageTurn={autoPageTurn}
+              onPageModeChange={setPageMode}
+              onAutoPageTurnChange={setAutoPageTurn}
+            />
+            <ShowTransport
+              large
+              cueIndex={cueIndex}
+              indexCount={indexCount}
+              nextChanges={nextChanges}
+              scores={scores}
+              isAutoplaying={isAutoplaying}
+              isBlackout={isBlackout}
+              autoplayInterval={autoplayInterval}
+              onPrevious={onPrevious}
+              onNext={onNext}
+              onSelect={onSetCueIndex}
+              onToggleAutoplay={onToggleAutoplay}
+              onToggleBlackout={onToggleBlackout}
+            />
+          </Box>
+          <Box className="show-music-rail">
+            <ShowScreenPreview
+              screenNumber={1}
+              cues={getActiveCuesForScreen(1, cueIndex)}
+              label="LIVE · Screen 1"
+              compact
+            />
+            <Box className="show-mini-screen-grid">
+              {Array.from(
+                { length: Math.max(0, screenCount - 1) },
+                (_, index) => {
+                  const screenNumber = index + 2
+                  return (
+                    <ShowScreenPreview
+                      key={screenNumber}
+                      screenNumber={screenNumber}
+                      cues={getActiveCuesForScreen(screenNumber, cueIndex)}
+                      label={`Screen ${screenNumber}`}
+                      compact
+                    />
+                  )
+                }
+              )}
+            </Box>
+            <ShowScreenPreview
+              screenNumber={1}
+              cues={getActiveCuesForScreen(1, nextIndex)}
+              label={`NEXT · Frame ${nextIndex}`}
+              compact
+            />
+            <ShowCueList
+              cueIndex={cueIndex}
+              indexCount={indexCount}
+              scores={scores}
+              onSelect={onSetCueIndex}
+            />
+            <ShowAudioStrip tracks={audioTracks} />
+          </Box>
+        </Box>
+      ) : (
+        <Box className="show-main show-main-control">
+          <Box className="show-control-primary">
+            <ShowScreenWall
+              screenCount={screenCount}
+              screens={screens}
+              cueIndex={cueIndex}
+              getActiveCuesForScreen={getActiveCuesForScreen}
+              onToggleScreen={onToggleScreen}
+            />
+            <ShowTransport
+              cueIndex={cueIndex}
+              indexCount={indexCount}
+              nextChanges={nextChanges}
+              scores={scores}
+              isAutoplaying={isAutoplaying}
+              isBlackout={isBlackout}
+              autoplayInterval={autoplayInterval}
+              onPrevious={onPrevious}
+              onNext={onNext}
+              onSelect={onSetCueIndex}
+              onToggleAutoplay={onToggleAutoplay}
+              onToggleBlackout={onToggleBlackout}
+            />
+            <ShowAudioStrip tracks={audioTracks} />
+          </Box>
+          <Box className="show-control-score">
+            <HStack justify="space-between">
+              <Text className="show-section-label">Score</Text>
+              <Button
+                size="xs"
+                variant="muvico-secondary"
+                onClick={() => setView("music")}
+              >
+                Expand
+              </Button>
+            </HStack>
+            <ShowScoreViewer
+              compact
+              score={selectedScore}
+              cueIndex={cueIndex}
+              pageMode="two"
+              autoPageTurn
+            />
+          </Box>
+        </Box>
+      )}
+
+      {monitorView && (
+        <ShowMonitorWindow
+          title={`${presentationName} · ${monitorView === "score" ? "Score" : "Screen wall"}`}
+          onClose={closeMonitor}
+        >
+          <Box className="show-monitor-output">
+            {monitorView === "score" ? (
+              <ShowScoreViewer
+                score={selectedScore}
+                cueIndex={cueIndex}
+                pageMode={pageMode}
+                autoPageTurn
+                compact
+              />
+            ) : (
+              <ShowScreenWall
+                screenCount={screenCount}
+                screens={screens}
+                cueIndex={cueIndex}
+                getActiveCuesForScreen={getActiveCuesForScreen}
+                onToggleScreen={onToggleScreen}
+              />
+            )}
+          </Box>
+        </ShowMonitorWindow>
+      )}
+    </Box>
+  )
+}
+
+export default ShowMode

--- a/src/client/components/presentation/ShowMonitorWindow.tsx
+++ b/src/client/components/presentation/ShowMonitorWindow.tsx
@@ -1,0 +1,68 @@
+import createCache from "@emotion/cache"
+import { CacheProvider } from "@emotion/react"
+import { useEffect, useRef, useState } from "react"
+import { createPortal } from "react-dom"
+import type { ReactNode } from "react"
+
+interface ShowMonitorWindowProps {
+  title: string
+  children: ReactNode
+  onClose: () => void
+}
+
+const ShowMonitorWindow = ({
+  title,
+  children,
+  onClose,
+}: ShowMonitorWindowProps) => {
+  const windowRef = useRef<Window | null>(null)
+  const [host, setHost] = useState<HTMLElement | null>(null)
+  const [cache, setCache] = useState<ReturnType<typeof createCache> | null>(
+    null
+  )
+
+  useEffect(() => {
+    const popup = window.open("", "MuViCo Monitor", "width=1280,height=800")
+    if (!popup) {
+      onClose()
+      return
+    }
+    windowRef.current = popup
+    popup.document.title = title
+    popup.document.documentElement.style.background = "#08060a"
+    popup.document.documentElement.style.height = "100%"
+    popup.document.body.style.margin = "0"
+    popup.document.body.style.height = "100%"
+    popup.document.body.style.overflow = "hidden"
+    document
+      .querySelectorAll("link[rel='stylesheet'], style")
+      .forEach((node) => popup.document.head.appendChild(node.cloneNode(true)))
+    setHost(popup.document.body)
+    setCache(
+      createCache({ key: "show-monitor", container: popup.document.head })
+    )
+
+    const handleClose = () => onClose()
+    popup.addEventListener("beforeunload", handleClose)
+    const poll = window.setInterval(() => {
+      if (popup.closed) onClose()
+    }, 750)
+
+    return () => {
+      window.clearInterval(poll)
+      popup.removeEventListener("beforeunload", handleClose)
+      if (!popup.closed) popup.close()
+      windowRef.current = null
+      setHost(null)
+      setCache(null)
+    }
+  }, [onClose, title])
+
+  if (!host || !cache) return null
+  return createPortal(
+    <CacheProvider value={cache}>{children}</CacheProvider>,
+    host
+  )
+}
+
+export default ShowMonitorWindow

--- a/src/client/components/presentation/ShowScoreViewer.tsx
+++ b/src/client/components/presentation/ShowScoreViewer.tsx
@@ -1,0 +1,447 @@
+import workerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url"
+import {
+  Box,
+  Button,
+  HStack,
+  IconButton,
+  Spinner,
+  Text,
+} from "@chakra-ui/react"
+import { ChevronLeftIcon, ChevronRightIcon } from "@chakra-ui/icons"
+import { useEffect, useMemo, useRef, useState } from "react"
+import getToken from "../../auth"
+import type {
+  PDFDocumentLoadingTask,
+  PDFDocumentProxy,
+  RenderTask,
+} from "pdfjs-dist/types/src/pdf"
+import type { ScoreDocument, ScoreMarker } from "../../types"
+import { ScoreMarkerPin } from "./ScoreMarkerOverlay"
+
+type PageMode = "two" | "scroll"
+
+interface ShowScoreViewerProps {
+  score: ScoreDocument | null
+  cueIndex: number
+  pageMode: PageMode
+  autoPageTurn: boolean
+  compact?: boolean
+  onPageModeChange?: (mode: PageMode) => void
+  onAutoPageTurnChange?: (active: boolean) => void
+}
+
+const clamp = (value: number, minimum: number, maximum: number) =>
+  Math.min(maximum, Math.max(minimum, value))
+
+const markerForFrame = (markers: ScoreMarker[], cueIndex: number) => {
+  const ordered = [...markers].sort(
+    (first, second) => first.frameIndex - second.frameIndex
+  )
+  return (
+    ordered.filter((marker) => marker.frameIndex <= cueIndex).at(-1) ??
+    ordered[0] ??
+    null
+  )
+}
+
+const ShowPdfPage = ({
+  pdf,
+  pageNumber,
+  markers,
+  activeMarker,
+  pageWidth,
+  onLoad,
+}: {
+  pdf: PDFDocumentProxy
+  pageNumber: number
+  markers: ScoreMarker[]
+  activeMarker: ScoreMarker | null
+  pageWidth?: number
+  onLoad?: (baseWidth: number, aspectRatio: number) => void
+}) => {
+  const hostRef = useRef<HTMLDivElement | null>(null)
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const onLoadRef = useRef(onLoad)
+  useEffect(() => {
+    onLoadRef.current = onLoad
+  }, [onLoad])
+
+  useEffect(() => {
+    const host = hostRef.current
+    const canvas = canvasRef.current
+    if (!host || !canvas) return
+    let task: RenderTask | null = null
+    let cancelled = false
+    let isRendering = false
+    let queuedWidth: number | null = null
+    let renderedWidth = 0
+
+    const render = async (width: number) => {
+      const page = await pdf.getPage(pageNumber)
+      if (cancelled) return
+      const base = page.getViewport({ scale: 1 })
+      onLoadRef.current?.(base.width, base.width / base.height)
+      const viewport = page.getViewport({ scale: width / base.width })
+      const dpr = window.devicePixelRatio || 1
+      const buffer = document.createElement("canvas")
+      buffer.width = Math.floor(viewport.width * dpr)
+      buffer.height = Math.floor(viewport.height * dpr)
+      const context = buffer.getContext("2d")
+      if (!context) return
+
+      const transform = dpr !== 1 ? [dpr, 0, 0, dpr, 0, 0] : undefined
+
+      task = page.render({
+        canvasContext: context,
+        viewport,
+        transform,
+        background: "#f7f4ee",
+      })
+      await task.promise
+      if (cancelled) return
+      const visibleContext = canvas.getContext("2d")
+      if (!visibleContext) return
+      canvas.width = buffer.width
+      canvas.height = buffer.height
+      canvas.style.width = `${viewport.width}px`
+      canvas.style.height = `${viewport.height}px`
+      visibleContext.drawImage(buffer, 0, 0)
+      renderedWidth = width
+    }
+
+    const flushRender = async () => {
+      if (isRendering || cancelled) return
+      isRendering = true
+      while (!cancelled && queuedWidth !== null) {
+        const width = queuedWidth
+        queuedWidth = null
+        if (Math.abs(width - renderedWidth) < 1) continue
+        try {
+          await render(width)
+        } catch {
+          if (cancelled) return
+        }
+      }
+      isRendering = false
+    }
+
+    const queueRender = () => {
+      queuedWidth = Math.max(260, Math.round(host.clientWidth))
+      void flushRender()
+    }
+
+    const observer = new ResizeObserver(queueRender)
+    observer.observe(host)
+    queueRender()
+    return () => {
+      cancelled = true
+      queuedWidth = null
+      observer.disconnect()
+      task?.cancel()
+    }
+  }, [pageNumber, pdf])
+
+  const containerStyle = pageWidth
+    ? {
+        width: `${pageWidth}px`,
+        flex: "0 0 auto",
+        maxWidth: "none",
+        minWidth: 0,
+      }
+    : undefined
+
+  return (
+    <Box
+      ref={hostRef}
+      className="show-score-page"
+      data-page={pageNumber}
+      style={containerStyle}
+    >
+      <canvas ref={canvasRef} />
+      {markers
+        .filter((marker) => marker.page === pageNumber && marker.rect)
+        .map((marker) => (
+          <ScoreMarkerPin
+            key={marker._id}
+            marker={marker}
+            isActive={marker._id === activeMarker?._id}
+          />
+        ))}
+      <Text className="show-score-page-number">p. {pageNumber}</Text>
+    </Box>
+  )
+}
+
+const ShowScoreViewer = ({
+  score,
+  cueIndex,
+  pageMode,
+  autoPageTurn,
+  compact = false,
+  onPageModeChange,
+  onAutoPageTurnChange,
+}: ShowScoreViewerProps) => {
+  const [pdf, setPdf] = useState<PDFDocumentProxy | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [loadError, setLoadError] = useState(false)
+  const [manualPage, setManualPage] = useState(1)
+  const [zoom, setZoom] = useState(0) // 0 means Fit, > 0 is absolute scale
+  const [aspectRatio, setAspectRatio] = useState<number | null>(null)
+  const [baseWidth, setBaseWidth] = useState<number | null>(null)
+  const [containerSize, setContainerSize] = useState({ w: 0, h: 0 })
+  const scrollRef = useRef<HTMLDivElement | null>(null)
+  const url = score?.file?.proxyUrl ?? score?.file?.url ?? score?.sourceUrl
+  const activeMarker = useMemo(
+    () => markerForFrame(score?.markers ?? [], cueIndex),
+    [cueIndex, score?.markers]
+  )
+  const activePage = clamp(
+    autoPageTurn ? (activeMarker?.page ?? manualPage) : manualPage,
+    1,
+    Math.max(pdf?.numPages ?? score?.pageCount ?? 1, 1)
+  )
+
+  useEffect(() => {
+    if (!url) {
+      setPdf(null)
+      setAspectRatio(null)
+      setBaseWidth(null)
+      return
+    }
+    let loadingTask: PDFDocumentLoadingTask | null = null
+    let cancelled = false
+    setIsLoading(true)
+    setLoadError(false)
+
+    const load = async () => {
+      try {
+        const { GlobalWorkerOptions, getDocument } = await import("pdfjs-dist")
+        GlobalWorkerOptions.workerSrc = workerUrl
+        const token = getToken()
+        loadingTask = getDocument({
+          url,
+          httpHeaders:
+            url.startsWith("/api/") && token
+              ? { Authorization: `bearer ${token}` }
+              : undefined,
+          disableRange: true,
+          disableStream: true,
+        })
+        const document = await loadingTask.promise
+        if (cancelled) return
+        setPdf(document)
+      } catch {
+        if (!cancelled) setLoadError(true)
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+      void loadingTask?.destroy()
+    }
+  }, [url])
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const ro = new ResizeObserver((entries) => {
+      if (entries[0]) {
+        setContainerSize({
+          w: entries[0].contentRect.width,
+          h: entries[0].contentRect.height,
+        })
+      }
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+
+  let pageWidth: number | undefined
+  let fitW = 0
+  if (containerSize.w > 0 && containerSize.h > 0 && aspectRatio) {
+    const gap = 12
+    const padding = 16 // safe margin vertically
+    const availableW =
+      pageMode === "two"
+        ? (containerSize.w - gap) / 2
+        : Math.min(containerSize.w, 980)
+    const availableH = containerSize.h - padding
+    fitW = Math.min(availableW, availableH * aspectRatio)
+    pageWidth = zoom === 0 ? fitW : (baseWidth ?? fitW) * zoom
+  }
+
+  const currentScale =
+    zoom === 0 ? (baseWidth && fitW ? fitW / baseWidth : 1) : zoom
+
+  useEffect(() => {
+    if (!autoPageTurn) return
+    setManualPage(activeMarker?.page ?? 1)
+  }, [activeMarker?.page, autoPageTurn])
+
+  useEffect(() => {
+    if (pageMode !== "scroll") return
+    scrollRef.current
+      ?.querySelector<HTMLElement>(`[data-page="${activePage}"]`)
+      ?.scrollIntoView({ block: "start", behavior: "smooth" })
+  }, [activePage, pageMode])
+
+  if (!score) {
+    return (
+      <Box className="show-score-empty">
+        <Text fontWeight={700}>No score selected</Text>
+        <Text>Import a PDF from the editor to use Music stand.</Text>
+      </Box>
+    )
+  }
+
+  return (
+    <Box className={`show-score ${compact ? "show-score-compact" : ""}`}>
+      <Box className="show-score-toolbar">
+        <Box minW={0}>
+          <Text className="show-score-measure">
+            {activeMarker?.measureLabel || `Frame ${cueIndex}`}
+          </Text>
+          <Text className="show-score-title" title={score.title}>
+            {score.title}
+          </Text>
+        </Box>
+        {!compact && (
+          <HStack spacing={2} ml="auto">
+            <Box className="show-segmented">
+              <Button
+                aria-label="Zoom out"
+                onClick={() =>
+                  setZoom(Math.max(0.25, Math.ceil(currentScale * 4 - 1.1) / 4))
+                }
+              >
+                -
+              </Button>
+              <Button onClick={() => setZoom(zoom === 0 ? 1 : 0)} w="52px">
+                {zoom === 0 ? "Fit" : `${Math.round(zoom * 100)}%`}
+              </Button>
+              <Button
+                aria-label="Zoom in"
+                onClick={() =>
+                  setZoom(Math.min(3, Math.floor(currentScale * 4 + 1.1) / 4))
+                }
+              >
+                +
+              </Button>
+            </Box>
+            <Box className="show-segmented">
+              <Button
+                data-active={pageMode === "two"}
+                onClick={() => onPageModeChange?.("two")}
+              >
+                Two pages
+              </Button>
+              <Button
+                data-active={pageMode === "scroll"}
+                onClick={() => onPageModeChange?.("scroll")}
+              >
+                Scrolling
+              </Button>
+            </Box>
+            <Button
+              className="show-auto-turn"
+              data-active={autoPageTurn}
+              onClick={() => onAutoPageTurnChange?.(!autoPageTurn)}
+            >
+              <Box className="show-toggle-track">
+                <Box />
+              </Box>
+              Auto page turn
+            </Button>
+          </HStack>
+        )}
+      </Box>
+      <Box
+        ref={scrollRef}
+        className={`show-score-pages show-score-pages-${pageMode}`}
+        style={{
+          justifyContent:
+            (!pageWidth ||
+              pageWidth < containerSize.w / (pageMode === "two" ? 2 : 1)) &&
+            pageMode === "two"
+              ? "center"
+              : "flex-start",
+          alignItems:
+            pageWidth && pageWidth > containerSize.w && pageMode === "scroll"
+              ? "flex-start"
+              : undefined,
+        }}
+      >
+        {isLoading && <Spinner color="muvico.accent" />}
+        {loadError && <Text>PDF preview unavailable.</Text>}
+        {pdf && pageMode === "two" && (
+          <>
+            <ShowPdfPage
+              pdf={pdf}
+              pageNumber={activePage}
+              markers={score.markers}
+              activeMarker={activeMarker}
+              pageWidth={pageWidth}
+              onLoad={(w, ratio) => {
+                setBaseWidth((prev) => prev ?? w)
+                setAspectRatio((prev) => prev ?? ratio)
+              }}
+            />
+            {activePage < pdf.numPages && (
+              <ShowPdfPage
+                pdf={pdf}
+                pageNumber={activePage + 1}
+                markers={score.markers}
+                activeMarker={activeMarker}
+                pageWidth={pageWidth}
+              />
+            )}
+          </>
+        )}
+        {pdf &&
+          pageMode === "scroll" &&
+          Array.from({ length: pdf.numPages }, (_, index) => index + 1).map(
+            (pageNumber) => (
+              <ShowPdfPage
+                key={pageNumber}
+                pdf={pdf}
+                pageNumber={pageNumber}
+                markers={score.markers}
+                activeMarker={activeMarker}
+                pageWidth={pageWidth}
+              />
+            )
+          )}
+      </Box>
+      {!compact && pdf && (
+        <HStack className="show-score-pagination">
+          <IconButton
+            aria-label="Previous score page"
+            icon={<ChevronLeftIcon />}
+            isDisabled={activePage <= 1}
+            onClick={() => {
+              setManualPage(activePage - 1)
+              onAutoPageTurnChange?.(false)
+            }}
+          />
+          <Text>
+            {activePage} / {pdf.numPages}
+          </Text>
+          <IconButton
+            aria-label="Next score page"
+            icon={<ChevronRightIcon />}
+            isDisabled={activePage >= pdf.numPages}
+            onClick={() => {
+              setManualPage(activePage + 1)
+              onAutoPageTurnChange?.(false)
+            }}
+          />
+        </HStack>
+      )}
+    </Box>
+  )
+}
+
+export default ShowScoreViewer

--- a/src/client/components/presentation/ShowScoreViewer.tsx
+++ b/src/client/components/presentation/ShowScoreViewer.tsx
@@ -286,7 +286,7 @@ const ShowScoreViewer = ({
     scrollRef.current
       ?.querySelector<HTMLElement>(`[data-page="${activePage}"]`)
       ?.scrollIntoView({ block: "start", behavior: "smooth" })
-  }, [activePage, pageMode])
+  }, [activePage, pageMode, pdf])
 
   if (!score) {
     return (
@@ -411,6 +411,14 @@ const ShowScoreViewer = ({
                 markers={score.markers}
                 activeMarker={activeMarker}
                 pageWidth={pageWidth}
+                onLoad={
+                  pageNumber === 1
+                    ? (w, ratio) => {
+                        setBaseWidth((prev) => prev ?? w)
+                        setAspectRatio((prev) => prev ?? ratio)
+                      }
+                    : undefined
+                }
               />
             )
           )}

--- a/src/client/components/presentation/ShowScreenPreview.tsx
+++ b/src/client/components/presentation/ShowScreenPreview.tsx
@@ -1,0 +1,172 @@
+import { Box, Button, Text } from "@chakra-ui/react"
+import { useState } from "react"
+import type { SyntheticEvent } from "react"
+import { isImageFile, isVideoFile } from "../utils/fileTypeUtils"
+import { normalizeCueOpacity } from "../utils/cueOpacityUtils"
+import { computeScreenSpanLayout } from "../utils/screenSpanLayout"
+import type { Cue } from "../../types"
+
+interface ShowScreenPreviewProps {
+  screenNumber: number
+  cues: Cue[]
+  isOnline?: boolean
+  compact?: boolean
+  label?: string
+  onOpen?: () => void
+}
+
+const renderSpannedImage = (cue: Cue, screenNumber: number) => (
+  <SpannedPreview cue={cue} screenNumber={screenNumber} />
+)
+
+const SpannedPreview = ({
+  cue,
+  screenNumber,
+}: {
+  cue: Cue
+  screenNumber: number
+}) => {
+  const [aspectRatio, setAspectRatio] = useState<number | null>(null)
+  const spanScreens = cue.spanScreens ?? [screenNumber]
+  const orderedScreens = [...spanScreens].sort((a, b) => a - b)
+  const position = Math.max(0, orderedScreens.indexOf(screenNumber))
+
+  const handleLoad = (event: SyntheticEvent<HTMLImageElement>) => {
+    const { naturalWidth, naturalHeight } = event.currentTarget
+    if (naturalWidth && naturalHeight)
+      setAspectRatio(naturalWidth / naturalHeight)
+  }
+
+  if (!aspectRatio) {
+    return (
+      <>
+        <img
+          src={cue.file?.url}
+          alt={cue.name}
+          className="show-preview-media"
+        />
+        <img
+          src={cue.file?.url}
+          alt=""
+          onLoad={handleLoad}
+          style={{ display: "none" }}
+        />
+      </>
+    )
+  }
+
+  const { canvasWidth, canvasHeight } = computeScreenSpanLayout(
+    orderedScreens,
+    {},
+    aspectRatio
+  )
+  const tileWidth = canvasWidth / orderedScreens.length
+  const tileHeight = tileWidth / (16 / 9)
+  const x =
+    orderedScreens.length > 1
+      ? (position / (orderedScreens.length - 1)) * 100
+      : 0
+
+  return (
+    <Box
+      role="img"
+      aria-label={cue.name}
+      position="absolute"
+      inset={0}
+      bgImage={`url(${cue.file?.url})`}
+      bgRepeat="no-repeat"
+      bgPosition={`${x}% 50%`}
+      bgSize={`${(canvasWidth / tileWidth) * 100}% ${(canvasHeight / tileHeight) * 100}%`}
+    />
+  )
+}
+
+const CueMedia = ({
+  cue,
+  screenNumber,
+}: {
+  cue: Cue
+  screenNumber: number
+}) => {
+  if (!cue.file)
+    return <Box position="absolute" inset={0} bg={cue.color ?? "#000"} />
+  if (isImageFile(cue.file)) {
+    if ((cue.spanScreens?.length ?? 0) > 1) {
+      return renderSpannedImage(cue, screenNumber)
+    }
+    return (
+      <img src={cue.file.url} alt={cue.name} className="show-preview-media" />
+    )
+  }
+  if (isVideoFile(cue.file)) {
+    return (
+      <video
+        src={cue.file.url}
+        className="show-preview-media"
+        autoPlay
+        loop
+        muted
+        playsInline
+      />
+    )
+  }
+  return <Box position="absolute" inset={0} bg={cue.color ?? "#000"} />
+}
+
+const ShowScreenPreview = ({
+  screenNumber,
+  cues,
+  isOnline = true,
+  compact = false,
+  label,
+  onOpen,
+}: ShowScreenPreviewProps) => {
+  const visibleNames = cues.map((cue) => cue.name).filter(Boolean)
+
+  return (
+    <Box
+      className={`show-screen-preview ${compact ? "show-screen-preview-compact" : ""} ${isOnline ? "" : "show-screen-preview-offline"}`}
+      data-testid={`show-screen-${screenNumber}`}
+    >
+      <Box className="show-screen-preview-header">
+        <Text as="span">{label ?? `Screen ${screenNumber}`}</Text>
+        {isOnline &&
+          cues.map((cue) => (
+            <Text key={cue._id} as="span" className="show-layer-badge">
+              L{Number(cue.layer ?? 0) + 1}
+            </Text>
+          ))}
+        <Text as="span" className="show-screen-cue-name">
+          {isOnline
+            ? visibleNames.join(" / ") || "No content"
+            : "window closed"}
+        </Text>
+        <Box className={`show-online-dot ${isOnline ? "is-online" : ""}`} />
+      </Box>
+      <Box className="show-screen-preview-canvas">
+        {!isOnline
+          ? onOpen && (
+              <Button size="sm" variant="muvico-secondary" onClick={onOpen}>
+                Open display {screenNumber}
+              </Button>
+            )
+          : cues.length
+            ? cues.map((cue, index) => (
+                <Box
+                  key={cue._id}
+                  position="absolute"
+                  inset={0}
+                  zIndex={100 - Number(cue.layer ?? index)}
+                  opacity={normalizeCueOpacity(cue.opacity)}
+                  overflow="hidden"
+                >
+                  <CueMedia cue={cue} screenNumber={screenNumber} />
+                </Box>
+              ))
+            : null}
+      </Box>
+    </Box>
+  )
+}
+
+export default ShowScreenPreview

--- a/src/client/components/presentation/index.jsx
+++ b/src/client/components/presentation/index.jsx
@@ -5,7 +5,7 @@
  * The component fetches presentation information from the Redux store and passes necessary props down to the EditModeContainer component for rendering the appropriate UI based on the current mode.
  */
 import { useEffect, useState } from "react"
-import { useParams, useNavigate } from "react-router-dom"
+import { useLocation, useParams, useNavigate } from "react-router-dom"
 import { fetchPresentationInfo } from "../../redux/presentationReducer"
 import { useDispatch, useSelector } from "react-redux"
 
@@ -16,6 +16,7 @@ const PresentationPage = ({ user }) => {
   const { id } = useParams()
   const dispatch = useDispatch()
   const navigate = useNavigate()
+  const location = useLocation()
   const [cueIndex, setCueIndex] = useState(0)
   const [showHint, setShowHint] = useState(false)
   const {
@@ -56,6 +57,7 @@ const PresentationPage = ({ user }) => {
   const presentationInfo = useSelector((state) => state.presentation.cues)
   const presentationName = useSelector((state) => state.presentation.name)
   const indexCount = useSelector((state) => state.presentation.indexCount)
+  const isShowMode = location.pathname.endsWith("/show")
 
   const toggleAudioMute = () => {
     setIsAudioMuted((prevMuted) => !prevMuted)
@@ -86,6 +88,9 @@ const PresentationPage = ({ user }) => {
       isAudioMuted={isAudioMuted}
       toggleAudioMute={toggleAudioMute}
       indexCount={indexCount}
+      isShowMode={isShowMode}
+      onEnterShow={() => navigate(`/presentation/${id}/show`)}
+      onExitShow={() => navigate(`/presentation/${id}`)}
     />
   )
 }

--- a/src/client/components/utils/fileTypeUtils.ts
+++ b/src/client/components/utils/fileTypeUtils.ts
@@ -22,6 +22,21 @@ export const isType = {
   audio: (file: MimeTyped) => file?.type?.includes("audio"),
 }
 
+type MediaFile = (MimeTyped & { url?: string }) | null | undefined
+
+const getCleanUrl = (file: MediaFile): string =>
+  String(file?.url || "")
+    .split("?")[0]
+    .split("#")[0]
+
+export const isImageFile = (file: MediaFile): boolean =>
+  Boolean(isType.image(file)) ||
+  /\.(jpg|jpeg|png|gif|webp|bmp|svg)$/i.test(getCleanUrl(file))
+
+export const isVideoFile = (file: MediaFile): boolean =>
+  Boolean(isType.video(file)) ||
+  /\.(mp4|webm|ogg|mov|m4v)$/i.test(getCleanUrl(file))
+
 export const VALID_VISUAL_MIME_TYPES = [
   "image/png",
   "image/jpeg",

--- a/src/client/tests/unit/EditModeContainerAudio.test.jsx
+++ b/src/client/tests/unit/EditModeContainerAudio.test.jsx
@@ -83,6 +83,7 @@ jest.mock("../../components/presentation/PresentationPlaybackControls", () => {
     )
   }
 })
+jest.mock("../../components/presentation/CueAudioPlayers", () => () => null)
 
 // makeResizable returns a disposer the caller must invoke on unmount.
 jest.mock("../../components/utils/ResizeElement", () =>

--- a/src/client/tests/unit/EditModeContainerPlayback.test.jsx
+++ b/src/client/tests/unit/EditModeContainerPlayback.test.jsx
@@ -84,6 +84,27 @@ jest.mock("../../components/presentation/PresentationPlaybackControls", () => {
   }
 })
 jest.mock("../../components/presentation/CueAudioPlayers", () => () => null)
+jest.mock("../../components/presentation/ShowMode", () => {
+  return function MockShowMode(props) {
+    return (
+      <div data-testid="mock-show-mode">
+        <span data-testid="mock-blackout">{String(props.isBlackout)}</span>
+        <button type="button" onClick={props.onPrevious}>
+          Show previous
+        </button>
+        <button type="button" onClick={props.onNext}>
+          Show next
+        </button>
+        <button type="button" onClick={props.onToggleBlackout}>
+          Show blackout
+        </button>
+        <button type="button" onClick={props.onExit}>
+          Exit show
+        </button>
+      </div>
+    )
+  }
+})
 
 // makeResizable returns a disposer the caller must invoke on unmount.
 jest.mock("../../components/utils/ResizeElement", () =>
@@ -269,5 +290,33 @@ describe("EditModeContainer playback behavior", () => {
 
     expect(fetchPresentationInfo).toHaveBeenCalledWith("presentation-1")
     expect(dispatchMock).toHaveBeenCalled()
+  })
+
+  test("connects show mode controls to the editor state", () => {
+    const updateCue = jest.fn()
+    const onExitShow = jest.fn()
+
+    render(
+      <EditModeContainer
+        {...baseProps}
+        isShowMode
+        updateCue={updateCue}
+        onExitShow={onExitShow}
+      />
+    )
+
+    expect(screen.getByTestId("mock-show-mode")).toBeInTheDocument()
+    expect(screen.getByTestId("mock-blackout")).toHaveTextContent("false")
+
+    fireEvent.click(screen.getByText("Show previous"))
+    fireEvent.click(screen.getByText("Show next"))
+    fireEvent.click(screen.getByText("Show blackout"))
+
+    expect(updateCue).toHaveBeenNthCalledWith(1, "Previous")
+    expect(updateCue).toHaveBeenNthCalledWith(2, "Next")
+    expect(screen.getByTestId("mock-blackout")).toHaveTextContent("true")
+
+    fireEvent.click(screen.getByText("Exit show"))
+    expect(onExitShow).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/client/tests/unit/EditModeContainerPlayback.test.jsx
+++ b/src/client/tests/unit/EditModeContainerPlayback.test.jsx
@@ -83,6 +83,7 @@ jest.mock("../../components/presentation/PresentationPlaybackControls", () => {
     )
   }
 })
+jest.mock("../../components/presentation/CueAudioPlayers", () => () => null)
 
 // makeResizable returns a disposer the caller must invoke on unmount.
 jest.mock("../../components/utils/ResizeElement", () =>

--- a/src/client/tests/unit/EditModeContainerScreens.test.jsx
+++ b/src/client/tests/unit/EditModeContainerScreens.test.jsx
@@ -83,6 +83,7 @@ jest.mock("../../components/presentation/PresentationPlaybackControls", () => {
     )
   }
 })
+jest.mock("../../components/presentation/CueAudioPlayers", () => () => null)
 
 // makeResizable returns a disposer the caller must invoke on unmount.
 jest.mock("../../components/utils/ResizeElement", () =>

--- a/src/client/tests/unit/EditModeContainerSettings.test.jsx
+++ b/src/client/tests/unit/EditModeContainerSettings.test.jsx
@@ -69,6 +69,7 @@ jest.mock("../../components/presentation/PresentationPlaybackControls", () => {
     return <div data-testid="mock-playback-controls" />
   }
 })
+jest.mock("../../components/presentation/CueAudioPlayers", () => () => null)
 
 // makeResizable returns a disposer the caller must invoke on unmount.
 jest.mock("../../components/utils/ResizeElement", () =>

--- a/src/client/tests/unit/EditModeContainerSpan.test.jsx
+++ b/src/client/tests/unit/EditModeContainerSpan.test.jsx
@@ -73,6 +73,7 @@ jest.mock("../../components/presentation/PresentationPlaybackControls", () => {
     return <div data-testid="mock-playback-controls" />
   }
 })
+jest.mock("../../components/presentation/CueAudioPlayers", () => () => null)
 
 // makeResizable returns a disposer the caller must invoke on unmount.
 jest.mock("../../components/utils/ResizeElement", () =>

--- a/src/client/tests/unit/PresentationPage.test.jsx
+++ b/src/client/tests/unit/PresentationPage.test.jsx
@@ -9,7 +9,7 @@ import { render, screen, fireEvent } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import PresentationPage from "../../components/presentation/index"
 import { useDispatch, useSelector } from "react-redux"
-import { useParams, useNavigate } from "react-router-dom"
+import { useLocation, useParams, useNavigate } from "react-router-dom"
 
 jest.mock("react-redux", () => ({
   useDispatch: jest.fn(),
@@ -19,6 +19,7 @@ jest.mock("react-redux", () => ({
 jest.mock("react-router-dom", () => ({
   useParams: jest.fn(),
   useNavigate: jest.fn(),
+  useLocation: jest.fn(),
 }))
 
 jest.mock("../../redux/presentationReducer", () => ({
@@ -43,6 +44,7 @@ jest.mock("../../components/presentation/EditModeContainer", () => {
     return (
       <div>
         <span data-testid="transition-type">{props.transitionType}</span>
+        <span data-testid="show-mode-route">{String(props.isShowMode)}</span>
         <button
           type="button"
           onClick={() => props.onTransitionChange("slide-left")}
@@ -60,6 +62,7 @@ describe("PresentationPage transition preference", () => {
     window.localStorage.clear()
     useParams.mockReturnValue({ id: "presentation-1" })
     useNavigate.mockReturnValue(jest.fn())
+    useLocation.mockReturnValue({ pathname: "/presentation/presentation-1" })
     useDispatch.mockReturnValue(jest.fn())
     useSelector.mockImplementation((selector) =>
       selector({
@@ -98,5 +101,15 @@ describe("PresentationPage transition preference", () => {
       window.localStorage.getItem("presentation-presentation-1-transition")
     ).toBe("slide-left")
     expect(screen.getByTestId("transition-type").textContent).toBe("slide-left")
+  })
+
+  test("passes show mode state from the route", () => {
+    useLocation.mockReturnValue({
+      pathname: "/presentation/presentation-1/show",
+    })
+
+    render(<PresentationPage user={{}} />)
+
+    expect(screen.getByTestId("show-mode-route")).toHaveTextContent("true")
   })
 })

--- a/src/client/tests/unit/PresentationPage.test.jsx
+++ b/src/client/tests/unit/PresentationPage.test.jsx
@@ -51,6 +51,12 @@ jest.mock("../../components/presentation/EditModeContainer", () => {
         >
           change-transition
         </button>
+        <button type="button" onClick={props.onEnterShow}>
+          enter-show
+        </button>
+        <button type="button" onClick={props.onExitShow}>
+          exit-show
+        </button>
       </div>
     )
   }
@@ -111,5 +117,21 @@ describe("PresentationPage transition preference", () => {
     render(<PresentationPage user={{}} />)
 
     expect(screen.getByTestId("show-mode-route")).toHaveTextContent("true")
+  })
+
+  test("navigates between edit and show routes", () => {
+    const navigate = jest.fn()
+    useNavigate.mockReturnValue(navigate)
+
+    render(<PresentationPage user={{}} />)
+
+    fireEvent.click(screen.getByText("enter-show"))
+    fireEvent.click(screen.getByText("exit-show"))
+
+    expect(navigate).toHaveBeenNthCalledWith(
+      1,
+      "/presentation/presentation-1/show"
+    )
+    expect(navigate).toHaveBeenNthCalledWith(2, "/presentation/presentation-1")
   })
 })

--- a/src/client/tests/unit/ScoreMarkerOverlay.test.tsx
+++ b/src/client/tests/unit/ScoreMarkerOverlay.test.tsx
@@ -93,6 +93,10 @@ describe("ScoreMarkerOverlay", () => {
 
     expect(screen.getByText("3")).toBeInTheDocument()
     expect(screen.queryByText("7")).not.toBeInTheDocument()
+    expect(screen.getByTestId("score-marker-pin")).toHaveAttribute(
+      "data-active",
+      "false"
+    )
   })
 
   test("clicking a marker selects it for editing instead of placing a new one", () => {

--- a/src/client/tests/unit/ScorePdfViewer.test.tsx
+++ b/src/client/tests/unit/ScorePdfViewer.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { ChakraProvider } from "@chakra-ui/react"
-import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import { act, render, screen, fireEvent, waitFor } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import ScorePdfViewer from "../../components/presentation/ScorePdfViewer"
 import {
@@ -12,6 +12,7 @@ import {
 import type { ScoreDocument } from "../../types"
 
 const mockGetDocument = jest.fn()
+let resizeCallback: ResizeObserverCallback
 
 jest.mock("pdfjs-dist", () => ({
   GlobalWorkerOptions: { workerSrc: "" },
@@ -52,7 +53,7 @@ const makeLoadingTask = (numPages = 1) => {
     getPage: jest.fn().mockResolvedValue(page),
     destroy: jest.fn().mockResolvedValue(undefined),
   }
-  return { promise: Promise.resolve(pdf), destroy: jest.fn() }
+  return { promise: Promise.resolve(pdf), destroy: jest.fn(), page }
 }
 
 const baseScore: ScoreDocument = {
@@ -104,9 +105,16 @@ describe("ScorePdfViewer", () => {
     mockGetDocument.mockReturnValue(makeLoadingTask())
     window.localStorage.setItem("user", JSON.stringify({ token: "test-token" }))
     global.ResizeObserver = class {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback
+      }
       observe() {}
       disconnect() {}
     } as unknown as typeof ResizeObserver
+    Object.defineProperty(window, "devicePixelRatio", {
+      configurable: true,
+      value: 1,
+    })
     Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
       configurable: true,
       value: jest.fn(() => ({
@@ -141,6 +149,39 @@ describe("ScorePdfViewer", () => {
         })
       )
     })
+  })
+
+  test("renders page thumbnails at the current device pixel ratio", async () => {
+    const loadingTask = makeLoadingTask(2)
+    mockGetDocument.mockReturnValue(loadingTask)
+    Object.defineProperty(window, "devicePixelRatio", {
+      configurable: true,
+      value: 2,
+    })
+
+    renderViewer({ ...baseScore, pageCount: 2 })
+    await waitForPdfLoaded()
+
+    act(() => {
+      resizeCallback(
+        [
+          {
+            contentRect: { width: 700 },
+          } as ResizeObserverEntry,
+        ],
+        {} as ResizeObserver
+      )
+    })
+
+    expect(await screen.findByText("Pages")).toBeInTheDocument()
+    await waitFor(() =>
+      expect(loadingTask.page.render.mock.calls.length).toBeGreaterThanOrEqual(
+        3
+      )
+    )
+    expect(loadingTask.page.render).toHaveBeenCalledWith(
+      expect.objectContaining({ transform: [2, 0, 0, 2, 0, 0] })
+    )
   })
 
   describe("markers", () => {

--- a/src/client/tests/unit/ScorePdfViewer.test.tsx
+++ b/src/client/tests/unit/ScorePdfViewer.test.tsx
@@ -109,7 +109,10 @@ describe("ScorePdfViewer", () => {
     } as unknown as typeof ResizeObserver
     Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
       configurable: true,
-      value: jest.fn(() => ({ setTransform: jest.fn() })),
+      value: jest.fn(() => ({
+        setTransform: jest.fn(),
+        drawImage: jest.fn(),
+      })),
     })
   })
 

--- a/src/client/tests/unit/Screen.test.jsx
+++ b/src/client/tests/unit/Screen.test.jsx
@@ -230,6 +230,49 @@ describe("Screen", () => {
     expect(window.open).not.toHaveBeenCalled()
   })
 
+  test("reports when the browser blocks an output popup", async () => {
+    window.open.mockReturnValueOnce(null)
+    const onClose = jest.fn()
+
+    await act(async () => {
+      render(
+        <Screen
+          screenNumber={2}
+          screenData={null}
+          isVisible={true}
+          onClose={onClose}
+        />
+      )
+    })
+
+    expect(onClose).toHaveBeenCalledWith(2)
+  })
+
+  test("detects an output popup closed without beforeunload", async () => {
+    jest.useFakeTimers()
+    const onClose = jest.fn()
+    let view
+
+    await act(async () => {
+      view = render(
+        <Screen
+          screenNumber={3}
+          screenData={null}
+          isVisible={true}
+          onClose={onClose}
+        />
+      )
+    })
+
+    const popup = window.open.mock.results.at(-1).value
+    popup.closed = true
+    act(() => jest.advanceTimersByTime(750))
+
+    expect(onClose).toHaveBeenCalledWith(3)
+    view.unmount()
+    jest.useRealTimers()
+  })
+
   test("renders video media when cue is a video", async () => {
     const screenData = {
       file: {

--- a/src/client/tests/unit/Screen.test.jsx
+++ b/src/client/tests/unit/Screen.test.jsx
@@ -137,6 +137,40 @@ describe("Screen", () => {
     })
   })
 
+  test("covers the output with black without removing the current cue", async () => {
+    const screenData = {
+      file: null,
+      color: "#ff00ff",
+      index: 0,
+      name: "color cue",
+      screen: 1,
+      _id: "color-cue",
+      loop: false,
+    }
+
+    await act(async () => {
+      render(
+        <Screen
+          screenNumber={1}
+          screenData={screenData}
+          isVisible={true}
+          isBlackout={true}
+          onClose={() => {}}
+        />
+      )
+    })
+
+    const popup = window.open.mock.results.at(-1).value
+    await waitFor(() => {
+      expect(
+        within(popup.document.body).getByTestId("screen-blackout")
+      ).toBeTruthy()
+      expect(
+        within(popup.document.body).getByTestId("incoming-cue-layer")
+      ).toBeTruthy()
+    })
+  })
+
   test("renders a color background when cue has no file but has color", async () => {
     const screenData = {
       file: null,

--- a/src/client/tests/unit/ShowMode.test.tsx
+++ b/src/client/tests/unit/ShowMode.test.tsx
@@ -1,0 +1,133 @@
+import React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import ShowMode from "../../components/presentation/ShowMode"
+
+jest.mock("../../components/utils/keyboardHandler", () => () => null)
+jest.mock("../../components/presentation/ShowScoreViewer", () => {
+  return function MockShowScoreViewer({ compact }: { compact?: boolean }) {
+    return <div data-testid={compact ? "compact-score" : "show-score"} />
+  }
+})
+jest.mock("../../components/presentation/ShowMonitorWindow", () => {
+  return function MockShowMonitorWindow({
+    children,
+  }: {
+    children: React.ReactNode
+  }) {
+    return <div data-testid="monitor-window">{children}</div>
+  }
+})
+
+const cues = [
+  {
+    _id: "cue-1",
+    cueType: "visual" as const,
+    index: 0,
+    screen: 1,
+    layer: 0,
+    opacity: 1,
+    name: "Opening image",
+    color: "#33283f",
+    file: null,
+    loop: false,
+    continuePlayback: false,
+  },
+]
+
+const renderShowMode = (overrides = {}) => {
+  const props = {
+    presentationName: "Concert",
+    screenCount: 2,
+    scores: [],
+    cueIndex: 0,
+    indexCount: 4,
+    screens: { 1: true, 2: false },
+    audioTracks: [],
+    autoplayInterval: 5,
+    isAutoplaying: false,
+    isBlackout: false,
+    getActiveCuesForScreen: jest.fn((screenNumber, index) =>
+      screenNumber === 1 && index === 0 ? cues : []
+    ),
+    onSetCueIndex: jest.fn(),
+    onPrevious: jest.fn(),
+    onNext: jest.fn(),
+    onToggleAutoplay: jest.fn(),
+    onToggleBlackout: jest.fn(),
+    onToggleScreen: jest.fn(),
+    onExit: jest.fn(),
+    ...overrides,
+  }
+  render(<ShowMode {...props} />)
+  return props
+}
+
+describe("ShowMode", () => {
+  test("renders the music stand first", () => {
+    renderShowMode()
+
+    expect(screen.getByText("Concert")).toBeInTheDocument()
+    expect(screen.getByTestId("show-score")).toBeInTheDocument()
+    expect(screen.getByText("1 / 2 displays online")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Music stand/ })).toHaveAttribute(
+      "data-active",
+      "true"
+    )
+    expect(
+      screen.getByRole("button", { name: /Control room/ })
+    ).toHaveAttribute("data-active", "false")
+  })
+
+  test("keeps operator previews visible while blackout is active", () => {
+    renderShowMode({ isBlackout: true })
+
+    expect(screen.getByText("Output blackout")).toBeInTheDocument()
+    expect(screen.getByText("Opening image")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Blackout on" })).toHaveAttribute(
+      "data-active",
+      "true"
+    )
+  })
+
+  test("connects transport and exit actions", () => {
+    const props = renderShowMode()
+
+    fireEvent.click(screen.getByRole("button", { name: /^GO/ }))
+    fireEvent.click(screen.getByRole("button", { name: "Blackout" }))
+    fireEvent.click(screen.getByRole("button", { name: "Exit" }))
+
+    expect(props.onNext).toHaveBeenCalledTimes(1)
+    expect(props.onToggleBlackout).toHaveBeenCalledTimes(1)
+    expect(props.onExit).toHaveBeenCalledTimes(1)
+  })
+
+  test("opens an offline display from its tile", () => {
+    const props = renderShowMode()
+
+    fireEvent.click(screen.getByRole("button", { name: /Control room/ }))
+
+    fireEvent.click(screen.getByRole("button", { name: "Open display 2" }))
+
+    expect(props.onToggleScreen).toHaveBeenCalledWith(2)
+  })
+
+  test("switches to music stand", () => {
+    renderShowMode()
+
+    fireEvent.click(screen.getByRole("button", { name: /Control room/ }))
+    fireEvent.click(screen.getByRole("button", { name: /Music stand/ }))
+
+    expect(screen.getByTestId("show-score")).toBeInTheDocument()
+    expect(screen.getByText("NEXT · Frame 1")).toBeInTheDocument()
+  })
+
+  test("opens the selected monitor output", () => {
+    renderShowMode()
+
+    fireEvent.click(screen.getByRole("button", { name: "Monitor" }))
+    fireEvent.click(screen.getByText("Screen wall"))
+
+    expect(screen.getByTestId("monitor-window")).toBeInTheDocument()
+  })
+})

--- a/src/client/tests/unit/ShowMode.test.tsx
+++ b/src/client/tests/unit/ShowMode.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { fireEvent, render, screen } from "@testing-library/react"
+import { act, fireEvent, render, screen } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import ShowMode from "../../components/presentation/ShowMode"
 
@@ -59,8 +59,8 @@ const renderShowMode = (overrides = {}) => {
     onExit: jest.fn(),
     ...overrides,
   }
-  render(<ShowMode {...props} />)
-  return props
+  const view = render(<ShowMode {...props} />)
+  return { ...props, view }
 }
 
 describe("ShowMode", () => {
@@ -129,5 +129,83 @@ describe("ShowMode", () => {
     fireEvent.click(screen.getByText("Screen wall"))
 
     expect(screen.getByTestId("monitor-window")).toBeInTheDocument()
+  })
+
+  test("selects marked frames and exposes active audio tracks", () => {
+    const props = renderShowMode({
+      cueIndex: 1,
+      isAutoplaying: true,
+      scores: [
+        {
+          _id: "score-1",
+          title: "Concert score",
+          source: "upload",
+          file: { url: "https://example.com/score.pdf" },
+          pageCount: 1,
+          markers: [{ _id: "marker-1", page: 1, frameIndex: 2 }],
+        },
+      ],
+      audioTracks: [
+        {
+          id: "audio-1",
+          name: "Background music",
+          layer: 1,
+          loop: true,
+          continuePlayback: true,
+        },
+      ],
+    })
+
+    expect(document.querySelector(".show-cue-marker-dot")).toBeInTheDocument()
+    expect(screen.getByText("Background music")).toBeInTheDocument()
+    expect(screen.getByText("A2")).toBeInTheDocument()
+    expect(screen.getByText("Loop")).toBeInTheDocument()
+    expect(screen.getByText("Auto on · 5s")).toBeInTheDocument()
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Go to frame 2" })[0])
+    fireEvent.click(screen.getByRole("button", { name: "Previous frame" }))
+    fireEvent.click(screen.getByText("Auto on · 5s"))
+
+    expect(props.onSetCueIndex).toHaveBeenCalledWith(2)
+    expect(props.onPrevious).toHaveBeenCalledTimes(1)
+    expect(props.onToggleAutoplay).toHaveBeenCalledTimes(1)
+  })
+
+  test("updates the elapsed time and stops its clock on unmount", () => {
+    jest.useFakeTimers()
+    const { view } = renderShowMode()
+
+    act(() => jest.advanceTimersByTime(1000))
+
+    expect(screen.getByText("00:00:01")).toBeInTheDocument()
+    view.unmount()
+    expect(jest.getTimerCount()).toBe(0)
+    jest.useRealTimers()
+  })
+
+  test("opens and closes the score monitor", () => {
+    renderShowMode()
+
+    fireEvent.click(screen.getByRole("button", { name: "Monitor" }))
+    fireEvent.click(screen.getByText("Score only"))
+
+    expect(screen.getByTestId("monitor-window")).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Monitor live" })
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Monitor live" }))
+    fireEvent.click(screen.getByText("Close monitor"))
+
+    expect(screen.queryByTestId("monitor-window")).not.toBeInTheDocument()
+  })
+
+  test("expands the compact score from the control room", () => {
+    renderShowMode()
+
+    fireEvent.click(screen.getByRole("button", { name: /Control room/ }))
+    fireEvent.click(screen.getByRole("button", { name: "Expand" }))
+
+    expect(screen.getByTestId("show-score")).toBeInTheDocument()
   })
 })

--- a/src/client/tests/unit/ShowMonitorWindow.test.tsx
+++ b/src/client/tests/unit/ShowMonitorWindow.test.tsx
@@ -1,10 +1,13 @@
 import React from "react"
-import { render, waitFor } from "@testing-library/react"
+import { act, render, waitFor } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import ShowMonitorWindow from "../../components/presentation/ShowMonitorWindow"
 
 describe("ShowMonitorWindow", () => {
   test("opens and closes a synchronized popup", async () => {
+    const style = document.createElement("style")
+    style.textContent = ".monitor-test { color: red; }"
+    document.head.appendChild(style)
     const popupDocument = document.implementation.createHTMLDocument()
     const popup = {
       document: popupDocument,
@@ -27,10 +30,56 @@ describe("ShowMonitorWindow", () => {
     await waitFor(() => {
       expect(popupDocument.body.textContent).toContain("Live monitor content")
       expect(popupDocument.title).toBe("Concert monitor")
+      expect(popupDocument.head.textContent).toContain("monitor-test")
     })
 
     view.unmount()
     expect(popup.close).toHaveBeenCalledTimes(1)
+    style.remove()
     open.mockRestore()
+  })
+
+  test("reports when the browser blocks the monitor popup", () => {
+    const open = jest.spyOn(window, "open").mockReturnValue(null)
+    const onClose = jest.fn()
+
+    render(
+      <ShowMonitorWindow title="Blocked monitor" onClose={onClose}>
+        <div>Hidden content</div>
+      </ShowMonitorWindow>
+    )
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+    open.mockRestore()
+  })
+
+  test("detects a monitor window closed without beforeunload", async () => {
+    jest.useFakeTimers()
+    const popupDocument = document.implementation.createHTMLDocument()
+    const popup = {
+      document: popupDocument,
+      closed: false,
+      close: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    }
+    const open = jest
+      .spyOn(window, "open")
+      .mockReturnValue(popup as unknown as Window)
+    const onClose = jest.fn()
+
+    render(
+      <ShowMonitorWindow title="Concert monitor" onClose={onClose}>
+        <div>Live monitor content</div>
+      </ShowMonitorWindow>
+    )
+
+    await act(async () => {})
+    popup.closed = true
+    act(() => jest.advanceTimersByTime(750))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+    open.mockRestore()
+    jest.useRealTimers()
   })
 })

--- a/src/client/tests/unit/ShowMonitorWindow.test.tsx
+++ b/src/client/tests/unit/ShowMonitorWindow.test.tsx
@@ -1,0 +1,36 @@
+import React from "react"
+import { render, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import ShowMonitorWindow from "../../components/presentation/ShowMonitorWindow"
+
+describe("ShowMonitorWindow", () => {
+  test("opens and closes a synchronized popup", async () => {
+    const popupDocument = document.implementation.createHTMLDocument()
+    const popup = {
+      document: popupDocument,
+      closed: false,
+      close: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    }
+    const open = jest
+      .spyOn(window, "open")
+      .mockReturnValue(popup as unknown as Window)
+    const onClose = jest.fn()
+
+    const view = render(
+      <ShowMonitorWindow title="Concert monitor" onClose={onClose}>
+        <div>Live monitor content</div>
+      </ShowMonitorWindow>
+    )
+
+    await waitFor(() => {
+      expect(popupDocument.body.textContent).toContain("Live monitor content")
+      expect(popupDocument.title).toBe("Concert monitor")
+    })
+
+    view.unmount()
+    expect(popup.close).toHaveBeenCalledTimes(1)
+    open.mockRestore()
+  })
+})

--- a/src/client/tests/unit/ShowScoreViewer.test.tsx
+++ b/src/client/tests/unit/ShowScoreViewer.test.tsx
@@ -1,0 +1,198 @@
+import React from "react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import ShowScoreViewer from "../../components/presentation/ShowScoreViewer"
+import type { ScoreDocument } from "../../types"
+
+const mockGetDocument = jest.fn()
+let resizeCallback: ResizeObserverCallback
+
+jest.mock("pdfjs-dist", () => ({
+  GlobalWorkerOptions: { workerSrc: "" },
+  getDocument: mockGetDocument,
+}))
+
+const score: ScoreDocument = {
+  _id: "score-1",
+  title: "Concert score",
+  source: "upload",
+  file: {
+    proxyUrl: "/api/presentation/presentation-1/scores/score-1/file",
+    url: "https://example.com/score.pdf",
+  },
+  pageCount: 2,
+  markers: [
+    {
+      _id: "marker-1",
+      page: 2,
+      frameIndex: 3,
+      measureLabel: "m. 12",
+      rect: { x: 0.1, y: 0.3, width: 0.8, height: 0.1 },
+    },
+  ],
+}
+
+describe("ShowScoreViewer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    global.ResizeObserver = class {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback
+      }
+      observe() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver
+    Element.prototype.scrollIntoView = jest.fn()
+    Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+      configurable: true,
+      value: jest.fn(() => ({
+        setTransform: jest.fn(),
+        drawImage: jest.fn(),
+      })),
+    })
+    const page = {
+      getViewport: jest.fn(({ scale }) => ({
+        width: 600 * scale,
+        height: 800 * scale,
+      })),
+      render: jest.fn(() => ({
+        promise: Promise.resolve(),
+        cancel: jest.fn(),
+      })),
+    }
+    const pdf = {
+      numPages: 2,
+      getPage: jest.fn().mockResolvedValue(page),
+    }
+    mockGetDocument.mockReturnValue({
+      promise: Promise.resolve(pdf),
+      destroy: jest.fn(),
+    })
+    window.localStorage.setItem("user", JSON.stringify({ token: "token" }))
+  })
+
+  test("shows a clear empty state without a score", () => {
+    render(
+      <ShowScoreViewer score={null} cueIndex={0} pageMode="two" autoPageTurn />
+    )
+
+    expect(screen.getByText("No score selected")).toBeInTheDocument()
+  })
+
+  test("follows the current frame marker and renders its highlight", async () => {
+    render(
+      <ShowScoreViewer score={score} cueIndex={3} pageMode="two" autoPageTurn />
+    )
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-page="2"]')).toBeInTheDocument()
+    })
+    expect(screen.getByText("m. 12")).toBeInTheDocument()
+    expect(screen.getByTestId("score-marker-pin")).toHaveAttribute(
+      "data-active",
+      "true"
+    )
+    expect(screen.getByText("3")).toBeInTheDocument()
+    expect(mockGetDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "/api/presentation/presentation-1/scores/score-1/file",
+        httpHeaders: { Authorization: "bearer token" },
+      })
+    )
+  })
+
+  test("switches between two-page and scrolling layouts", async () => {
+    const onPageModeChange = jest.fn()
+    const onAutoPageTurnChange = jest.fn()
+    render(
+      <ShowScoreViewer
+        score={score}
+        cueIndex={0}
+        pageMode="two"
+        autoPageTurn={false}
+        onPageModeChange={onPageModeChange}
+        onAutoPageTurnChange={onAutoPageTurnChange}
+      />
+    )
+
+    await waitFor(() =>
+      expect(document.querySelector('[data-page="1"]')).toBeInTheDocument()
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Scrolling" }))
+    fireEvent.click(screen.getByRole("button", { name: "Auto page turn" }))
+
+    expect(onPageModeChange).toHaveBeenCalledWith("scroll")
+    expect(onAutoPageTurnChange).toHaveBeenCalledWith(true)
+  })
+
+  test("zoom controls still step even before the page is measured", async () => {
+    render(
+      <ShowScoreViewer
+        score={score}
+        cueIndex={0}
+        pageMode="two"
+        autoPageTurn={false}
+      />
+    )
+
+    await waitFor(() =>
+      expect(document.querySelector('[data-page="1"]')).toBeInTheDocument()
+    )
+    expect(screen.getByRole("button", { name: "Fit" })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Zoom in" }))
+    expect(screen.getByRole("button", { name: "125%" })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Zoom out" }))
+    expect(screen.getByRole("button", { name: "100%" })).toBeInTheDocument()
+  })
+
+  test("serializes page rendering while the viewer is resizing", async () => {
+    let finishFirstRender: () => void = () => {}
+    const renderPage = jest
+      .fn()
+      .mockReturnValueOnce({
+        promise: new Promise<void>((resolve) => {
+          finishFirstRender = resolve
+        }),
+        cancel: jest.fn(),
+      })
+      .mockReturnValue({ promise: Promise.resolve(), cancel: jest.fn() })
+    const page = {
+      getViewport: jest.fn(({ scale }) => ({
+        width: 600 * scale,
+        height: 800 * scale,
+      })),
+      render: renderPage,
+    }
+    mockGetDocument.mockReturnValue({
+      promise: Promise.resolve({
+        numPages: 1,
+        getPage: jest.fn().mockResolvedValue(page),
+      }),
+      destroy: jest.fn(),
+    })
+
+    render(
+      <ShowScoreViewer
+        score={{ ...score, pageCount: 1 }}
+        cueIndex={0}
+        pageMode="two"
+        autoPageTurn={false}
+      />
+    )
+
+    await waitFor(() => expect(renderPage).toHaveBeenCalledTimes(1))
+    const pageHost = document.querySelector('[data-page="1"]') as HTMLElement
+    Object.defineProperty(pageHost, "clientWidth", {
+      configurable: true,
+      value: 720,
+    })
+    resizeCallback([], {} as ResizeObserver)
+    expect(renderPage).toHaveBeenCalledTimes(1)
+
+    finishFirstRender()
+    await waitFor(() => expect(renderPage).toHaveBeenCalledTimes(2))
+  })
+})

--- a/src/client/tests/unit/ShowScoreViewer.test.tsx
+++ b/src/client/tests/unit/ShowScoreViewer.test.tsx
@@ -1,11 +1,12 @@
 import React from "react"
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import ShowScoreViewer from "../../components/presentation/ShowScoreViewer"
 import type { ScoreDocument } from "../../types"
 
 const mockGetDocument = jest.fn()
 let resizeCallback: ResizeObserverCallback
+let resizeCallbacks: ResizeObserverCallback[]
 
 jest.mock("pdfjs-dist", () => ({
   GlobalWorkerOptions: { workerSrc: "" },
@@ -23,6 +24,12 @@ const score: ScoreDocument = {
   pageCount: 2,
   markers: [
     {
+      _id: "marker-0",
+      page: 1,
+      frameIndex: 0,
+      rect: { x: 0.2, y: 0.2, width: 0, height: 0 },
+    },
+    {
       _id: "marker-1",
       page: 2,
       frameIndex: 3,
@@ -35,9 +42,11 @@ const score: ScoreDocument = {
 describe("ShowScoreViewer", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    resizeCallbacks = []
     global.ResizeObserver = class {
       constructor(callback: ResizeObserverCallback) {
         resizeCallback = callback
+        resizeCallbacks.push(callback)
       }
       observe() {}
       disconnect() {}
@@ -120,9 +129,11 @@ describe("ShowScoreViewer", () => {
     )
 
     fireEvent.click(screen.getByRole("button", { name: "Scrolling" }))
+    fireEvent.click(screen.getByRole("button", { name: "Two pages" }))
     fireEvent.click(screen.getByRole("button", { name: "Auto page turn" }))
 
     expect(onPageModeChange).toHaveBeenCalledWith("scroll")
+    expect(onPageModeChange).toHaveBeenCalledWith("two")
     expect(onAutoPageTurnChange).toHaveBeenCalledWith(true)
   })
 
@@ -139,6 +150,11 @@ describe("ShowScoreViewer", () => {
     await waitFor(() =>
       expect(document.querySelector('[data-page="1"]')).toBeInTheDocument()
     )
+    expect(screen.getByRole("button", { name: "Fit" })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Fit" }))
+    expect(screen.getByRole("button", { name: "100%" })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "100%" }))
     expect(screen.getByRole("button", { name: "Fit" })).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole("button", { name: "Zoom in" }))
@@ -194,5 +210,140 @@ describe("ShowScoreViewer", () => {
 
     finishFirstRender()
     await waitFor(() => expect(renderPage).toHaveBeenCalledTimes(2))
+  })
+
+  test("shows a load error when the PDF cannot be opened", async () => {
+    mockGetDocument.mockReturnValue({
+      promise: Promise.reject(new Error("invalid PDF")),
+      destroy: jest.fn(),
+    })
+
+    render(
+      <ShowScoreViewer
+        score={score}
+        cueIndex={0}
+        pageMode="two"
+        autoPageTurn={false}
+      />
+    )
+
+    expect(
+      await screen.findByText("PDF preview unavailable.")
+    ).toBeInTheDocument()
+  })
+
+  test("loads a public score without an authorization header", async () => {
+    render(
+      <ShowScoreViewer
+        score={{
+          ...score,
+          file: { url: "https://example.com/public-score.pdf" },
+        }}
+        cueIndex={0}
+        pageMode="two"
+        autoPageTurn={false}
+      />
+    )
+
+    await waitFor(() => expect(mockGetDocument).toHaveBeenCalled())
+    expect(mockGetDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://example.com/public-score.pdf",
+        httpHeaders: undefined,
+      })
+    )
+  })
+
+  test("navigates score pages manually and disables automatic turns", async () => {
+    const onAutoPageTurnChange = jest.fn()
+    render(
+      <ShowScoreViewer
+        score={score}
+        cueIndex={0}
+        pageMode="two"
+        autoPageTurn={false}
+        onAutoPageTurnChange={onAutoPageTurnChange}
+      />
+    )
+
+    await screen.findByText("1 / 2")
+    fireEvent.click(screen.getByRole("button", { name: "Next score page" }))
+
+    expect(await screen.findByText("2 / 2")).toBeInTheDocument()
+    expect(onAutoPageTurnChange).toHaveBeenLastCalledWith(false)
+
+    fireEvent.click(screen.getByRole("button", { name: "Previous score page" }))
+    expect(await screen.findByText("1 / 2")).toBeInTheDocument()
+  })
+
+  test("fits scrolling pages to the measured viewer and follows the active page", async () => {
+    render(
+      <ShowScoreViewer
+        score={score}
+        cueIndex={3}
+        pageMode="scroll"
+        autoPageTurn
+      />
+    )
+
+    await waitFor(() => {
+      expect(document.querySelectorAll(".show-score-page")).toHaveLength(2)
+      expect(Element.prototype.scrollIntoView).toHaveBeenCalled()
+    })
+
+    await act(async () => {
+      resizeCallbacks.forEach((callback) =>
+        callback(
+          [
+            {
+              contentRect: { width: 1000, height: 800 },
+            } as ResizeObserverEntry,
+          ],
+          {} as ResizeObserver
+        )
+      )
+    })
+
+    await waitFor(() => {
+      expect(
+        document.querySelector<HTMLElement>('[data-page="1"]')
+      ).toHaveStyle({
+        width: "588px",
+      })
+    })
+  })
+
+  test("recovers from a failed page render", async () => {
+    const renderPage = jest.fn(() => ({
+      promise: Promise.reject(new Error("render failed")),
+      cancel: jest.fn(),
+    }))
+    mockGetDocument.mockReturnValue({
+      promise: Promise.resolve({
+        numPages: 1,
+        getPage: jest.fn().mockResolvedValue({
+          getViewport: jest.fn(({ scale }) => ({
+            width: 600 * scale,
+            height: 800 * scale,
+          })),
+          render: renderPage,
+        }),
+      }),
+      destroy: jest.fn(),
+    })
+
+    render(
+      <ShowScoreViewer
+        score={{ ...score, pageCount: 1 }}
+        cueIndex={0}
+        pageMode="two"
+        autoPageTurn={false}
+      />
+    )
+
+    await waitFor(() => expect(renderPage).toHaveBeenCalled())
+    expect(
+      screen.queryByText("PDF preview unavailable.")
+    ).not.toBeInTheDocument()
   })
 })

--- a/src/client/tests/unit/ShowScreenPreview.test.tsx
+++ b/src/client/tests/unit/ShowScreenPreview.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, screen } from "@testing-library/react"
+import { fireEvent, render, screen } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import ShowScreenPreview from "../../components/presentation/ShowScreenPreview"
 import type { Cue } from "../../types"
@@ -70,5 +70,104 @@ describe("ShowScreenPreview", () => {
     expect(
       screen.getByRole("img", { name: "drive-image.png" })
     ).toBeInTheDocument()
+  })
+
+  test("renders the correct crop for an image spanning multiple screens", () => {
+    render(
+      <ShowScreenPreview
+        screenNumber={2}
+        cues={[
+          makeCue({
+            name: "panorama.png",
+            screen: 1,
+            spanScreens: [2, 1],
+            file: {
+              url: "https://example.com/panorama.png",
+              type: "image/png",
+            },
+          }),
+        ]}
+      />
+    )
+
+    const probe = document.querySelector<HTMLImageElement>('img[alt=""]')!
+    Object.defineProperty(probe, "naturalWidth", { value: 3200 })
+    Object.defineProperty(probe, "naturalHeight", { value: 900 })
+    fireEvent.load(probe)
+
+    const crop = screen.getByRole("img", { name: "panorama.png" })
+    expect(crop).toHaveStyle({
+      backgroundPosition: "100% 50%",
+      backgroundSize: "200% 100%",
+    })
+  })
+
+  test("renders video and unsupported media fallbacks", () => {
+    const { rerender } = render(
+      <ShowScreenPreview
+        screenNumber={1}
+        cues={[
+          makeCue({
+            name: "intro.mp4",
+            file: { url: "https://example.com/intro.mp4", type: "video/mp4" },
+          }),
+        ]}
+      />
+    )
+
+    const video = document.querySelector("video")
+    expect(video).toHaveAttribute("src", "https://example.com/intro.mp4")
+    expect(video).toHaveAttribute("autoplay")
+    expect(video).toHaveAttribute("loop")
+    expect(video).toHaveProperty("muted", true)
+
+    rerender(
+      <ShowScreenPreview
+        screenNumber={1}
+        cues={[
+          makeCue({
+            name: "unsupported",
+            color: "#123456",
+            file: {
+              url: "https://example.com/file.bin",
+              type: "application/octet-stream",
+            },
+          }),
+        ]}
+      />
+    )
+
+    expect(document.querySelector("video")).not.toBeInTheDocument()
+    expect(
+      document.querySelector(".show-screen-preview-canvas > div > div")
+    ).toHaveStyle({
+      background: "#123456",
+    })
+  })
+
+  test("shows empty, compact, and offline states", () => {
+    const onOpen = jest.fn()
+    const { rerender } = render(
+      <ShowScreenPreview screenNumber={3} cues={[]} compact label="Preview" />
+    )
+
+    expect(screen.getByText("Preview")).toBeInTheDocument()
+    expect(screen.getByText("No content")).toBeInTheDocument()
+    expect(screen.getByTestId("show-screen-3")).toHaveClass(
+      "show-screen-preview-compact"
+    )
+
+    rerender(
+      <ShowScreenPreview
+        screenNumber={3}
+        cues={[]}
+        isOnline={false}
+        onOpen={onOpen}
+      />
+    )
+
+    expect(screen.getByText("window closed")).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Open display 3" }))
+    expect(onOpen).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/client/tests/unit/ShowScreenPreview.test.tsx
+++ b/src/client/tests/unit/ShowScreenPreview.test.tsx
@@ -1,0 +1,74 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import ShowScreenPreview from "../../components/presentation/ShowScreenPreview"
+import type { Cue } from "../../types"
+
+const makeCue = (overrides: Partial<Cue>): Cue => ({
+  _id: "cue-1",
+  cueType: "visual",
+  index: 0,
+  screen: 1,
+  layer: 0,
+  name: "Cue",
+  color: "#000000",
+  file: null,
+  loop: false,
+  continuePlayback: false,
+  opacity: 1,
+  ...overrides,
+})
+
+describe("ShowScreenPreview", () => {
+  test("stacks every active layer, base layer on top", () => {
+    const cues = [
+      makeCue({
+        _id: "cue-l2",
+        layer: 1,
+        name: "background.png",
+        file: { url: "https://example.com/background.png", type: "image/png" },
+      }),
+      makeCue({
+        _id: "cue-l1",
+        layer: 0,
+        name: "overlay.png",
+        opacity: 0.5,
+        file: { url: "https://example.com/overlay.png", type: "image/png" },
+      }),
+    ]
+
+    render(<ShowScreenPreview screenNumber={1} cues={cues} />)
+
+    expect(screen.getByText("L2")).toBeInTheDocument()
+    expect(screen.getByText("L1")).toBeInTheDocument()
+    expect(screen.getByText("background.png / overlay.png")).toBeInTheDocument()
+
+    const images = screen.getAllByRole("img")
+    expect(images).toHaveLength(2)
+
+    const layerBoxes = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        ".show-screen-preview-canvas > div"
+      )
+    )
+    expect(layerBoxes).toHaveLength(2)
+    expect(layerBoxes[0]).toHaveStyle({ zIndex: "99" })
+    expect(layerBoxes[1]).toHaveStyle({ zIndex: "100", opacity: "0.5" })
+  })
+
+  test("renders media whose mime type is missing but whose url is an image", () => {
+    const cues = [
+      makeCue({
+        _id: "cue-drive",
+        name: "drive-image.png",
+        file: { url: "https://example.com/drive-image.png" },
+      }),
+    ]
+
+    render(<ShowScreenPreview screenNumber={1} cues={cues} />)
+
+    expect(
+      screen.getByRole("img", { name: "drive-image.png" })
+    ).toBeInTheDocument()
+  })
+})

--- a/styles.css
+++ b/styles.css
@@ -191,6 +191,835 @@
   white-space: nowrap;
 }
 
+.show-mode-shell {
+  width: 100%;
+  height: 100dvh;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: #08060a;
+  color: #f0e4ff;
+  user-select: none;
+}
+
+.show-topbar {
+  flex: 0 0 60px;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 0 18px;
+  overflow-x: auto;
+  background: #100c14;
+  border-bottom: 1px solid #221c2a;
+}
+
+.show-badge,
+.show-display-status,
+.show-clock-group,
+.show-monitor-button,
+.show-exit {
+  flex: 0 0 auto;
+}
+
+.show-badge {
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 10px;
+  border-radius: 6px;
+  background: #e5484d;
+  color: white;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+}
+
+.show-badge > div,
+.show-online-dot {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+}
+
+.show-badge > div {
+  background: white;
+}
+
+.show-title {
+  max-width: 280px;
+  overflow: hidden;
+  font-size: 1rem;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.show-divider {
+  width: 1px;
+  height: 26px;
+  flex: 0 0 auto;
+  background: #221c2a;
+}
+
+.show-clock-group {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.show-clock-group > p:first-child,
+.show-next-change > p:first-child,
+.show-section-label {
+  color: #7b6b89;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.show-clock-group > p:last-child,
+.show-wall-clock {
+  font-size: 1.125rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.show-wall-clock {
+  color: #cbb6dd;
+}
+
+.show-segmented {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  padding: 3px;
+  border: 1px solid #2f2637;
+  border-radius: 9px;
+  background: #161020;
+}
+
+.show-segmented button {
+  min-width: 0;
+  height: 30px;
+  gap: 7px;
+  padding: 0 12px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent !important;
+  color: #695d73 !important;
+  font-size: 0.75rem;
+  font-weight: 700;
+  opacity: 0.62;
+}
+
+.show-segmented button:hover {
+  background: #211a28 !important;
+  color: #a995b8 !important;
+  opacity: 0.82;
+}
+
+.show-segmented button[data-active="true"],
+.show-segmented button[data-active="true"]:hover {
+  background: #3a2d45 !important;
+  color: #ffffff !important;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
+  opacity: 1;
+}
+
+.show-monitor-button,
+.show-exit,
+.show-display-status {
+  height: 34px !important;
+  border: 1px solid #2f2637 !important;
+  border-radius: 8px !important;
+  background: #161020 !important;
+  color: #cbb6dd !important;
+  font-size: 0.75rem !important;
+}
+
+.show-blackout-status {
+  height: 26px;
+  display: flex;
+  align-items: center;
+  padding: 0 9px;
+  border: 1px solid #e5484d;
+  border-radius: 6px;
+  background: #e5484d;
+  color: white;
+  font-size: 0.6875rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.show-monitor-button[data-active="true"] {
+  border-color: #7fd4bd !important;
+  background: #101a17 !important;
+  color: #7fd4bd !important;
+}
+
+.show-monitor-menu {
+  border-color: #4a2d63 !important;
+  background: #14101a !important;
+  color: #f0e4ff !important;
+}
+
+.show-monitor-menu [role="menuitem"] {
+  background: #14101a;
+}
+
+.show-monitor-menu [role="menuitem"]:hover {
+  background: #241333;
+}
+
+.show-display-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px;
+  white-space: nowrap;
+}
+
+.show-online-dot {
+  background: #5b5263;
+}
+
+.show-online-dot.is-online {
+  background: #7fd4bd;
+  box-shadow: 0 0 0 3px rgba(127, 212, 189, 0.12);
+}
+
+.show-exit {
+  padding: 0 14px !important;
+  background: transparent !important;
+}
+
+.show-main {
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  display: flex;
+  gap: 14px;
+  padding: 14px;
+}
+
+.show-main-music {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(290px, 23vw);
+}
+
+.show-music-primary,
+.show-control-primary,
+.show-music-rail,
+.show-control-score {
+  min-width: 0;
+  min-height: 0;
+}
+
+.show-music-primary,
+.show-control-primary,
+.show-music-rail,
+.show-control-score {
+  display: flex;
+  flex-direction: column;
+}
+
+.show-music-primary,
+.show-control-primary {
+  gap: 12px;
+}
+
+.show-music-rail,
+.show-control-score {
+  gap: 10px;
+  padding: 12px;
+  overflow: hidden;
+  border: 1px solid #221c2a;
+  border-radius: 10px;
+  background: #100c14;
+}
+
+.show-score {
+  min-height: 0;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.show-score-toolbar {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.show-score-measure {
+  color: #e0c9ff;
+  font-size: 1.65rem;
+  font-weight: 800;
+  line-height: 1.1;
+}
+
+.show-score-title {
+  max-width: 38vw;
+  overflow: hidden;
+  color: #7b6b89;
+  font-size: 0.75rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.show-auto-turn {
+  height: 36px !important;
+  gap: 7px;
+  border: 1px solid #2f2637 !important;
+  background: #161020 !important;
+  color: #cbb6dd !important;
+  font-size: 0.75rem !important;
+}
+
+.show-toggle-track {
+  width: 28px;
+  height: 16px;
+  padding: 2px;
+  border-radius: 8px;
+  background: #3a3145;
+}
+
+.show-toggle-track > div {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #0c1a16;
+  transition: transform 0.15s ease;
+}
+
+.show-auto-turn[data-active="true"] .show-toggle-track {
+  background: #7fd4bd;
+}
+
+.show-auto-turn[data-active="true"] .show-toggle-track > div {
+  transform: translateX(12px);
+}
+
+.show-score-pages {
+  min-width: 0;
+  min-height: 0;
+  flex: 1 1 auto;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  overflow: auto;
+  border-radius: 6px;
+}
+
+.show-score-pages-two .show-score-page {
+  flex: 1 1 0;
+  min-width: 300px;
+}
+
+.show-score-pages-scroll {
+  flex-direction: column;
+  align-items: center;
+  scroll-behavior: smooth;
+}
+
+.show-score-pages-scroll .show-score-page {
+  width: min(100%, 980px);
+  flex: 0 0 auto;
+}
+
+.show-score-page {
+  position: relative;
+  overflow: hidden;
+  border-radius: 5px;
+  background: #f7f4ee;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.55);
+}
+
+.show-score-page canvas {
+  width: 100% !important;
+  height: auto !important;
+  display: block;
+}
+
+.show-score-page-number {
+  position: absolute;
+  right: 10px;
+  bottom: 8px;
+  padding: 2px 7px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.86);
+  color: #6b6357;
+  font-size: 0.6875rem;
+  font-weight: 700;
+}
+
+.show-score-pagination {
+  justify-content: center;
+  color: #cbb6dd;
+  font-size: 0.75rem;
+}
+
+.show-score-pagination button {
+  width: 30px;
+  height: 30px;
+  min-width: 30px;
+  border: 1px solid #2f2637;
+  background: #161020;
+}
+
+.show-score-empty {
+  min-height: 0;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border: 1px dashed #3a2447;
+  border-radius: 8px;
+  background: #100c14;
+  color: #cbb6dd;
+}
+
+.show-score-empty p:last-child {
+  color: #7b6b89;
+  font-size: 0.75rem;
+}
+
+.show-screen-preview {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 2px solid #e5484d;
+  border-radius: 8px;
+  background: #0d0a11;
+}
+
+.show-screen-preview-offline {
+  border: 1px dashed #3a3145;
+}
+
+.show-screen-preview-header {
+  min-width: 0;
+  min-height: 36px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0 10px;
+  background: #1d1016;
+  color: #ff9a9d;
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.show-screen-preview-offline .show-screen-preview-header {
+  background: #14101a;
+  color: #7b6b89;
+}
+
+.show-layer-badge {
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: #cbb0ee;
+  color: #160b1f;
+  font-size: 0.625rem;
+}
+
+.show-screen-cue-name {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  color: #cbb6dd;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.show-screen-preview-canvas {
+  min-height: 0;
+  flex: 1 1 auto;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  background: black;
+}
+
+.show-preview-media {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.show-screen-preview-compact {
+  flex: 0 0 auto;
+  aspect-ratio: 16 / 9;
+}
+
+.show-screen-preview-compact .show-screen-preview-header {
+  min-height: 28px;
+  padding-inline: 8px;
+  font-size: 0.6875rem;
+}
+
+.show-mini-screen-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.show-cue-list {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.show-cue-chip {
+  position: relative;
+  min-width: 34px !important;
+  height: 32px !important;
+  padding: 0 9px !important;
+  border: 1px solid transparent !important;
+  border-radius: 6px !important;
+  background: #14101a !important;
+  color: #7b6b89 !important;
+  font-size: 0.75rem !important;
+  font-weight: 800 !important;
+}
+
+.show-cue-chip[data-state="live"] {
+  border-color: #e5484d !important;
+  background: #1d1016 !important;
+  color: #ff9a9d !important;
+}
+
+.show-cue-chip[data-state="next"] {
+  border-color: #7fd4bd !important;
+  background: #101a17 !important;
+  color: #7fd4bd !important;
+}
+
+.show-cue-marker-dot {
+  position: absolute;
+  right: 3px;
+  bottom: 3px;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.show-audio-strip {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border: 1px solid #22483e;
+  border-radius: 8px;
+  background: #101a17;
+}
+
+.show-audio-track {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #7fd4bd;
+  font-size: 0.6875rem;
+}
+
+.show-audio-track > p:first-of-type {
+  max-width: 170px;
+  overflow: hidden;
+  color: #d9f5ec;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.show-audio-track > span {
+  padding: 1px 5px;
+  border-radius: 4px;
+  background: #16302a;
+}
+
+.show-audio-meter {
+  height: 14px;
+  display: flex;
+  align-items: end;
+  gap: 2px;
+}
+
+.show-audio-meter > div {
+  width: 2px;
+  background: #7fd4bd;
+}
+
+.show-audio-meter > div:nth-child(1) {
+  height: 45%;
+}
+.show-audio-meter > div:nth-child(2) {
+  height: 90%;
+}
+.show-audio-meter > div:nth-child(3) {
+  height: 65%;
+}
+.show-audio-meter > div:nth-child(4) {
+  height: 35%;
+}
+
+.show-muted {
+  color: #7b6b89;
+  font-size: 0.6875rem;
+}
+
+.show-transport {
+  flex: 0 0 auto;
+  min-width: 0;
+  min-height: 84px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  overflow: hidden;
+  border: 1px solid #221c2a;
+  border-radius: 10px;
+  background: #100c14;
+}
+
+.show-transport-large {
+  min-height: 96px;
+}
+
+.show-previous,
+.show-go,
+.show-auto,
+.show-blackout {
+  flex: 0 0 auto;
+  border-radius: 9px !important;
+}
+
+.show-previous {
+  width: 68px;
+  height: 60px !important;
+  border: 1px solid #2f2637 !important;
+  background: #161020 !important;
+  color: #cbb6dd !important;
+}
+
+.show-previous svg {
+  width: 24px;
+  height: 24px;
+}
+
+.show-go {
+  height: 60px !important;
+  min-width: 130px !important;
+  padding: 0 30px !important;
+  background: #23b26d !important;
+  color: #04150c !important;
+  font-size: 1.5rem !important;
+  font-weight: 800 !important;
+  letter-spacing: 0.06em;
+}
+
+.show-go:disabled {
+  background: #315846 !important;
+}
+
+.show-transport-large .show-go {
+  min-width: 280px !important;
+  flex: 1 1 auto;
+  gap: 16px;
+}
+
+.show-go span {
+  font-size: 0.8125rem;
+  letter-spacing: 0;
+  opacity: 0.72;
+}
+
+.show-next-change {
+  flex: 0 0 auto;
+}
+
+.show-next-change > p:last-child {
+  max-width: 250px;
+  overflow: hidden;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.show-transport > .show-cue-list {
+  flex: 1 1 auto;
+}
+
+.show-auto,
+.show-blackout {
+  height: 42px !important;
+  border: 1px solid #2f2637 !important;
+  background: #161020 !important;
+  color: #cbb6dd !important;
+  font-size: 0.75rem !important;
+}
+
+.show-auto[data-active="true"] {
+  border-color: #7fd4bd !important;
+  background: #101a17 !important;
+  color: #7fd4bd !important;
+}
+
+.show-blackout {
+  border-color: #6b2a2c !important;
+  background: #1d1016 !important;
+  color: #ff9a9d !important;
+}
+
+.show-blackout[data-active="true"] {
+  background: #e5484d !important;
+  color: white !important;
+}
+
+.show-main-control {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 22vw);
+}
+
+.show-screen-wall {
+  min-height: 0;
+  flex: 1 1 auto;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-auto-rows: minmax(190px, 1fr);
+  gap: 10px;
+  overflow: auto;
+}
+
+.show-control-score .show-score-toolbar {
+  display: none;
+}
+
+.show-control-score .show-score-pages {
+  min-height: 200px;
+}
+
+.show-control-score .show-score-page {
+  min-width: 100%;
+}
+
+.show-monitor-output {
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  padding: 14px;
+  overflow: hidden;
+  background: #08060a;
+  color: #f0e4ff;
+}
+
+.show-monitor-output > .show-screen-wall,
+.show-monitor-output > .show-score {
+  width: 100%;
+}
+
+@media (max-width: 1200px) {
+  .show-topbar {
+    gap: 10px;
+  }
+
+  .show-wall-clock,
+  .show-display-status,
+  .show-view-switch button svg {
+    display: none;
+  }
+
+  .show-main-music,
+  .show-main-control {
+    grid-template-columns: minmax(0, 1fr) 280px;
+  }
+
+  .show-transport {
+    flex-wrap: wrap;
+  }
+
+  .show-transport > .show-cue-list {
+    order: 3;
+    width: 100%;
+  }
+}
+
+@media (max-width: 820px) {
+  .show-topbar {
+    flex-basis: 52px;
+    padding-inline: 10px;
+  }
+
+  .show-title,
+  .show-divider,
+  .show-clock-group,
+  .show-monitor-button {
+    display: none !important;
+  }
+
+  .show-main {
+    padding: 8px;
+  }
+
+  .show-main-music,
+  .show-main-control {
+    display: flex;
+    flex-direction: column;
+    overflow: auto;
+  }
+
+  .show-music-primary,
+  .show-control-primary {
+    min-height: calc(100dvh - 70px);
+  }
+
+  .show-music-rail,
+  .show-control-score {
+    overflow: visible;
+  }
+
+  .show-score-toolbar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .show-score-toolbar > div:last-child {
+    margin-left: 0;
+  }
+
+  .show-score-pages-two .show-score-page {
+    min-width: 78vw;
+  }
+
+  .show-screen-wall {
+    grid-template-columns: 1fr;
+  }
+}
+
 .screen-status-open,
 .screen-status-closed,
 .audio-state-playing,


### PR DESCRIPTION
Adds a dedicated live view with music-stand and control-room layouts, GO transport, blackout, cue list and second-window monitor output.

Closes #910.